### PR TITLE
feat: 플레이어 체력 시스템 구현 (피격/게임오버) (#26)

### DIFF
--- a/project1/Assets/Art/Characters/Player/Sprites/mudang_attack_ld_sheet.png.meta
+++ b/project1/Assets/Art/Characters/Player/Sprites/mudang_attack_ld_sheet.png.meta
@@ -457,6 +457,20 @@ TextureImporter:
     spriteCustomMetadata:
       entries: []
     nameFileIdTable:
+      mudang_attack_ld_00: 21300001
+      mudang_attack_ld_01: 21300002
+      mudang_attack_ld_02: 21300003
+      mudang_attack_ld_03: 21300004
+      mudang_attack_ld_04: 21300005
+      mudang_attack_ld_05: 21300006
+      mudang_attack_ld_06: 21300007
+      mudang_attack_ld_07: 21300008
+      mudang_attack_ld_08: 21300009
+      mudang_attack_ld_09: 21300010
+      mudang_attack_ld_10: 21300011
+      mudang_attack_ld_11: 21300012
+      mudang_attack_ld_12: 21300013
+      mudang_attack_ld_13: 21300014
       mudang_idle_00: 21300001
       mudang_idle_01: 21300002
       mudang_idle_02: 21300003

--- a/project1/Assets/Art/Characters/Player/Sprites/mudang_attack_ru_sheet.png.meta
+++ b/project1/Assets/Art/Characters/Player/Sprites/mudang_attack_ru_sheet.png.meta
@@ -471,6 +471,20 @@ TextureImporter:
       mudang_attack_11: 21300012
       mudang_attack_12: 21300013
       mudang_attack_13: 21300014
+      mudang_attack_ru_00: 21300001
+      mudang_attack_ru_01: 21300002
+      mudang_attack_ru_02: 21300003
+      mudang_attack_ru_03: 21300004
+      mudang_attack_ru_04: 21300005
+      mudang_attack_ru_05: 21300006
+      mudang_attack_ru_06: 21300007
+      mudang_attack_ru_07: 21300008
+      mudang_attack_ru_08: 21300009
+      mudang_attack_ru_09: 21300010
+      mudang_attack_ru_10: 21300011
+      mudang_attack_ru_11: 21300012
+      mudang_attack_ru_12: 21300013
+      mudang_attack_ru_13: 21300014
       mudang_attack_sheet_00: 2988139018223898463
       mudang_attack_sheet_01: -6749884809059432365
       mudang_attack_sheet_02: -3736991436816635456

--- a/project1/Assets/Scripts/Combat/EnemyContactDamage.cs
+++ b/project1/Assets/Scripts/Combat/EnemyContactDamage.cs
@@ -1,0 +1,48 @@
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(EnemyHealth))]
+    public class EnemyContactDamage : MonoBehaviour
+    {
+        [SerializeField, Min(0.1f)]
+        private float _contactDamage = 10f;
+
+        [SerializeField]
+        private bool _destroyOnContact = true;
+
+        private EnemyHealth _enemyHealth;
+
+        private void Awake()
+        {
+            _enemyHealth = GetComponent<EnemyHealth>();
+        }
+
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            if (_enemyHealth != null && !_enemyHealth.IsAlive)
+            {
+                return;
+            }
+
+            PlayerHealth playerHealth = other.GetComponent<PlayerHealth>();
+            if (playerHealth == null)
+            {
+                playerHealth = other.GetComponentInParent<PlayerHealth>();
+            }
+
+            if (playerHealth == null || !playerHealth.IsAlive)
+            {
+                return;
+            }
+
+            playerHealth.TakeDamage(_contactDamage, _enemyHealth);
+
+            if (_destroyOnContact && _enemyHealth != null && _enemyHealth.IsAlive)
+            {
+                _enemyHealth.ApplyDamage(_enemyHealth.MaxHealth * 10f, this);
+            }
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/EnemyContactDamage.cs
+++ b/project1/Assets/Scripts/Combat/EnemyContactDamage.cs
@@ -41,7 +41,7 @@ namespace Mukseon.Gameplay.Combat
 
             if (_destroyOnContact && _enemyHealth != null && _enemyHealth.IsAlive)
             {
-                _enemyHealth.ApplyDamage(_enemyHealth.MaxHealth * 10f, this);
+                _enemyHealth.Kill(countAsKill: false);
             }
         }
     }

