### PR TITLE
feat: 레벨업 스킬 선택 UI 패널 구현 및 11종 스킬 시스템 지원 (#32)

### DIFF
--- a/project1/Assets/Scripts/Progression/PlayerLevelSystem.cs
+++ b/project1/Assets/Scripts/Progression/PlayerLevelSystem.cs
@@ -14,7 +14,7 @@ namespace Mukseon.Gameplay.Progression
         BonusTargets = 2,
         PickupRadius = 3,
 
-        // 공용 스킬 (7종)
+        // 공용 스킬 (6종)
         SummonDokkaebiOrb = 10,   // 도깨비불 소환
         InkExplosionOnKill = 11,  // 먹물 폭발 (적 처치 시 광역)
         BarrierRadiusExpand = 12, // 결계 확장
@@ -70,8 +70,10 @@ namespace Mukseon.Gameplay.Progression
         /// <summary>
         /// 해당 시스템이 아직 구현되지 않은 스킬 효과 타입이 선택되었을 때 발생합니다.
         /// 각 전담 시스템(DokkaebiOrb, InkExplosion 등)이 이 이벤트를 구독하여 효과를 처리합니다.
+        /// 두 번째 인자는 적용될 스킬의 다음 레벨 번호입니다. 구독자가 레벨 시스템을 직접 조회할 경우
+        /// 레벨 증가 전 시점이므로 off-by-one이 발생할 수 있어 명시적으로 전달합니다.
         /// </summary>
-        public event Action<SkillData> OnSkillEffectPending;
+        public event Action<SkillData, int> OnSkillEffectPending;
 
         public int CurrentLevel => _progressionModel != null ? _progressionModel.Level : 1;
         public float CurrentExperience => _progressionModel != null ? _progressionModel.CurrentExperience : 0f;
@@ -265,17 +267,15 @@ namespace Mukseon.Gameplay.Progression
                         _soulCollector.AddPickupRadius(definition.Value);
                     }
                     break;
-                case LevelUpSkillEffectType.SummonDokkaebiOrb:
-                case LevelUpSkillEffectType.InkExplosionOnKill:
-                case LevelUpSkillEffectType.BarrierRadiusExpand:
-                case LevelUpSkillEffectType.KnockbackShield:
-                case LevelUpSkillEffectType.HealthRegen:
-                case LevelUpSkillEffectType.InkTrailSlow:
-                case LevelUpSkillEffectType.FanAttackBuff:
-                case LevelUpSkillEffectType.SwordAttackBuff:
-                case LevelUpSkillEffectType.SalPulliKummuBuff:
-                case LevelUpSkillEffectType.PaCheonJingBuff:
-                    OnSkillEffectPending?.Invoke(definition);
+                default:
+                    if (OnSkillEffectPending != null)
+                    {
+                        OnSkillEffectPending.Invoke(definition, GetSkillLevel(definition.SkillId) + 1);
+                    }
+                    else
+                    {
+                        Debug.LogWarning($"[PlayerLevelSystem] ApplySkillEffect: 처리되지 않은 스킬 타입 {definition.EffectType} ('{definition.SkillId}'). switch 케이스를 추가하거나 OnSkillEffectPending 구독을 확인하세요.");
+                    }
                     break;
             }
         }

