### PR TITLE
feat: 적 공격 방향 시퀀스 시스템 및 HUD 표시 (#54)

### DIFF
--- a/project1/Assets/Prefabs/Enemies/Boss_Dureoksini.prefab
+++ b/project1/Assets/Prefabs/Enemies/Boss_Dureoksini.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 1475677598667535634}
   - component: {fileID: 1831119107564088829}
   - component: {fileID: 110446678007002424}
+  - component: {fileID: 6676783505557286248}
   m_Layer: 0
   m_Name: Boss_Dureoksini
   m_TagString: Untagged
@@ -157,7 +158,7 @@ MonoBehaviour:
   _destroyOnDeath: 1
   _disableCollidersOnDeath: 1
   _swipeDirection: 4
-  _monsterData: {fileID: 0}
+  _monsterData: {fileID: 11400000, guid: 29fa4d2c3fd292642baaf7f072b8e86e, type: 2}
   _moveSpeed: 1
 --- !u!114 &1831119107564088829
 MonoBehaviour:
@@ -191,3 +192,16 @@ MonoBehaviour:
   _movePattern: 0
   _playerTarget: {fileID: 0}
   _riseHeight: 10
+--- !u!114 &6676783505557286248
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5516339678559892061}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 719023c2dc6a5b94a960b5d8fd7d8fae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyAttackSequence
+  _sequence: 

--- a/project1/Assets/Prefabs/Enemies/Dummy_Down.prefab
+++ b/project1/Assets/Prefabs/Enemies/Dummy_Down.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 4234627494100266546}
   - component: {fileID: 2488382620803013241}
   - component: {fileID: 707632565690213840}
+  - component: {fileID: 902457377154407016}
   m_Layer: 0
   m_Name: Dummy_Down
   m_TagString: Untagged
@@ -153,7 +154,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2c6d5a7ef7a14cf0b98f6d9381d7a201, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyHealth
-  _maxHealth: 10
+  _maxHealth: 3
   _destroyOnDeath: 1
   _disableCollidersOnDeath: 1
   _swipeDirection: 2
@@ -190,3 +191,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyMover
   _movePattern: 0
   _playerTarget: {fileID: 0}
+  _riseHeight: 10
+--- !u!114 &902457377154407016
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6892844264584007441}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 719023c2dc6a5b94a960b5d8fd7d8fae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyAttackSequence
+  _sequence: 020000000300000004000000

--- a/project1/Assets/Prefabs/Enemies/Dummy_Left.prefab
+++ b/project1/Assets/Prefabs/Enemies/Dummy_Left.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 4368540737326870438}
   - component: {fileID: 4829204163632401306}
   - component: {fileID: 2394660698194004625}
+  - component: {fileID: 2776196048433973373}
   m_Layer: 0
   m_Name: Dummy_Left
   m_TagString: Untagged
@@ -153,7 +154,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2c6d5a7ef7a14cf0b98f6d9381d7a201, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyHealth
-  _maxHealth: 10
+  _maxHealth: 3
   _destroyOnDeath: 1
   _disableCollidersOnDeath: 1
   _swipeDirection: 3
@@ -190,3 +191,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyMover
   _movePattern: 0
   _playerTarget: {fileID: 0}
+  _riseHeight: 10
+--- !u!114 &2776196048433973373
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6848363840087502861}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 719023c2dc6a5b94a960b5d8fd7d8fae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyAttackSequence
+  _sequence: 030000000200000001000000

--- a/project1/Assets/Prefabs/Enemies/Dummy_Right.prefab
+++ b/project1/Assets/Prefabs/Enemies/Dummy_Right.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 1475677598667535634}
   - component: {fileID: 1831119107564088829}
   - component: {fileID: 110446678007002424}
+  - component: {fileID: 8797208339621773822}
   m_Layer: 0
   m_Name: Dummy_Right
   m_TagString: Untagged
@@ -153,7 +154,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2c6d5a7ef7a14cf0b98f6d9381d7a201, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyHealth
-  _maxHealth: 10
+  _maxHealth: 3
   _destroyOnDeath: 1
   _disableCollidersOnDeath: 1
   _swipeDirection: 4
@@ -190,3 +191,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyMover
   _movePattern: 0
   _playerTarget: {fileID: 0}