--- a/project1/Assets/Scripts/Combat/EnemyContactDamage.cs.meta
+++ b/project1/Assets/Scripts/Combat/EnemyContactDamage.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c05d2c5a591c5d646907c7fd1e1f8d0c

--- a/project1/Assets/Scripts/Combat/EnemyHealth.cs
+++ b/project1/Assets/Scripts/Combat/EnemyHealth.cs
@@ -100,7 +100,22 @@ namespace Mukseon.Gameplay.Combat
             }
         }
 
-        private void Die()
+        /// <summary>
+        /// Instantly kills this enemy. Use countAsKill=false for self-destruct/contact deaths
+        /// that should not grant kill rewards (e.g. Gangshin gauge).
+        /// </summary>
+        public void Kill(bool countAsKill = true)
+        {
+            if (!IsAlive)
+            {
+                return;
+            }
+
+            CurrentHealth = 0f;
+            Die(countAsKill);
+        }
+
+        private void Die(bool countAsKill = true)
         {
             if (!IsAlive)
             {
@@ -120,7 +135,11 @@ namespace Mukseon.Gameplay.Combat
 
             OnDied?.Invoke();
             OnDeath?.Invoke(this);
-            AnyEnemyDied?.Invoke(this);
+
+            if (countAsKill)
+            {
+                AnyEnemyDied?.Invoke(this);
+            }
 
             if (_destroyOnDeath)
             {

--- a/project1/Assets/Scripts/Combat/GameOverHandler.cs
+++ b/project1/Assets/Scripts/Combat/GameOverHandler.cs
@@ -1,0 +1,84 @@
+using System;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    [DisallowMultipleComponent]
+    public class GameOverHandler : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField]
+        private PlayerHealth _playerHealth;
+
+        [SerializeField]
+        private WaveCombatDirector _waveCombatDirector;
+
+        [Header("Settings")]
+        [SerializeField]
+        private bool _pauseTimeOnGameOver = true;
+
+        [Header("Debug")]
+        [SerializeField]
+        private bool _showDebugLogs;
+
+        private bool _isGameOver;
+
+        public bool IsGameOver => _isGameOver;
+        public event Action OnGameOver;
+
+        private void OnEnable()
+        {
+            if (_playerHealth != null)
+            {
+                _playerHealth.OnDied += HandlePlayerDied;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (_playerHealth != null)
+            {
+                _playerHealth.OnDied -= HandlePlayerDied;
+            }
+        }
+
+        private void HandlePlayerDied()
+        {
+            if (_isGameOver)
+            {
+                return;
+            }
+
+            _isGameOver = true;
+
+#if UNITY_EDITOR
+            if (_showDebugLogs)
+            {
+                Debug.Log("[GameOverHandler] Game Over triggered.");
+            }
+#endif
+
+            if (_waveCombatDirector != null)
+            {
+                _waveCombatDirector.StopWaves();
+            }
+
+            if (_pauseTimeOnGameOver)
+            {
+                Time.timeScale = 0f;
+            }
+
+            OnGameOver?.Invoke();
+        }
+
+        public void ResetGameOver()
+        {
+            _isGameOver = false;
+
+            if (_pauseTimeOnGameOver)
+            {
+                Time.timeScale = 1f;
+            }
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/GameOverHandler.cs.meta
+++ b/project1/Assets/Scripts/Combat/GameOverHandler.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b3a2b7b5cb3c3664192a950edb76caf3

--- a/project1/Assets/Scripts/Combat/GangshinInvincibilityLink.cs
+++ b/project1/Assets/Scripts/Combat/GangshinInvincibilityLink.cs
@@ -1,0 +1,58 @@
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    [DisallowMultipleComponent]
+    public class GangshinInvincibilityLink : MonoBehaviour
+    {
+        [SerializeField]
+        private GangshinController _gangshinController;
+
+        [SerializeField]
+        private PlayerHealth _playerHealth;
+
+        private void Awake()
+        {
+            if (_gangshinController == null)
+            {
+                _gangshinController = GetComponent<GangshinController>();
+            }
+
+            if (_playerHealth == null)
+            {
+                _playerHealth = GetComponent<PlayerHealth>();
+            }
+        }
+
+        private void OnEnable()
+        {
+            if (_gangshinController != null)
+            {
+                _gangshinController.OnStateChanged += HandleGangshinStateChanged;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (_gangshinController != null)
+            {
+                _gangshinController.OnStateChanged -= HandleGangshinStateChanged;
+            }
+
+            if (_playerHealth != null)
+            {
+                _playerHealth.SetInvincible(false);
+            }
+        }
+
+        private void HandleGangshinStateChanged(GangshinState newState)
+        {
+            if (_playerHealth == null)
+            {
+                return;
+            }
+
+            _playerHealth.SetInvincible(newState == GangshinState.Active);
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/GangshinInvincibilityLink.cs.meta
+++ b/project1/Assets/Scripts/Combat/GangshinInvincibilityLink.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 76326102252468148bbc337f030e9e4e

--- a/project1/Assets/Scripts/Combat/PlayerHealth.cs
+++ b/project1/Assets/Scripts/Combat/PlayerHealth.cs
@@ -46,16 +46,25 @@ namespace Mukseon.Gameplay.Combat
             }
         }
 
+        private bool _initialized;
+
+        private void Start()
+        {
+            if (!_initialized)
+            {
+                ResolveMaxHealth();
+                _currentHealth = _resolvedMaxHealth;
+                _isDead = false;
+                _initialized = true;
+            }
+        }
+
         private void OnEnable()
         {
             if (_playerStatSystem != null)
             {
                 _playerStatSystem.OnStatChanged += HandleStatChanged;
             }
-
-            ResolveMaxHealth();
-            _currentHealth = _resolvedMaxHealth;
-            _isDead = false;
         }
 
         private void OnDisable()

--- a/project1/Assets/Scripts/Combat/PlayerHealth.cs
+++ b/project1/Assets/Scripts/Combat/PlayerHealth.cs
@@ -1,0 +1,188 @@
+using System;
+using Mukseon.Gameplay.Stats;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(PlayerStatSystem))]
+    public class PlayerHealth : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField]
+        private PlayerStatSystem _playerStatSystem;
+
+        [Header("Settings")]
+        [SerializeField, Min(1f)]
+        private float _fallbackMaxHealth = 100f;
+
+        private const float AbsoluteMinHealth = 1f;
+
+        [Header("Debug")]
+        [SerializeField]
+        private bool _showDebugLogs;
+
+        private float _currentHealth;
+        private float _resolvedMaxHealth;
+        private bool _isDead;
+        private bool _isInvincible;
+
+        public float CurrentHealth => _currentHealth;
+        public float MaxHealth => _resolvedMaxHealth;
+        public float HealthNormalized => _resolvedMaxHealth > 0f ? Mathf.Clamp01(_currentHealth / _resolvedMaxHealth) : 0f;
+        public bool IsAlive => !_isDead;
+        public bool IsInvincible => _isInvincible;
+
+        public event Action<float, float> OnHealthChanged;
+        public event Action<float> OnDamaged;
+        public event Action<float> OnHealed;
+        public event Action OnDied;
+
+        private void Awake()
+        {
+            if (_playerStatSystem == null)
+            {
+                _playerStatSystem = GetComponent<PlayerStatSystem>();
+            }
+        }
+
+        private void OnEnable()
+        {
+            if (_playerStatSystem != null)
+            {
+                _playerStatSystem.OnStatChanged += HandleStatChanged;
+            }
+
+            ResolveMaxHealth();
+            _currentHealth = _resolvedMaxHealth;
+            _isDead = false;
+        }
+
+        private void OnDisable()
+        {
+            if (_playerStatSystem != null)
+            {
+                _playerStatSystem.OnStatChanged -= HandleStatChanged;
+            }
+        }
+
+        public void TakeDamage(float amount, object source = null)
+        {
+            if (_isDead || amount <= 0f)
+            {
+                return;
+            }
+
+            if (_isInvincible)
+            {
+#if UNITY_EDITOR
+                if (_showDebugLogs)
+                {
+                    Debug.Log($"[PlayerHealth] Damage blocked (invincible). amount={amount} source={source}");
+                }
+#endif
+                return;
+            }
+
+            float previous = _currentHealth;
+            _currentHealth = Mathf.Max(0f, _currentHealth - amount);
+
+            float actualDamage = previous - _currentHealth;
+
+#if UNITY_EDITOR
+            if (_showDebugLogs)
+            {
+                Debug.Log($"[PlayerHealth] TakeDamage {actualDamage:F1} (source={source}). HP: {previous:F1} → {_currentHealth:F1}");
+            }
+#endif
+
+            OnDamaged?.Invoke(actualDamage);
+            OnHealthChanged?.Invoke(_currentHealth, _resolvedMaxHealth);
+
+            if (_currentHealth <= 0f)
+            {
+                Die();
+            }
+        }
+
+        public void Heal(float amount)
+        {
+            if (_isDead || amount <= 0f)
+            {
+                return;
+            }
+
+            float previous = _currentHealth;
+            _currentHealth = Mathf.Min(_resolvedMaxHealth, _currentHealth + amount);
+
+            float actualHeal = _currentHealth - previous;
+            if (actualHeal > 0f)
+            {
+                OnHealed?.Invoke(actualHeal);
+                OnHealthChanged?.Invoke(_currentHealth, _resolvedMaxHealth);
+            }
+        }
+
+        public void SetInvincible(bool invincible)
+        {
+            _isInvincible = invincible;
+        }
+
+        public void ResetHealth()
+        {
+            ResolveMaxHealth();
+            _currentHealth = _resolvedMaxHealth;
+            _isDead = false;
+            OnHealthChanged?.Invoke(_currentHealth, _resolvedMaxHealth);
+        }
+
+        private void Die()
+        {
+            if (_isDead)
+            {
+                return;
+            }
+
+            _isDead = true;
+
+#if UNITY_EDITOR
+            if (_showDebugLogs)
+            {
+                Debug.Log("[PlayerHealth] Player died.");
+            }
+#endif
+
+            OnDied?.Invoke();
+        }
+
+        private void HandleStatChanged(StatType statType, float newValue)
+        {
+            if (statType != StatType.MaxHealth)
+            {
+                return;
+            }
+
+            float previousMax = _resolvedMaxHealth;
+            ResolveMaxHealth();
+
+            if (_resolvedMaxHealth > previousMax)
+            {
+                float bonus = _resolvedMaxHealth - previousMax;
+                _currentHealth = Mathf.Min(_resolvedMaxHealth, _currentHealth + bonus);
+            }
+            else
+            {
+                _currentHealth = Mathf.Min(_currentHealth, _resolvedMaxHealth);
+            }
+
+            OnHealthChanged?.Invoke(_currentHealth, _resolvedMaxHealth);
+        }
+
+        private void ResolveMaxHealth()
+        {
+            float statValue = _playerStatSystem != null ? _playerStatSystem.GetValue(StatType.MaxHealth) : 0f;
+            float fallback = _fallbackMaxHealth > 0f ? _fallbackMaxHealth : 100f;
+            _resolvedMaxHealth = statValue > 0f ? statValue : Mathf.Max(AbsoluteMinHealth, fallback);
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/PlayerHealth.cs.meta
+++ b/project1/Assets/Scripts/Combat/PlayerHealth.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 24b8dfe57ccf4364cabd6e4fd54a825f

--- a/project1/Assets/Scripts/Combat/PlayerHealthHudPresenter.cs
+++ b/project1/Assets/Scripts/Combat/PlayerHealthHudPresenter.cs
@@ -44,9 +44,42 @@ namespace Mukseon.Gameplay.Combat
         private GUIStyle _labelStyle;
         private GUIStyle _gameOverStyle;
         private Texture2D _pixel;
+        private string _cachedHealthLabel;
+        private bool _referencesResolved;
 
         private void Awake()
         {
+            TryResolveReferences();
+        }
+
+        private void OnEnable()
+        {
+            if (_playerHealth != null)
+            {
+                _playerHealth.OnHealthChanged += HandleHealthChanged;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (_playerHealth != null)
+            {
+                _playerHealth.OnHealthChanged -= HandleHealthChanged;
+            }
+        }
+
+        private void HandleHealthChanged(float current, float max)
+        {
+            _cachedHealthLabel = $"HP {Mathf.CeilToInt(current)}/{Mathf.CeilToInt(max)}";
+        }
+
+        private void TryResolveReferences()
+        {
+            if (_referencesResolved)
+            {
+                return;
+            }
+
             if (_playerHealth == null)
             {
                 _playerHealth = FindPlayerHealth();
@@ -55,6 +88,11 @@ namespace Mukseon.Gameplay.Combat
             if (_gameOverHandler == null)
             {
                 _gameOverHandler = FindGameOverHandler();
+            }
+
+            if (_playerHealth != null && _gameOverHandler != null)
+            {
+                _referencesResolved = true;
             }
         }
 
@@ -69,6 +107,11 @@ namespace Mukseon.Gameplay.Combat
 
         private void OnGUI()
         {
+            if (!_referencesResolved)
+            {
+                TryResolveReferences();
+            }
+
             EnsureGuiResources();
 
             if (_playerHealth != null)
@@ -95,10 +138,14 @@ namespace Mukseon.Gameplay.Combat
                 DrawRect(new Rect(backgroundRect.x, backgroundRect.y, fillWidth, backgroundRect.height), fillColor);
             }
 
-            string label = $"HP {Mathf.CeilToInt(_playerHealth.CurrentHealth)}/{Mathf.CeilToInt(_playerHealth.MaxHealth)}";
+            if (string.IsNullOrEmpty(_cachedHealthLabel))
+            {
+                _cachedHealthLabel = $"HP {Mathf.CeilToInt(_playerHealth.CurrentHealth)}/{Mathf.CeilToInt(_playerHealth.MaxHealth)}";
+            }
+
             GUI.Label(
                 new Rect(backgroundRect.x, backgroundRect.y + backgroundRect.height + 2f, backgroundRect.width + 80f, 20f),
-                label,
+                _cachedHealthLabel,
                 _labelStyle);
         }
 

--- a/project1/Assets/Scripts/Combat/PlayerHealthHudPresenter.cs
+++ b/project1/Assets/Scripts/Combat/PlayerHealthHudPresenter.cs
@@ -1,0 +1,180 @@
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    [DisallowMultipleComponent]
+    public class PlayerHealthHudPresenter : MonoBehaviour
+    {
+        [SerializeField]
+        private PlayerHealth _playerHealth;
+
+        [SerializeField]
+        private GameOverHandler _gameOverHandler;
+
+        [Header("Health Bar")]
+        [SerializeField]
+        private Vector2 _barPosition = new Vector2(16f, 16f);
+
+        [SerializeField]
+        private Vector2 _barSize = new Vector2(220f, 18f);
+
+        [SerializeField]
+        private Color _barBackgroundColor = new Color(0f, 0f, 0f, 0.55f);
+
+        [SerializeField]
+        private Color _barFillColor = new Color(0.85f, 0.2f, 0.2f, 0.95f);
+
+        [SerializeField]
+        private Color _barLowHealthColor = new Color(1f, 0.15f, 0.05f, 0.95f);
+
+        [SerializeField, Range(0f, 1f)]
+        private float _lowHealthThreshold = 0.3f;
+
+        [Header("Game Over")]
+        [SerializeField]
+        private int _gameOverFontSize = 36;
+
+        [SerializeField]
+        private Color _gameOverOverlayColor = new Color(0f, 0f, 0f, 0.6f);
+
+        [Header("Label")]
+        [SerializeField]
+        private int _fontSize = 16;
+
+        private GUIStyle _labelStyle;
+        private GUIStyle _gameOverStyle;
+        private Texture2D _pixel;
+
+        private void Awake()
+        {
+            if (_playerHealth == null)
+            {
+                _playerHealth = FindPlayerHealth();
+            }
+
+            if (_gameOverHandler == null)
+            {
+                _gameOverHandler = FindGameOverHandler();
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (_pixel != null)
+            {
+                Destroy(_pixel);
+                _pixel = null;
+            }
+        }
+
+        private void OnGUI()
+        {
+            EnsureGuiResources();
+
+            if (_playerHealth != null)
+            {
+                DrawHealthBar();
+            }
+
+            if (_gameOverHandler != null && _gameOverHandler.IsGameOver)
+            {
+                DrawGameOverOverlay();
+            }
+        }
+
+        private void DrawHealthBar()
+        {
+            Rect backgroundRect = new Rect(_barPosition.x, _barPosition.y, _barSize.x, _barSize.y);
+            DrawRect(backgroundRect, _barBackgroundColor);
+
+            float normalized = _playerHealth.HealthNormalized;
+            float fillWidth = backgroundRect.width * normalized;
+            if (fillWidth > 0f)
+            {
+                Color fillColor = normalized <= _lowHealthThreshold ? _barLowHealthColor : _barFillColor;
+                DrawRect(new Rect(backgroundRect.x, backgroundRect.y, fillWidth, backgroundRect.height), fillColor);
+            }
+
+            string label = $"HP {Mathf.CeilToInt(_playerHealth.CurrentHealth)}/{Mathf.CeilToInt(_playerHealth.MaxHealth)}";
+            GUI.Label(
+                new Rect(backgroundRect.x, backgroundRect.y + backgroundRect.height + 2f, backgroundRect.width + 80f, 20f),
+                label,
+                _labelStyle);
+        }
+
+        private void DrawGameOverOverlay()
+        {
+            DrawRect(new Rect(0f, 0f, Screen.width, Screen.height), _gameOverOverlayColor);
+
+            float labelWidth = 300f;
+            float labelHeight = 50f;
+            Rect labelRect = new Rect(
+                (Screen.width - labelWidth) * 0.5f,
+                (Screen.height - labelHeight) * 0.4f,
+                labelWidth,
+                labelHeight);
+
+            GUI.Label(labelRect, "GAME OVER", _gameOverStyle);
+        }
+
+        private void DrawRect(Rect rect, Color color)
+        {
+            Color previous = GUI.color;
+            GUI.color = color;
+            GUI.DrawTexture(rect, _pixel);
+            GUI.color = previous;
+        }
+
+        private void EnsureGuiResources()
+        {
+            if (_pixel == null)
+            {
+                _pixel = new Texture2D(1, 1);
+                _pixel.SetPixel(0, 0, Color.white);
+                _pixel.Apply();
+            }
+
+            if (_labelStyle == null)
+            {
+                _labelStyle = new GUIStyle(GUI.skin.label)
+                {
+                    fontSize = _fontSize
+                };
+                _labelStyle.normal.textColor = Color.white;
+            }
+            else
+            {
+                _labelStyle.fontSize = _fontSize;
+            }
+
+            if (_gameOverStyle == null)
+            {
+                _gameOverStyle = new GUIStyle(GUI.skin.label)
+                {
+                    fontSize = _gameOverFontSize,
+                    alignment = TextAnchor.MiddleCenter,
+                    fontStyle = FontStyle.Bold
+                };
+                _gameOverStyle.normal.textColor = Color.white;
+            }
+        }
+
+        private static PlayerHealth FindPlayerHealth()
+        {
+#if UNITY_2023_1_OR_NEWER
+            return FindFirstObjectByType<PlayerHealth>();
+#else
+            return FindObjectOfType<PlayerHealth>();
+#endif
+        }
+
+        private static GameOverHandler FindGameOverHandler()
+        {
+#if UNITY_2023_1_OR_NEWER
+            return FindFirstObjectByType<GameOverHandler>();
+#else
+            return FindObjectOfType<GameOverHandler>();
+#endif
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/PlayerHealthHudPresenter.cs.meta
+++ b/project1/Assets/Scripts/Combat/PlayerHealthHudPresenter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a6760ae11e1b8bc40a627f7d9ac4fdf6

--- a/project1/Assets/Tests/EditMode/PlayerHealthTests.cs
+++ b/project1/Assets/Tests/EditMode/PlayerHealthTests.cs
@@ -1,0 +1,196 @@
+using System.Reflection;
+using Mukseon.Gameplay.Combat;
+using Mukseon.Gameplay.Stats;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Mukseon.Tests.EditMode
+{
+    public class PlayerHealthTests
+    {
+        private GameObject _go;
+        private PlayerHealth _playerHealth;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _go = new GameObject("PlayerHealthTest");
+            _go.AddComponent<PlayerStatSystem>();
+            _playerHealth = _go.AddComponent<PlayerHealth>();
+
+            // Ensure fallback max health is set (serialized defaults may not apply in EditMode tests)
+            SetPrivateField(_playerHealth, "_fallbackMaxHealth", 100f);
+
+            // Re-trigger initialization
+            _playerHealth.ResetHealth();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_go != null)
+            {
+                Object.DestroyImmediate(_go);
+            }
+        }
+
+        [Test]
+        public void TakeDamage_DecreasesCurrentHealth()
+        {
+            float maxHealth = _playerHealth.MaxHealth;
+            Assert.That(maxHealth, Is.GreaterThan(0f));
+
+            _playerHealth.TakeDamage(10f);
+
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(maxHealth - 10f).Within(0.01f));
+            Assert.That(_playerHealth.IsAlive, Is.True);
+        }
+
+        [Test]
+        public void TakeDamage_IgnoresZeroAndNegative()
+        {
+            float before = _playerHealth.CurrentHealth;
+
+            _playerHealth.TakeDamage(0f);
+            _playerHealth.TakeDamage(-5f);
+
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(before));
+        }
+
+        [Test]
+        public void TakeDamage_TriggersOnDied_WhenHealthReachesZero()
+        {
+            bool didDie = false;
+            _playerHealth.OnDied += () => didDie = true;
+
+            _playerHealth.TakeDamage(_playerHealth.MaxHealth + 100f);
+
+            Assert.That(_playerHealth.IsAlive, Is.False);
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(0f));
+            Assert.That(didDie, Is.True);
+        }
+
+        [Test]
+        public void TakeDamage_BlockedWhileInvincible()
+        {
+            float before = _playerHealth.CurrentHealth;
+            _playerHealth.SetInvincible(true);
+
+            _playerHealth.TakeDamage(50f);
+
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(before));
+            Assert.That(_playerHealth.IsAlive, Is.True);
+        }
+
+        [Test]
+        public void TakeDamage_IgnoredAfterDeath()
+        {
+            _playerHealth.TakeDamage(_playerHealth.MaxHealth + 1f);
+            Assert.That(_playerHealth.IsAlive, Is.False);
+
+            int diedCount = 0;
+            _playerHealth.OnDied += () => diedCount++;
+
+            _playerHealth.TakeDamage(10f);
+
+            Assert.That(diedCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Heal_IncreasesHealthUpToMax()
+        {
+            _playerHealth.TakeDamage(30f);
+            float afterDamage = _playerHealth.CurrentHealth;
+
+            _playerHealth.Heal(15f);
+
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(afterDamage + 15f).Within(0.01f));
+        }
+
+        [Test]
+        public void Heal_DoesNotExceedMaxHealth()
+        {
+            _playerHealth.TakeDamage(10f);
+            _playerHealth.Heal(9999f);
+
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(_playerHealth.MaxHealth).Within(0.01f));
+        }
+
+        [Test]
+        public void Heal_IgnoredAfterDeath()
+        {
+            _playerHealth.TakeDamage(_playerHealth.MaxHealth + 1f);
+            Assert.That(_playerHealth.IsAlive, Is.False);
+
+            _playerHealth.Heal(50f);
+
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(0f));
+        }
+
+        [Test]
+        public void ResetHealth_RestoresFullHealthAndAliveState()
+        {
+            _playerHealth.TakeDamage(_playerHealth.MaxHealth + 1f);
+            Assert.That(_playerHealth.IsAlive, Is.False);
+
+            _playerHealth.ResetHealth();
+
+            Assert.That(_playerHealth.IsAlive, Is.True);
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(_playerHealth.MaxHealth).Within(0.01f));
+        }
+
+        [Test]
+        public void HealthNormalized_ReturnsCorrectRatio()
+        {
+            float max = _playerHealth.MaxHealth;
+
+            Assert.That(_playerHealth.HealthNormalized, Is.EqualTo(1f).Within(0.01f));
+
+            _playerHealth.TakeDamage(max * 0.5f);
+            Assert.That(_playerHealth.HealthNormalized, Is.EqualTo(0.5f).Within(0.01f));
+        }
+
+        [Test]
+        public void OnDamaged_FiresWithCorrectAmount()
+        {
+            float reported = 0f;
+            _playerHealth.OnDamaged += amount => reported = amount;
+
+            _playerHealth.TakeDamage(25f);
+
+            Assert.That(reported, Is.EqualTo(25f).Within(0.01f));
+        }
+
+        [Test]
+        public void OnHealed_FiresWithCorrectAmount()
+        {
+            _playerHealth.TakeDamage(40f);
+
+            float reported = 0f;
+            _playerHealth.OnHealed += amount => reported = amount;
+
+            _playerHealth.Heal(20f);
+
+            Assert.That(reported, Is.EqualTo(20f).Within(0.01f));
+        }
+
+        [Test]
+        public void OnHealthChanged_FiresOnDamageAndHeal()
+        {
+            int callCount = 0;
+            _playerHealth.OnHealthChanged += (current, max) => callCount++;
+
+            _playerHealth.TakeDamage(10f);
+            _playerHealth.Heal(5f);
+
+            Assert.That(callCount, Is.EqualTo(2));
+        }
+
+        private static void SetPrivateField(object target, string fieldName, object value)
+        {
+            FieldInfo field = target.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.That(field, Is.Not.Null, $"Field '{fieldName}' not found on {target.GetType().Name}");
+            field.SetValue(target, value);
+        }
+    }
+}