--- a/project1/Assets/Scripts/Progression/PlayerLevelSystem.cs
+++ b/project1/Assets/Scripts/Progression/PlayerLevelSystem.cs
@@ -8,10 +8,25 @@ namespace Mukseon.Gameplay.Progression
 {
     public enum LevelUpSkillEffectType
     {
+        // 스탯 기반 (범용)
         StatFlat = 0,
         StatPercent = 1,
         BonusTargets = 2,
-        PickupRadius = 3
+        PickupRadius = 3,
+
+        // 공용 스킬 (7종)
+        SummonDokkaebiOrb = 10,   // 도깨비불 소환
+        InkExplosionOnKill = 11,  // 먹물 폭발 (적 처치 시 광역)
+        BarrierRadiusExpand = 12, // 결계 확장
+        KnockbackShield = 13,     // 수호 장승의 진 (피격 시 넉백)
+        HealthRegen = 14,         // 재생의 굿거리
+        InkTrailSlow = 15,        // 끈적한 묵액 (궤적 둔화)
+
+        // 클래스 전용 스킬 (4종)
+        FanAttackBuff = 20,       // [무당 전용] 부채살 흩뿌리기
+        SwordAttackBuff = 21,     // [박수 전용] 묵직한 신검
+        SalPulliKummuBuff = 22,   // [무당 강신] 살풀이 검무
+        PaCheonJingBuff = 23,     // [박수 강신] 파천의 징
     }
 
     [DisallowMultipleComponent]
@@ -51,6 +66,12 @@ namespace Mukseon.Gameplay.Progression
         public event Action<int, IReadOnlyList<SkillData>> OnLevelSelectionOpened;
         public event Action<int> OnLevelSelectionClosed;
         public event Action<SkillData, int> OnSkillApplied;
+
+        /// <summary>
+        /// 해당 시스템이 아직 구현되지 않은 스킬 효과 타입이 선택되었을 때 발생합니다.
+        /// 각 전담 시스템(DokkaebiOrb, InkExplosion 등)이 이 이벤트를 구독하여 효과를 처리합니다.
+        /// </summary>
+        public event Action<SkillData> OnSkillEffectPending;
 
         public int CurrentLevel => _progressionModel != null ? _progressionModel.Level : 1;
         public float CurrentExperience => _progressionModel != null ? _progressionModel.CurrentExperience : 0f;
@@ -243,6 +264,18 @@ namespace Mukseon.Gameplay.Progression
                     {
                         _soulCollector.AddPickupRadius(definition.Value);
                     }
+                    break;
+                case LevelUpSkillEffectType.SummonDokkaebiOrb:
+                case LevelUpSkillEffectType.InkExplosionOnKill:
+                case LevelUpSkillEffectType.BarrierRadiusExpand:
+                case LevelUpSkillEffectType.KnockbackShield:
+                case LevelUpSkillEffectType.HealthRegen:
+                case LevelUpSkillEffectType.InkTrailSlow:
+                case LevelUpSkillEffectType.FanAttackBuff:
+                case LevelUpSkillEffectType.SwordAttackBuff:
+                case LevelUpSkillEffectType.SalPulliKummuBuff:
+                case LevelUpSkillEffectType.PaCheonJingBuff:
+                    OnSkillEffectPending?.Invoke(definition);
                     break;
             }
         }

--- a/project1/Assets/Scripts/Progression/PlayerLevelSystem.cs
+++ b/project1/Assets/Scripts/Progression/PlayerLevelSystem.cs
@@ -12,9 +12,9 @@ namespace Mukseon.Gameplay.Progression
         StatFlat = 0,
         StatPercent = 1,
         BonusTargets = 2,
-        PickupRadius = 3,
+        PickupRadius = 3,         // 혼불 당기기 (자력) — docs 3.3 기준 공용 스킬 7종 중 하나
 
-        // 공용 스킬 (6종)
+        // 공용 스킬 (6종) — PickupRadius 포함 시 7종, 클래스 전용 4종과 합산하면 총 11종
         SummonDokkaebiOrb = 10,   // 도깨비불 소환
         InkExplosionOnKill = 11,  // 먹물 폭발 (적 처치 시 광역)
         BarrierRadiusExpand = 12, // 결계 확장
@@ -268,11 +268,8 @@ namespace Mukseon.Gameplay.Progression
                     }
                     break;
                 default:
-                    if (OnSkillEffectPending != null)
-                    {
-                        OnSkillEffectPending.Invoke(definition, GetSkillLevel(definition.SkillId) + 1);
-                    }
-                    else
+                    OnSkillEffectPending?.Invoke(definition, GetSkillLevel(definition.SkillId) + 1);
+                    if (OnSkillEffectPending == null)
                     {
                         Debug.LogWarning($"[PlayerLevelSystem] ApplySkillEffect: 처리되지 않은 스킬 타입 {definition.EffectType} ('{definition.SkillId}'). switch 케이스를 추가하거나 OnSkillEffectPending 구독을 확인하세요.");
                     }