+  _riseHeight: 10
+--- !u!114 &8797208339621773822
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5516339678559892061}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 719023c2dc6a5b94a960b5d8fd7d8fae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyAttackSequence
+  _sequence: 040000000100000002000000

--- a/project1/Assets/Prefabs/Enemies/Dummy_Up.prefab
+++ b/project1/Assets/Prefabs/Enemies/Dummy_Up.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 3535088139439741544}
   - component: {fileID: 8930110949059020394}
   - component: {fileID: 753179079726369400}
+  - component: {fileID: 8489735811375365995}
   m_Layer: 0
   m_Name: Dummy_Up
   m_TagString: Untagged
@@ -153,7 +154,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2c6d5a7ef7a14cf0b98f6d9381d7a201, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyHealth
-  _maxHealth: 10
+  _maxHealth: 3
   _destroyOnDeath: 1
   _disableCollidersOnDeath: 1
   _swipeDirection: 1
@@ -190,3 +191,17 @@ MonoBehaviour:
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyMover
   _movePattern: 0
   _playerTarget: {fileID: 0}
+  _riseHeight: 10
+--- !u!114 &8489735811375365995
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7248748341038818817}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 719023c2dc6a5b94a960b5d8fd7d8fae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyAttackSequence
+  _sequence: 010000000400000003000000

--- a/project1/Assets/Scripts/Combat/EnemyAttackSequence.cs
+++ b/project1/Assets/Scripts/Combat/EnemyAttackSequence.cs
@@ -64,6 +64,9 @@ namespace Mukseon.Gameplay.Combat
             _currentIndex = 0;
         }
 