--- a/project1/Assets/Tests/EditMode/PlayerHealthTests.cs.meta
+++ b/project1/Assets/Tests/EditMode/PlayerHealthTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fffa57ac36ae14846801a090cd64aa07


### PR DESCRIPTION
## Summary
- `PlayerHealth` 컴포넌트: 현재 HP 추적, 데미지/힐 처리, 무적 상태, `StatType.MaxHealth` 연동
- `EnemyContactDamage`: 적이 플레이어 결계(Trigger)에 도달 시 데미지 전달
- `GameOverHandler`: 사망 시 `WaveCombatDirector` 정지 + `Time.timeScale = 0`
- `GangshinInvincibilityLink`: 강신 Active 상태에서 자동 무적 연동
- `PlayerHealthHudPresenter`: OnGUI 기반 HP바 + 게임오버 오버레이 (기존 HUD 스타일 유지)
- `PlayerHealthTests`: 13개 EditMode 단위 테스트 (전체 34개 테스트 통과)

## 연결된 이슈
Closes #26

## Test plan
- [x] 전체 EditMode 테스트 34개 통과 (PlayerHealth 13개 포함)
- [ ] 플레이어 GameObject에 `PlayerHealth` + `EnemyContactDamage`(적 프리팹) 추가 후 씬 테스트
- [ ] 강신 발동 중 무적 상태에서 데미지가 차단되는지 확인
- [ ] HP 0 도달 시 게임오버 오버레이 표시 및 웨이브 정지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)