--- a/project1/Assets/Scripts/Progression/SkillData.cs
+++ b/project1/Assets/Scripts/Progression/SkillData.cs
@@ -27,6 +27,9 @@ namespace Mukseon.Gameplay.Progression
         [SerializeField, Min(1)]
         private int _maxLevel = 5;
 
+        [SerializeField]
+        private Sprite _icon;
+
         public string SkillId => string.IsNullOrWhiteSpace(_skillId) ? name : _skillId;
         public string DisplayName => string.IsNullOrWhiteSpace(_displayName) ? name : _displayName;
         public string Description => _description;
@@ -34,6 +37,7 @@ namespace Mukseon.Gameplay.Progression
         public StatType StatType => _statType;
         public float Value => _value;
         public int MaxLevel => Mathf.Max(1, _maxLevel);
+        public Sprite Icon => _icon;
 
         public bool IsValid(out string reason)
         {

--- a/project1/Assets/Scripts/UI/GameplayHudBootstrapper.cs
+++ b/project1/Assets/Scripts/UI/GameplayHudBootstrapper.cs
@@ -19,6 +19,22 @@ namespace Mukseon.Gameplay.UI
             public float OffsetY;
         }
 
+        private readonly struct CardSlot
+        {
+            public readonly Button Button;
+            public readonly VisualElement Icon;
+            public readonly Label NameLabel;
+            public readonly Label DescLabel;
+
+            public CardSlot(Button button, VisualElement icon, Label nameLabel, Label descLabel)
+                => (Button, Icon, NameLabel, DescLabel) = (button, icon, nameLabel, descLabel);
+        }
+
+        private static class Strings
+        {
+            public const string LevelUpTitle = "레벨 업! 스킬을 선택하세요";
+        }
+
         private const string RootObjectName = "GameplayHudRuntime";
 
         private PlayerHealth _playerHealth;
@@ -49,12 +65,10 @@ namespace Mukseon.Gameplay.UI
         private VisualElement _bossRoot;
         private VisualElement _bossFill;
         private Label _bossLabel;
+        private VisualElement _levelUpContainer;
         private VisualElement _levelUpPanel;
         private Label _levelUpTitle;
-        private readonly List<Button> _choiceButtons = new List<Button>(3);
-        private readonly List<VisualElement> _cardIconElements = new List<VisualElement>(3);
-        private readonly List<Label> _cardNameLabels = new List<Label>(3);
-        private readonly List<Label> _cardDescLabels = new List<Label>(3);
+        private readonly List<CardSlot> _cardSlots = new List<CardSlot>(3);
 
         private readonly HashSet<EnemyHealth> _trackedEnemies = new HashSet<EnemyHealth>();
         private readonly Dictionary<EnemyHealth, Label> _arrowLabels = new Dictionary<EnemyHealth, Label>();
@@ -204,10 +218,32 @@ namespace Mukseon.Gameplay.UI
 
             const float panelW = 580f;
             const float panelH = 440f;
-            _levelUpPanel = Panel(_root, (1920f - panelW) * 0.5f, (1080f - panelH) * 0.5f, panelW, panelH);
+
+            _levelUpContainer = new VisualElement();
+            _levelUpContainer.style.position = Position.Absolute;
+            Stretch(_levelUpContainer);
+            _levelUpContainer.style.justifyContent = Justify.Center;
+            _levelUpContainer.style.alignItems = Align.Center;
+            _levelUpContainer.style.display = DisplayStyle.None;
+            _root.Add(_levelUpContainer);
+
+            _levelUpPanel = new VisualElement();
+            _levelUpPanel.style.width = panelW;
+            _levelUpPanel.style.height = panelH;
             _levelUpPanel.style.backgroundColor = new Color(0.06f, 0.06f, 0.10f, 0.96f);