+        /// <summary>
+        /// 랜덤 시퀀스를 생성한다. 연속으로 같은 방향이 나올 수 있으며, 이는 의도된 동작이다.
+        /// </summary>
         public static SwipeDirection[] GenerateRandomSequence(int length)
         {
             length = Mathf.Max(1, length);

--- a/project1/Assets/Scripts/Combat/EnemyAttackSequence.cs
+++ b/project1/Assets/Scripts/Combat/EnemyAttackSequence.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using Mukseon.Core.Input;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    [DisallowMultipleComponent]
+    public class EnemyAttackSequence : MonoBehaviour
+    {
+        private static readonly SwipeDirection[] DirectionPool =
+        {
+            SwipeDirection.Up,
+            SwipeDirection.Down,
+            SwipeDirection.Left,
+            SwipeDirection.Right
+        };
+
+        [SerializeField]
+        private SwipeDirection[] _sequence = new SwipeDirection[0];
+
+        private int _currentIndex;
+
+        public int CurrentIndex => _currentIndex;
+        public int SequenceLength => _sequence != null ? _sequence.Length : 0;
+        public IReadOnlyList<SwipeDirection> Sequence => _sequence;
+
+        public SwipeDirection CurrentDirection
+        {
+            get
+            {
+                if (_sequence == null || _sequence.Length == 0 || _currentIndex >= _sequence.Length)
+                {
+                    return SwipeDirection.None;
+                }
+
+                return _sequence[_currentIndex];
+            }
+        }
+
+        public event Action<int> OnAdvanced;
+        public event Action OnSequenceSet;
+
+        public void SetSequence(SwipeDirection[] sequence)
+        {
+            _sequence = sequence ?? new SwipeDirection[0];
+            _currentIndex = 0;
+            OnSequenceSet?.Invoke();
+        }
+
+        public void Advance()
+        {
+            if (_sequence == null || _sequence.Length == 0)
+            {
+                return;
+            }
+
+            _currentIndex = (_currentIndex + 1) % _sequence.Length;
+            OnAdvanced?.Invoke(_currentIndex);
+        }
+
+        public void ResetSequence()
+        {
+            _currentIndex = 0;
+        }
+
+        public static SwipeDirection[] GenerateRandomSequence(int length)
+        {
+            length = Mathf.Max(1, length);
+            SwipeDirection[] sequence = new SwipeDirection[length];
+            for (int i = 0; i < length; i++)
+            {
+                sequence[i] = DirectionPool[UnityEngine.Random.Range(0, DirectionPool.Length)];
+            }
+
+            return sequence;
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/EnemyAttackSequence.cs.meta
+++ b/project1/Assets/Scripts/Combat/EnemyAttackSequence.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 719023c2dc6a5b94a960b5d8fd7d8fae

--- a/project1/Assets/Scripts/Combat/EnemyHealth.cs
+++ b/project1/Assets/Scripts/Combat/EnemyHealth.cs
@@ -32,6 +32,7 @@ namespace Mukseon.Gameplay.Combat
 
         private Collider2D[] _colliders;
         private EnemyAttackSequence _attackSequence;
+        private bool _attackSequenceCached;
 
         public float MaxHealth => _maxHealth;
         public float CurrentHealth { get; private set; }
@@ -45,9 +46,10 @@ namespace Mukseon.Gameplay.Combat
         {
             get
             {
-                if (_attackSequence == null)
+                if (!_attackSequenceCached)
                 {
                     _attackSequence = GetComponent<EnemyAttackSequence>();
+                    _attackSequenceCached = true;
                 }
 
                 return _attackSequence;
@@ -197,7 +199,15 @@ namespace Mukseon.Gameplay.Combat
         {
             _destroyOnDeath = false;
             ResetHealth();
-            _attackSequence?.ResetSequence();
+
+            if (_attackSequence != null && _monsterData != null && _monsterData.RandomizeSequence)
+            {
+                _attackSequence.SetSequence(EnemyAttackSequence.GenerateRandomSequence((int)_maxHealth));
+            }
+            else
+            {
+                _attackSequence?.ResetSequence();
+            }
 
             if (_disableCollidersOnDeath)
             {

--- a/project1/Assets/Scripts/Combat/EnemyHealth.cs
+++ b/project1/Assets/Scripts/Combat/EnemyHealth.cs
@@ -82,6 +82,7 @@ namespace Mukseon.Gameplay.Combat
         private void Awake()
         {
             _attackSequence = GetComponent<EnemyAttackSequence>();
+            _attackSequenceCached = true;
             ApplyMonsterData();
 
             if (_attackSequence == null && _swipeDirection == SwipeDirection.None)

--- a/project1/Assets/Scripts/Combat/EnemyHealth.cs
+++ b/project1/Assets/Scripts/Combat/EnemyHealth.cs
@@ -31,6 +31,7 @@ namespace Mukseon.Gameplay.Combat
         private float _moveSpeed = 1f;
 
         private Collider2D[] _colliders;
+        private EnemyAttackSequence _attackSequence;
 
         public float MaxHealth => _maxHealth;
         public float CurrentHealth { get; private set; }
@@ -40,10 +41,28 @@ namespace Mukseon.Gameplay.Combat
         public MonsterData MonsterData => _monsterData;
         public string DisplayName => _monsterData != null ? _monsterData.DisplayName : gameObject.name;
         public bool IsBoss => _monsterData != null && _monsterData.IsBoss;
+        public EnemyAttackSequence AttackSequence
+        {
+            get
+            {
+                if (_attackSequence == null)
+                {
+                    _attackSequence = GetComponent<EnemyAttackSequence>();
+                }
+
+                return _attackSequence;
+            }
+        }
+
         public SwipeDirection SwipeDirection
         {
             get
             {
+                if (AttackSequence != null)
+                {
+                    return _attackSequence.CurrentDirection;
+                }
+
                 if (_swipeDirection == SwipeDirection.None)
                 {
                     _swipeDirection = InferSwipeDirectionFromName(gameObject.name);
@@ -60,9 +79,10 @@ namespace Mukseon.Gameplay.Combat
 
         private void Awake()
         {
+            _attackSequence = GetComponent<EnemyAttackSequence>();
             ApplyMonsterData();
 
-            if (_swipeDirection == SwipeDirection.None)
+            if (_attackSequence == null && _swipeDirection == SwipeDirection.None)
             {
                 _swipeDirection = InferSwipeDirectionFromName(gameObject.name);
             }
@@ -177,6 +197,7 @@ namespace Mukseon.Gameplay.Combat
         {
             _destroyOnDeath = false;
             ResetHealth();
+            _attackSequence?.ResetSequence();
 
             if (_disableCollidersOnDeath)
             {
@@ -207,9 +228,17 @@ namespace Mukseon.Gameplay.Combat
 
             _maxHealth = _monsterData.MaxHealth;
             _moveSpeed = _monsterData.MoveSpeed;
-            if (_monsterData.SwipeDirection != SwipeDirection.None)
+
+            if (_attackSequence != null)
             {
-                _swipeDirection = _monsterData.SwipeDirection;
+                if (_monsterData.RandomizeSequence)
+                {
+                    _attackSequence.SetSequence(EnemyAttackSequence.GenerateRandomSequence((int)_maxHealth));
+                }
+                else if (_monsterData.SwipeDirectionSequence != null && _monsterData.SwipeDirectionSequence.Length > 0)
+                {
+                    _attackSequence.SetSequence(_monsterData.SwipeDirectionSequence);
+                }
             }
         }
 

--- a/project1/Assets/Scripts/Combat/MonsterData.cs
+++ b/project1/Assets/Scripts/Combat/MonsterData.cs
@@ -19,7 +19,10 @@ namespace Mukseon.Gameplay.Combat
         private EnemyHealth _enemyPrefab;
 
         [SerializeField]
-        private SwipeDirection _swipeDirection = SwipeDirection.None;
+        private SwipeDirection[] _swipeDirectionSequence = new SwipeDirection[0];
+
+        [SerializeField]
+        private bool _randomizeSequence;
 
         [SerializeField, Min(1f)]
         private float _maxHealth = 10f;
@@ -37,7 +40,8 @@ namespace Mukseon.Gameplay.Combat
         public string DisplayName => string.IsNullOrWhiteSpace(_displayName) ? name : _displayName;
         public bool IsBoss => _isBoss;
         public EnemyHealth EnemyPrefab => _enemyPrefab;
-        public SwipeDirection SwipeDirection => _swipeDirection;
+        public SwipeDirection[] SwipeDirectionSequence => _swipeDirectionSequence;
+        public bool RandomizeSequence => _randomizeSequence;
         public float MaxHealth => Mathf.Max(1f, _maxHealth);
         public float MoveSpeed => Mathf.Max(0f, _moveSpeed);
         public int SoulDropCount => Mathf.Max(1, _soulDropCount);

--- a/project1/Assets/Scripts/Combat/SwipeAttackEventListener.cs
+++ b/project1/Assets/Scripts/Combat/SwipeAttackEventListener.cs
@@ -114,7 +114,13 @@ namespace Mukseon.Gameplay.Combat
             for (int i = 0; i < selectedCount; i++)
             {
                 EnemyHealth enemyHealth = _targetBuffer[i];
-                enemyHealth.ApplyDamage(damage, this);
+                float actualDamage = enemyHealth.AttackSequence != null ? 1f : damage;
+                enemyHealth.ApplyDamage(actualDamage, this);
+
+                if (enemyHealth.IsAlive && enemyHealth.AttackSequence != null)
+                {
+                    enemyHealth.AttackSequence.Advance();
+                }
             }
 
             return selectedCount;

--- a/project1/Assets/Scripts/Combat/SwipeAttackEventListener.cs
+++ b/project1/Assets/Scripts/Combat/SwipeAttackEventListener.cs
@@ -114,12 +114,13 @@ namespace Mukseon.Gameplay.Combat
             for (int i = 0; i < selectedCount; i++)
             {
                 EnemyHealth enemyHealth = _targetBuffer[i];
-                float actualDamage = enemyHealth.AttackSequence != null ? 1f : damage;
+                EnemyAttackSequence attackSequence = enemyHealth.AttackSequence;
+                float actualDamage = attackSequence != null ? 1f : damage;
                 enemyHealth.ApplyDamage(actualDamage, this);
 
-                if (enemyHealth.IsAlive && enemyHealth.AttackSequence != null)
+                if (enemyHealth.IsAlive && attackSequence != null)
                 {
-                    enemyHealth.AttackSequence.Advance();
+                    attackSequence.Advance();
                 }
             }
 

--- a/project1/Assets/Scripts/UI/GameplayHudBootstrapper.cs
+++ b/project1/Assets/Scripts/UI/GameplayHudBootstrapper.cs
@@ -954,8 +954,9 @@ namespace Mukseon.Gameplay.UI
                 : new Vector2(screenPoint.x, Screen.height - screenPoint.y);
 
             label.style.display = DisplayStyle.Flex;
-            label.style.left = panelPos.x - 60f;
+            label.style.left = panelPos.x;
             label.style.top = panelPos.y - screenYOffset;
+            label.style.translate = new Translate(Length.Percent(-50f), 0f);
         }
 
         private static void PositionSequenceHud(EnemyHealth enemy, SequenceHud hud, Camera camera, IPanel panel)
@@ -983,8 +984,9 @@ namespace Mukseon.Gameplay.UI
                 : new Vector2(screenPoint.x, Screen.height - screenPoint.y);
 
             container.style.display = DisplayStyle.Flex;
-            container.style.left = panelPos.x - 60f;
+            container.style.left = panelPos.x;
             container.style.top = panelPos.y - 24f;
+            container.style.translate = new Translate(Length.Percent(-50f), 0f);
         }
 
         private static string Arrow(SwipeDirection direction)

--- a/project1/Assets/Scripts/UI/GameplayHudBootstrapper.cs
+++ b/project1/Assets/Scripts/UI/GameplayHudBootstrapper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Mukseon.Core.Input;
 using Mukseon.Gameplay.Combat;
@@ -70,8 +71,17 @@ namespace Mukseon.Gameplay.UI
         private Label _levelUpTitle;
         private readonly List<CardSlot> _cardSlots = new List<CardSlot>(3);
 
+        private sealed class SequenceHud
+        {
+            public VisualElement Container;
+            public Label[] ArrowLabels = new Label[3];
+            public Label EllipsisLabel;
+            public Action<int> AdvancedHandler;
+            public Action SequenceSetHandler;
+        }
+
         private readonly HashSet<EnemyHealth> _trackedEnemies = new HashSet<EnemyHealth>();
-        private readonly Dictionary<EnemyHealth, Label> _arrowLabels = new Dictionary<EnemyHealth, Label>();
+        private readonly Dictionary<EnemyHealth, SequenceHud> _sequenceHuds = new Dictionary<EnemyHealth, SequenceHud>();
         private readonly List<FloatingText> _floatingTexts = new List<FloatingText>();
         private readonly List<EnemyHealth> _enemyBuffer = new List<EnemyHealth>(64);
         private readonly List<EnemyHealth> _removedEnemyBuffer = new List<EnemyHealth>(64);
@@ -100,7 +110,7 @@ namespace Mukseon.Gameplay.UI
 #endif
         }
 
-        private static T FindSceneObject<T>() where T : Object
+        private static T FindSceneObject<T>() where T : UnityEngine.Object
         {
 #if UNITY_2023_1_OR_NEWER
             return FindFirstObjectByType<T>(FindObjectsInactive.Include);
@@ -592,7 +602,7 @@ namespace Mukseon.Gameplay.UI
                 {
                     enemy.OnDamagedDetailed += HandleEnemyDamaged;
                     enemy.OnDeath += HandleEnemyDeath;
-                    CreateArrow(enemy);
+                    CreateSequenceHud(enemy);
                     if (enemy.IsBoss)
                     {
                         _bossEnemy = enemy;
@@ -646,10 +656,24 @@ namespace Mukseon.Gameplay.UI
 
             _trackedEnemies.Remove(enemy);
 
-            if (enemy != null && _arrowLabels.TryGetValue(enemy, out Label label))
+            if (enemy != null && _sequenceHuds.TryGetValue(enemy, out SequenceHud hud))
             {
-                label.RemoveFromHierarchy();
-                _arrowLabels.Remove(enemy);
+                EnemyAttackSequence seq = enemy.AttackSequence;
+                if (seq != null)
+                {
+                    if (hud.AdvancedHandler != null)
+                    {
+                        seq.OnAdvanced -= hud.AdvancedHandler;
+                    }
+
+                    if (hud.SequenceSetHandler != null)
+                    {
+                        seq.OnSequenceSet -= hud.SequenceSetHandler;
+                    }
+                }
+
+                hud.Container.RemoveFromHierarchy();
+                _sequenceHuds.Remove(enemy);
             }
 
             if (_bossEnemy == enemy)
@@ -676,13 +700,119 @@ namespace Mukseon.Gameplay.UI
             }
         }
 
-        private void CreateArrow(EnemyHealth enemy)
+        private void CreateSequenceHud(EnemyHealth enemy)
         {
-            Label label = Text(_worldRoot, 0f, 0f, 48f, 24f, 24, TextAnchor.MiddleCenter);
-            label.style.color = new Color(1f, 0.94f, 0.5f);
-            label.style.unityFontStyleAndWeight = FontStyle.Bold;
-            label.text = Arrow(enemy.SwipeDirection);
-            _arrowLabels[enemy] = label;
+            VisualElement container = new VisualElement();
+            container.style.position = Position.Absolute;
+            container.style.flexDirection = FlexDirection.Row;
+            container.style.alignItems = Align.Center;
+            container.style.backgroundColor = new Color(0f, 0f, 0f, 0.55f);
+            container.style.borderTopLeftRadius = 4f;
+            container.style.borderTopRightRadius = 4f;
+            container.style.borderBottomLeftRadius = 4f;
+            container.style.borderBottomRightRadius = 4f;
+            container.style.paddingLeft = 4f;
+            container.style.paddingRight = 4f;
+            _worldRoot.Add(container);
+
+            SequenceHud hud = new SequenceHud();
+            hud.Container = container;
+
+            for (int i = 0; i < 3; i++)
+            {
+                Label arrowLabel = new Label();
+                arrowLabel.style.width = 28f;
+                arrowLabel.style.height = 32f;
+                arrowLabel.style.unityTextAlign = TextAnchor.MiddleCenter;
+                arrowLabel.style.whiteSpace = WhiteSpace.Normal;
+                container.Add(arrowLabel);
+                hud.ArrowLabels[i] = arrowLabel;
+            }
+
+            Label ellipsis = new Label();
+            ellipsis.text = "...";
+            ellipsis.style.width = 24f;
+            ellipsis.style.height = 32f;
+            ellipsis.style.color = new Color(1f, 1f, 1f, 0.5f);
+            ellipsis.style.fontSize = 16f;
+            ellipsis.style.unityTextAlign = TextAnchor.MiddleCenter;
+            container.Add(ellipsis);
+            hud.EllipsisLabel = ellipsis;
+
+            _sequenceHuds[enemy] = hud;
+
+            EnemyAttackSequence seq = enemy.AttackSequence;
+            if (seq != null)
+            {
+                hud.AdvancedHandler = _ => RefreshSequenceHud(enemy);
+                seq.OnAdvanced += hud.AdvancedHandler;
+
+                hud.SequenceSetHandler = () => RefreshSequenceHud(enemy);
+                seq.OnSequenceSet += hud.SequenceSetHandler;
+            }
+
+            RefreshSequenceHud(enemy);
+        }
+
+        private void RefreshSequenceHud(EnemyHealth enemy)
+        {
+            if (!_sequenceHuds.TryGetValue(enemy, out SequenceHud hud))
+            {
+                return;
+            }
+
+            EnemyAttackSequence seq = enemy.AttackSequence;
+
+            if (seq == null)
+            {
+                hud.ArrowLabels[0].text = Arrow(enemy.SwipeDirection);
+                hud.ArrowLabels[0].style.display = DisplayStyle.Flex;
+                hud.ArrowLabels[0].style.color = new Color(1f, 0.94f, 0.5f);
+                hud.ArrowLabels[0].style.fontSize = 24f;
+                hud.ArrowLabels[0].style.unityFontStyleAndWeight = FontStyle.Bold;
+                for (int i = 1; i < 3; i++)
+                {
+                    hud.ArrowLabels[i].style.display = DisplayStyle.None;
+                }
+
+                hud.EllipsisLabel.style.display = DisplayStyle.None;
+                return;
+            }
+
+            int currentIdx = seq.CurrentIndex;
+            int total = seq.SequenceLength;
+            int remaining = total - currentIdx;
+
+            for (int i = 0; i < 3; i++)
+            {
+                int seqIdx = currentIdx + i;
+                Label label = hud.ArrowLabels[i];
+
+                if (seqIdx < total)
+                {
+                    label.style.display = DisplayStyle.Flex;
+                    label.text = Arrow(seq.Sequence[seqIdx]);
+
+                    if (i == 0)
+                    {
+                        label.style.color = new Color(1f, 0.94f, 0.2f);
+                        label.style.fontSize = 28f;
+                        label.style.unityFontStyleAndWeight = FontStyle.Bold;
+                    }
+                    else
+                    {
+                        label.style.color = new Color(1f, 1f, 1f, 0.45f);
+                        label.style.fontSize = 20f;
+                        label.style.unityFontStyleAndWeight = FontStyle.Normal;
+                    }
+                }
+                else
+                {
+                    label.style.display = DisplayStyle.None;
+                }
+            }
+
+            hud.EllipsisLabel.style.display = remaining > 3 ? DisplayStyle.Flex : DisplayStyle.None;
         }
 
         private void HandleEnemyDamaged(EnemyHealth enemy, float damageAmount, object source)
@@ -733,9 +863,11 @@ namespace Mukseon.Gameplay.UI
                 return;
             }
 
-            foreach (KeyValuePair<EnemyHealth, Label> pair in _arrowLabels)
+            IPanel panel = _root?.panel;
+
+            foreach (KeyValuePair<EnemyHealth, SequenceHud> pair in _sequenceHuds)
             {
-                PositionAtEnemy(pair.Key, pair.Value, camera, 1.6f, -24f);
+                PositionSequenceHud(pair.Key, pair.Value, camera, panel);
             }
 
             for (int i = _floatingTexts.Count - 1; i >= 0; i--)
@@ -750,7 +882,7 @@ namespace Mukseon.Gameplay.UI
                     continue;
                 }
 
-                PositionAtEnemy(floatingText.Enemy, floatingText.Label, camera, 1.2f, floatingText.OffsetY);
+                PositionAtEnemy(floatingText.Enemy, floatingText.Label, camera, panel, 1.2f, floatingText.OffsetY);
                 Color color = floatingText.Label.resolvedStyle.color;
                 color.a = Mathf.Clamp01(floatingText.TimeLeft / 0.8f);
                 floatingText.Label.style.color = color;
@@ -802,7 +934,7 @@ namespace Mukseon.Gameplay.UI
             RefreshWave();
         }
 
-        private static void PositionAtEnemy(EnemyHealth enemy, Label label, Camera camera, float worldYOffset, float screenYOffset)
+        private static void PositionAtEnemy(EnemyHealth enemy, Label label, Camera camera, IPanel panel, float worldYOffset, float screenYOffset)
         {
             if (enemy == null || label == null || !enemy.IsAlive)
             {
@@ -817,9 +949,42 @@ namespace Mukseon.Gameplay.UI
                 return;
             }
 
+            Vector2 panelPos = panel != null
+                ? RuntimePanelUtils.ScreenToPanel(panel, new Vector2(screenPoint.x, Screen.height - screenPoint.y))
+                : new Vector2(screenPoint.x, Screen.height - screenPoint.y);
+
             label.style.display = DisplayStyle.Flex;
-            label.style.left = screenPoint.x - 60f;
-            label.style.top = Screen.height - screenPoint.y - screenYOffset;
+            label.style.left = panelPos.x - 60f;
+            label.style.top = panelPos.y - screenYOffset;
+        }
+
+        private static void PositionSequenceHud(EnemyHealth enemy, SequenceHud hud, Camera camera, IPanel panel)
+        {
+            VisualElement container = hud.Container;
+            if (enemy == null || container == null || !enemy.IsAlive)
+            {
+                if (container != null)
+                {
+                    container.style.display = DisplayStyle.None;
+                }
+
+                return;
+            }
+
+            Vector3 screenPoint = camera.WorldToScreenPoint(enemy.transform.position + Vector3.up * 1.6f);
+            if (screenPoint.z <= 0f)
+            {
+                container.style.display = DisplayStyle.None;
+                return;
+            }
+
+            Vector2 panelPos = panel != null
+                ? RuntimePanelUtils.ScreenToPanel(panel, new Vector2(screenPoint.x, Screen.height - screenPoint.y))
+                : new Vector2(screenPoint.x, Screen.height - screenPoint.y);
+
+            container.style.display = DisplayStyle.Flex;
+            container.style.left = panelPos.x - 60f;
+            container.style.top = panelPos.y - 24f;
         }
 
         private static string Arrow(SwipeDirection direction)

--- a/project1/Assets/Settings/Data/Monsters/Monster_AshenClaw.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_AshenClaw.asset
@@ -14,9 +14,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.MonsterData
   _monsterId: monster.ashen_claw
   _displayName: Ashen Claw
+  _isBoss: 0
   _enemyPrefab: {fileID: 3535088139439741544, guid: 9f359b9056e17c241bc9c9c0ecd3976f, type: 3}
-  _swipeDirection: 1
-  _maxHealth: 18
+  _swipeDirectionSequence: 
+  _randomizeSequence: 1
+  _maxHealth: 3
   _moveSpeed: 1.2
   _soulDropCount: 1
   _experiencePerOrb: 1

--- a/project1/Assets/Settings/Data/Monsters/Monster_BrambleIdol.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_BrambleIdol.asset
@@ -15,8 +15,9 @@ MonoBehaviour:
   _monsterId: monster.bramble_idol
   _displayName: Bramble Idol
   _enemyPrefab: {fileID: 1475677598667535634, guid: dd3d8ac0cb439f64bbbaa2bbe5d1ccc0, type: 3}
-  _swipeDirection: 4
-  _maxHealth: 40
+  _swipeDirectionSequence:
+  _randomizeSequence: 1
+  _maxHealth: 5
   _moveSpeed: 0.85
   _soulDropCount: 3
   _experiencePerOrb: 2

--- a/project1/Assets/Settings/Data/Monsters/Monster_Dureoksini.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_Dureoksini.asset
@@ -16,8 +16,9 @@ MonoBehaviour:
   _displayName: Dureoksini
   _isBoss: 1
   _enemyPrefab: {fileID: 1475677598667535634, guid: 0892b944d90654243b825a22b54ccad7, type: 3}
-  _swipeDirection: 4
-  _maxHealth: 300
+  _swipeDirectionSequence:
+  _randomizeSequence: 1
+  _maxHealth: 20
   _moveSpeed: 0.7
   _soulDropCount: 8
   _experiencePerOrb: 5

--- a/project1/Assets/Settings/Data/Monsters/Monster_DuskShade.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_DuskShade.asset
@@ -15,8 +15,9 @@ MonoBehaviour:
   _monsterId: monster.dusk_shade
   _displayName: Dusk Shade
   _enemyPrefab: {fileID: 4368540737326870438, guid: 4d75fb8dd84b9fb40bbaace1f8a21592, type: 3}
-  _swipeDirection: 3
-  _maxHealth: 28
+  _swipeDirectionSequence:
+  _randomizeSequence: 1
+  _maxHealth: 4
   _moveSpeed: 1.5
   _soulDropCount: 2
   _experiencePerOrb: 1


### PR DESCRIPTION
## Summary
- 적마다 순서가 정해진 공격 방향 시퀀스를 부여하고, 유저가 순서대로 스와이프해야 피해가 적용되는 시스템 구현
- 적 머리 위에 시퀀스 화살표 HUD 표시 (최대 3개 + `...`, 현재 타겟 하이라이트)
- MonsterData의 단일 SwipeDirection을 SwipeDirection[] 시퀀스로 교체, 랜덤 생성 옵션 추가

## Changes
### 새 파일
- `EnemyAttackSequence.cs` — 방향 시퀀스 인덱스 관리, `OnAdvanced`/`OnSequenceSet` 이벤트, 랜덤 시퀀스 생성

### 수정 파일
- `MonsterData.cs` — `_swipeDirection` → `_swipeDirectionSequence[]` + `_randomizeSequence`
- `EnemyHealth.cs` — `EnemyAttackSequence` lazy 로딩, `SwipeDirection`이 현재 인덱스 방향 반환
- `SwipeAttackEventListener.cs` — 시퀀스 적에게 스와이프당 1 데미지 고정, 피해 후 인덱스 전진
- `GameplayHudBootstrapper.cs` — 단일 화살표 → 시퀀스 HUD (반투명 배경 패널, `RuntimePanelUtils.ScreenToPanel` 좌표 변환 수정)

### 데이터
- 적 프리팹 5개에 `EnemyAttackSequence` 컴포넌트 추가
- MonsterData HP 조정: AshenClaw(3), DuskShade(4), BrambleIdol(5), Dureoksini(20)

## Test plan
- [x] 체력 3인 적: 머리 위에 화살표 3개가 순서대로 표시
- [x] 체력 5 초과인 적: 화살표 3개 + `...` 표시, 공격 성공 시 다음 화살표 드러남
- [x] 현재 타격 방향 화살표만 노란색 하이라이트
- [x] 잘못된 방향 스와이프 시 피해 미적용
- [x] 올바른 방향 스와이프마다 HP 1 감소 및 시퀀스 전진
- [x] 보스 적 시퀀스 정상 표시 (반투명 배경으로 가독성 확보)

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)