+            _levelUpContainer.Add(_levelUpPanel);
+
             _levelUpTitle = Text(_levelUpPanel, 16f, 14f, panelW - 32f, 30f, 22, TextAnchor.MiddleCenter);
-            _levelUpPanel.style.display = DisplayStyle.None;
+
+            VisualElement cardsContainer = new VisualElement();
+            cardsContainer.style.position = Position.Absolute;
+            cardsContainer.style.left = 16f;
+            cardsContainer.style.right = 16f;
+            cardsContainer.style.top = 56f;
+            cardsContainer.style.bottom = 16f;
+            cardsContainer.style.flexDirection = FlexDirection.Column;
+            cardsContainer.style.justifyContent = Justify.SpaceBetween;
+            _levelUpPanel.Add(cardsContainer);
 
             for (int i = 0; i < 3; i++)
             {
@@ -221,10 +257,6 @@ namespace Mukseon.Gameplay.UI
                 });
 
                 card.text = string.Empty;
-                card.style.position = Position.Absolute;
-                card.style.left = 16f;
-                card.style.top = 56f + (116f * i);
-                card.style.width = panelW - 32f;
                 card.style.height = 108f;
                 card.style.backgroundColor = new Color(0.12f, 0.14f, 0.22f, 0.98f);
                 card.style.color = Color.white;
@@ -236,8 +268,7 @@ namespace Mukseon.Gameplay.UI
                 card.style.borderTopRightRadius = 6f;
                 card.style.borderBottomLeftRadius = 6f;
                 card.style.borderBottomRightRadius = 6f;
-                _levelUpPanel.Add(card);
-                _choiceButtons.Add(card);
+                cardsContainer.Add(card);
 
                 // 스킬 아이콘
                 VisualElement icon = new VisualElement();
@@ -252,7 +283,6 @@ namespace Mukseon.Gameplay.UI
                 icon.style.borderBottomLeftRadius = 4f;
                 icon.style.borderBottomRightRadius = 4f;
                 card.Add(icon);
-                _cardIconElements.Add(icon);
 
                 // 스킬 이름 + 레벨
                 Label nameLabel = new Label();
@@ -266,7 +296,6 @@ namespace Mukseon.Gameplay.UI
                 nameLabel.style.unityFontStyleAndWeight = FontStyle.Bold;
                 nameLabel.style.unityTextAlign = TextAnchor.MiddleLeft;
                 card.Add(nameLabel);
-                _cardNameLabels.Add(nameLabel);
 
                 // 스킬 설명
                 Label descLabel = new Label();
@@ -280,7 +309,8 @@ namespace Mukseon.Gameplay.UI
                 descLabel.style.unityTextAlign = TextAnchor.UpperLeft;
                 descLabel.style.whiteSpace = WhiteSpace.Normal;
                 card.Add(descLabel);
-                _cardDescLabels.Add(descLabel);
+
+                _cardSlots.Add(new CardSlot(card, icon, nameLabel, descLabel));
             }
         }
 
@@ -486,18 +516,19 @@ namespace Mukseon.Gameplay.UI
         private void RefreshLevelUp()
         {
             bool visible = _playerLevelSystem != null && _playerLevelSystem.IsSelectionOpen && _playerLevelSystem.CurrentChoices.Count > 0;
-            _levelUpPanel.style.display = visible ? DisplayStyle.Flex : DisplayStyle.None;
+            _levelUpContainer.style.display = visible ? DisplayStyle.Flex : DisplayStyle.None;
             if (!visible)
             {
                 return;
             }
 
-            _levelUpTitle.text = $"레벨 업! 스킬을 선택하세요  (Lv.{_playerLevelSystem.CurrentLevel})";
+            _levelUpTitle.text = $"{Strings.LevelUpTitle}  (Lv.{_playerLevelSystem.CurrentLevel})";
             IReadOnlyList<SkillData> choices = _playerLevelSystem.CurrentChoices;
-            for (int i = 0; i < _choiceButtons.Count; i++)
+            for (int i = 0; i < _cardSlots.Count; i++)
             {
+                CardSlot slot = _cardSlots[i];
                 bool hasChoice = i < choices.Count;
-                _choiceButtons[i].style.display = hasChoice ? DisplayStyle.Flex : DisplayStyle.None;
+                slot.Button.style.display = hasChoice ? DisplayStyle.Flex : DisplayStyle.None;
                 if (!hasChoice)
                 {
                     continue;
@@ -510,19 +541,19 @@ namespace Mukseon.Gameplay.UI
                 // 아이콘
                 if (choice.Icon != null)
                 {
-                    _cardIconElements[i].style.backgroundImage = new StyleBackground(choice.Icon);
+                    slot.Icon.style.backgroundImage = new StyleBackground(choice.Icon);
                 }
                 else
                 {
-                    _cardIconElements[i].style.backgroundImage = StyleKeyword.None;
+                    slot.Icon.style.backgroundImage = StyleKeyword.None;
                 }
 
                 // 이름 + 레벨
                 string levelText = currentLevel > 0 ? $"  Lv.{currentLevel} → {nextLevel}" : $"  Lv.{nextLevel}";
-                _cardNameLabels[i].text = choice.DisplayName + levelText;
+                slot.NameLabel.text = choice.DisplayName + levelText;
 
                 // 설명
-                _cardDescLabels[i].text = choice.Description;
+                slot.DescLabel.text = choice.Description;
             }
         }
 

--- a/project1/Assets/Scripts/UI/GameplayHudBootstrapper.cs
+++ b/project1/Assets/Scripts/UI/GameplayHudBootstrapper.cs
@@ -239,7 +239,9 @@ namespace Mukseon.Gameplay.UI
             cardsContainer.style.position = Position.Absolute;
             cardsContainer.style.left = 16f;
             cardsContainer.style.right = 16f;
-            cardsContainer.style.top = 56f;
+            // titleY(14) + titleHeight(30) + gap(12) = 56
+            const float cardsTop = 14f + 30f + 12f;
+            cardsContainer.style.top = cardsTop;
             cardsContainer.style.bottom = 16f;
             cardsContainer.style.flexDirection = FlexDirection.Column;
             cardsContainer.style.justifyContent = Justify.SpaceBetween;
@@ -522,7 +524,7 @@ namespace Mukseon.Gameplay.UI
                 return;
             }
 
-            _levelUpTitle.text = $"{Strings.LevelUpTitle}  (Lv.{_playerLevelSystem.CurrentLevel})";
+            _levelUpTitle.text = $"{Strings.LevelUpTitle} (Lv.{_playerLevelSystem.CurrentLevel})";
             IReadOnlyList<SkillData> choices = _playerLevelSystem.CurrentChoices;
             for (int i = 0; i < _cardSlots.Count; i++)
             {

--- a/project1/Assets/Scripts/UI/GameplayHudBootstrapper.cs
+++ b/project1/Assets/Scripts/UI/GameplayHudBootstrapper.cs
@@ -52,6 +52,9 @@ namespace Mukseon.Gameplay.UI
         private VisualElement _levelUpPanel;
         private Label _levelUpTitle;
         private readonly List<Button> _choiceButtons = new List<Button>(3);
+        private readonly List<VisualElement> _cardIconElements = new List<VisualElement>(3);
+        private readonly List<Label> _cardNameLabels = new List<Label>(3);
+        private readonly List<Label> _cardDescLabels = new List<Label>(3);
 
         private readonly HashSet<EnemyHealth> _trackedEnemies = new HashSet<EnemyHealth>();
         private readonly Dictionary<EnemyHealth, Label> _arrowLabels = new Dictionary<EnemyHealth, Label>();
@@ -199,15 +202,17 @@ namespace Mukseon.Gameplay.UI
             _bossFill.style.backgroundColor = new Color(0.88f, 0.12f, 0.12f);
             _bossRoot.style.display = DisplayStyle.None;
 
-            _levelUpPanel = Panel(_root, 680f, 360f, 560f, 360f);
-            _levelUpPanel.style.backgroundColor = new Color(0.08f, 0.08f, 0.12f, 0.94f);
-            _levelUpTitle = Text(_levelUpPanel, 24f, 24f, 512f, 28f, 24, TextAnchor.MiddleCenter);
+            const float panelW = 580f;
+            const float panelH = 440f;
+            _levelUpPanel = Panel(_root, (1920f - panelW) * 0.5f, (1080f - panelH) * 0.5f, panelW, panelH);
+            _levelUpPanel.style.backgroundColor = new Color(0.06f, 0.06f, 0.10f, 0.96f);
+            _levelUpTitle = Text(_levelUpPanel, 16f, 14f, panelW - 32f, 30f, 22, TextAnchor.MiddleCenter);
             _levelUpPanel.style.display = DisplayStyle.None;
 
             for (int i = 0; i < 3; i++)
             {
                 int choiceIndex = i;
-                Button button = new Button(() =>
+                Button card = new Button(() =>
                 {
                     if (_playerLevelSystem != null)
                     {
@@ -215,18 +220,67 @@ namespace Mukseon.Gameplay.UI
                     }
                 });
 
-                button.style.position = Position.Absolute;
-                button.style.left = 24f;
-                button.style.top = 72f + (84f * i);
-                button.style.width = 512f;
-                button.style.height = 68f;
-                button.style.whiteSpace = WhiteSpace.Normal;
-                button.style.unityTextAlign = TextAnchor.MiddleLeft;
-                button.style.fontSize = 18f;
-                button.style.backgroundColor = new Color(0.14f, 0.16f, 0.24f, 0.96f);
-                button.style.color = Color.white;
-                _levelUpPanel.Add(button);
-                _choiceButtons.Add(button);
+                card.text = string.Empty;
+                card.style.position = Position.Absolute;
+                card.style.left = 16f;
+                card.style.top = 56f + (116f * i);
+                card.style.width = panelW - 32f;
+                card.style.height = 108f;
+                card.style.backgroundColor = new Color(0.12f, 0.14f, 0.22f, 0.98f);
+                card.style.color = Color.white;
+                card.style.paddingTop = 0f;
+                card.style.paddingBottom = 0f;
+                card.style.paddingLeft = 0f;
+                card.style.paddingRight = 0f;
+                card.style.borderTopLeftRadius = 6f;
+                card.style.borderTopRightRadius = 6f;
+                card.style.borderBottomLeftRadius = 6f;
+                card.style.borderBottomRightRadius = 6f;
+                _levelUpPanel.Add(card);
+                _choiceButtons.Add(card);
+
+                // 스킬 아이콘
+                VisualElement icon = new VisualElement();
+                icon.style.position = Position.Absolute;
+                icon.style.left = 14f;
+                icon.style.top = 14f;
+                icon.style.width = 80f;
+                icon.style.height = 80f;
+                icon.style.backgroundColor = new Color(0.20f, 0.22f, 0.32f, 1f);
+                icon.style.borderTopLeftRadius = 4f;
+                icon.style.borderTopRightRadius = 4f;
+                icon.style.borderBottomLeftRadius = 4f;
+                icon.style.borderBottomRightRadius = 4f;
+                card.Add(icon);
+                _cardIconElements.Add(icon);
+
+                // 스킬 이름 + 레벨
+                Label nameLabel = new Label();
+                nameLabel.style.position = Position.Absolute;
+                nameLabel.style.left = 108f;
+                nameLabel.style.top = 10f;
+                nameLabel.style.width = 418f;
+                nameLabel.style.height = 28f;
+                nameLabel.style.color = Color.white;
+                nameLabel.style.fontSize = 19f;
+                nameLabel.style.unityFontStyleAndWeight = FontStyle.Bold;
+                nameLabel.style.unityTextAlign = TextAnchor.MiddleLeft;
+                card.Add(nameLabel);
+                _cardNameLabels.Add(nameLabel);
+
+                // 스킬 설명
+                Label descLabel = new Label();
+                descLabel.style.position = Position.Absolute;
+                descLabel.style.left = 108f;
+                descLabel.style.top = 44f;
+                descLabel.style.width = 418f;
+                descLabel.style.height = 56f;
+                descLabel.style.color = new Color(0.78f, 0.78f, 0.84f, 1f);
+                descLabel.style.fontSize = 13f;
+                descLabel.style.unityTextAlign = TextAnchor.UpperLeft;
+                descLabel.style.whiteSpace = WhiteSpace.Normal;
+                card.Add(descLabel);
+                _cardDescLabels.Add(descLabel);
             }
         }
 
@@ -438,7 +492,7 @@ namespace Mukseon.Gameplay.UI
                 return;
             }
 
-            _levelUpTitle.text = $"Level {_playerLevelSystem.CurrentLevel} - choose a skill";
+            _levelUpTitle.text = $"레벨 업! 스킬을 선택하세요  (Lv.{_playerLevelSystem.CurrentLevel})";
             IReadOnlyList<SkillData> choices = _playerLevelSystem.CurrentChoices;
             for (int i = 0; i < _choiceButtons.Count; i++)
             {
@@ -450,8 +504,25 @@ namespace Mukseon.Gameplay.UI
                 }
 
                 SkillData choice = choices[i];
-                int nextLevel = _playerLevelSystem.GetSkillLevel(choice.SkillId) + 1;
-                _choiceButtons[i].text = $"{choice.DisplayName} Lv.{nextLevel}\n{choice.Description}";
+                int currentLevel = _playerLevelSystem.GetSkillLevel(choice.SkillId);
+                int nextLevel = currentLevel + 1;
+
+                // 아이콘
+                if (choice.Icon != null)
+                {
+                    _cardIconElements[i].style.backgroundImage = new StyleBackground(choice.Icon);
+                }
+                else
+                {
+                    _cardIconElements[i].style.backgroundImage = StyleKeyword.None;
+                }
+
+                // 이름 + 레벨
+                string levelText = currentLevel > 0 ? $"  Lv.{currentLevel} → {nextLevel}" : $"  Lv.{nextLevel}";
+                _cardNameLabels[i].text = choice.DisplayName + levelText;
+
+                // 설명
+                _cardDescLabels[i].text = choice.Description;
             }
         }
 


### PR DESCRIPTION
## Summary

- `LevelUpSkillEffectType` 확장: 기존 4종 → 14종 (공용 스킬 6종 + 클래스 전용 4종으로 11개 스킬 트리 전체 지원)
- `SkillData`에 `Sprite Icon` 필드 추가 (Inspector에서 스킬 아이콘 할당 가능)
- `GameplayHudBootstrapper` 레벨업 패널을 카드 레이아웃으로 교체 (아이콘 + 이름/레벨 + 설명)
- `OnSkillEffectPending` 이벤트 추가: 전담 시스템 미구현 스킬 타입 선택 시 해당 시스템이 구독하여 처리할 수 있는 위임 구조 마련

## 미구현 스킬 처리

`SummonDokkaebiOrb`, `InkExplosionOnKill` 등 10종의 새 스킬 타입은 enum 및 이벤트 훅만 준비된 상태입니다.  
각 효과의 실제 구현은 관련 이슈(#29, #30 등)에서 전담 시스템이 `OnSkillEffectPending`을 구독하여 처리합니다.  
현재는 관련 `SkillData` SO가 없으므로 선택지 풀에 노출되지 않습니다.

## Test plan

- [ ] 플레이 모드 진입 후 경험치 획득으로 레벨업 발생 확인
- [ ] 레벨업 시 카드 레이아웃 패널이 화면 중앙에 표시되는지 확인
- [ ] 스킬 카드에 이름, 레벨(Lv.N), 설명이 올바르게 표시되는지 확인
- [ ] 스킬 선택 후 패널이 닫히고 게임이 재개되는지 확인
- [ ] `SkillData` SO의 Icon 슬롯에 스프라이트 할당 시 카드 아이콘 영역에 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)