### PR TITLE
feat: Day 1 — 웨이브 VS 타임라인 전환 + 기본 접촉 적 + 챕터 1 타임라인 (#62 #70)

### DIFF
--- a/project1/Assets/Scenes/SampleScene.unity
+++ b/project1/Assets/Scenes/SampleScene.unity
@@ -1122,9 +1122,12 @@ MonoBehaviour:
   _spawnPoints: []
   _collectSpawnPointsFromChildren: 1
   _autoStartOnEnable: 1
-  _interWaveDelaySeconds: 1.5
   _loopWaves: 0
-  _despawnActiveEnemiesOnTimeExpired: 1
+  _miniBossMinuteMarks:
+  - 3
+  - 6
+  - 9
+  _bossMinuteMark: 10
   _defaultSpawnIntervalSeconds: 1
   _defaultMaxAliveEnemies: 5
   _showDebugLogs: 0

--- a/project1/Assets/Scenes/SampleScene.unity
+++ b/project1/Assets/Scenes/SampleScene.unity
@@ -1118,7 +1118,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7b7e2c7a47d44145ab1382f7783377fa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.WaveCombatDirector
-  _waveDatabase: {fileID: 11400000, guid: 9cca3c485446fe546a4b118f88950e0a, type: 2}
+  _waveDatabase: {fileID: 11400000, guid: 761c6a7730f34dde86070de259bcccd6, type: 2}
   _spawnPoints: []
   _collectSpawnPointsFromChildren: 1
   _autoStartOnEnable: 1

--- a/project1/Assets/Scripts/Combat/WaveCombatDirector.cs
+++ b/project1/Assets/Scripts/Combat/WaveCombatDirector.cs
@@ -32,6 +32,19 @@ namespace Mukseon.Gameplay.Combat
         [SerializeField]
         private bool _collectSpawnPointsFromChildren;
 
+        [Header("Offscreen Spawn")]
+        [Tooltip("적을 화면 바깥 랜덤 위치에서 소환할지 여부. 끄면 _spawnPoints / 자식 스폰포인트를 사용한다.")]
+        [SerializeField]
+        private bool _spawnOffscreen = true;
+
+        [Tooltip("스폰 기준 카메라. 비우면 Camera.main을 사용한다.")]
+        [SerializeField]
+        private Camera _spawnCamera;
+
+        [Tooltip("화면 가장자리에서 이만큼(월드 단위) 더 바깥에서 소환한다.")]
+        [SerializeField, Min(0f)]
+        private float _offscreenSpawnMargin = 1f;
+
         [Header("Flow")]
         [SerializeField]
         private bool _autoStartOnEnable = true;
@@ -147,7 +160,9 @@ namespace Mukseon.Gameplay.Combat
                 OnWaveEnded?.Invoke(CurrentWaveNumber, WaveEndReason.Cancelled);
             }
 
-            CleanupAliveEnemies(false);
+            // 시스템 전체 정지/비활성화 시점에는 추적을 잃은 적이 씬에 남지 않도록 실제로 디스폰한다.
+            // (보스 진입 시 의도적으로 적을 남기는 EnterBossPhase와 달리 여기서는 깨끗이 정리)
+            CleanupAliveEnemies(true);
             ResetWaveRuntime();
 
             _isWaveActive = false;
@@ -182,8 +197,19 @@ namespace Mukseon.Gameplay.Combat
             WaveDefinition currentWave = GetCurrentWave();
             if (currentWave != null && _waveElapsedSeconds >= currentWave.DurationSeconds)
             {
-                AdvanceWave();
+                // 마지막 웨이브에서 루프하지 않으면 보스 마크 전까지 현재 웨이브를 유지한다.
+                // (AdvanceWave를 매 프레임 무의미하게 호출하지 않도록 여기서 막는다.)
+                bool isLastWave = _currentWaveIndex >= GetWaveCount() - 1;
+                if (!isLastWave || _loopWaves)
+                {
+                    AdvanceWave();
+                }
             }
+        }
+
+        private int GetWaveCount()
+        {
+            return _waveDatabase != null && _waveDatabase.Waves != null ? _waveDatabase.Waves.Count : 0;
         }
 
         private void CheckTimelineMarks()
@@ -230,6 +256,9 @@ namespace Mukseon.Gameplay.Combat
             // 일반 적은 보스 시스템(#37)이 페이드아웃/즉시 제거 방식을 결정하므로
             // 여기서는 살아있는 적을 강제 정리하지 않고 스포닝만 멈춘다.
             OnBossPhaseStarted?.Invoke();
+
+            // OnAllWavesCompleted는 보스 진입과 별개로 'HUD 등의 일반 전투 구간 종료' 정리용으로 함께 발행한다.
+            // 보스 처리 자체는 OnBossPhaseStarted 구독자(#37)가 담당한다.
             OnAllWavesCompleted?.Invoke();
 
 #if UNITY_EDITOR
@@ -274,14 +303,13 @@ namespace Mukseon.Gameplay.Combat
 
             if (nextWaveIndex >= waveCount)
             {
+                // Tick()에서 마지막 웨이브는 루프 시에만 AdvanceWave를 호출하므로 여기 도달은 _loopWaves가 true인 경우뿐.
                 if (_loopWaves)
                 {
                     nextWaveIndex = 0;
                 }
                 else
                 {
-                    // 마지막 웨이브는 보스 마크 전까지 그대로 유지(스폰 지속). 전환만 멈춘다.
-                    _waveElapsedSeconds = 0f;
                     return;
                 }
             }
@@ -357,23 +385,32 @@ namespace Mukseon.Gameplay.Combat
         }
 
         /// <summary>
-        /// 1회 소환 라운드.
-        /// 1) 최소 유지 수에 미달한 종류부터 채운다.
+        /// 1회 소환 라운드. 한 라운드에서 각 종류는 최대 1마리씩만 소환된다.
+        /// 1) 최소 유지 수에 미달한 종류를 1마리씩 채운다.
         /// 2) 모든 종류가 최소 수를 충족하면 각 종류를 1마리씩 추가 소환한다(난이도 상승).
         /// 상한(maxAliveEnemies)에 도달하면 중단한다.
+        /// 순회 시작 인덱스를 매 라운드 랜덤화하여 리스트 앞쪽 종류가 상한을 독점하는 편향을 제거한다.
+        /// 따라서 최악의 경우 한 라운드에 _spawnRuntime.Count 마리까지 소환될 수 있다.
         /// </summary>
         private void RunSpawnRound(int maxAliveEnemies)
         {
-            bool anyBelowMinimum = false;
+            int count = _spawnRuntime.Count;
+            if (count <= 0)
+            {
+                return;
+            }
 
-            for (int i = 0; i < _spawnRuntime.Count; i++)
+            bool anyBelowMinimum = false;
+            int startOffset = UnityEngine.Random.Range(0, count);
+
+            for (int i = 0; i < count; i++)
             {
                 if (_aliveEnemies.Count >= maxAliveEnemies)
                 {
                     return;
                 }
 
-                SpawnRuntimeEntry runtimeEntry = _spawnRuntime[i];
+                SpawnRuntimeEntry runtimeEntry = _spawnRuntime[(startOffset + i) % count];
                 int aliveOfSpecies = GetAliveCount(runtimeEntry.SpeciesKey);
                 if (aliveOfSpecies < runtimeEntry.Entry.MinAliveCount)
                 {
@@ -387,28 +424,29 @@ namespace Mukseon.Gameplay.Combat
                 return;
             }
 
-            // 모든 종류가 최소 수를 충족 → 각 종류 1마리씩 추가 소환.
-            for (int i = 0; i < _spawnRuntime.Count; i++)
+            // 모든 종류가 최소 수를 충족 → 각 종류 1마리씩 추가 소환. 시작 인덱스를 다시 랜덤화한다.
+            startOffset = UnityEngine.Random.Range(0, count);
+            for (int i = 0; i < count; i++)
             {
                 if (_aliveEnemies.Count >= maxAliveEnemies)
                 {
                     return;
                 }
 
-                SpawnEnemy(_spawnRuntime[i]);
+                SpawnEnemy(_spawnRuntime[(startOffset + i) % count]);
             }
         }
 
         private void SpawnEnemy(SpawnRuntimeEntry runtimeEntry)
         {
-            Transform spawnPoint = ResolveSpawnPoint();
+            Vector3 spawnPosition = ResolveSpawnPosition();
             GameObject prefabGO = runtimeEntry.Entry.EnemyPrefab.gameObject;
             GameObject spawnedObject;
             EnemyHealth spawnedEnemy;
 
             if (PoolManager.Instance != null)
             {
-                spawnedObject = PoolManager.Instance.GetInactive(prefabGO, spawnPoint.position, spawnPoint.rotation);
+                spawnedObject = PoolManager.Instance.GetInactive(prefabGO, spawnPosition, Quaternion.identity);
                 spawnedEnemy = spawnedObject.GetComponent<EnemyHealth>();
                 spawnedEnemy.ApplyMonsterData(runtimeEntry.Entry.MonsterData);
                 spawnedEnemy.SetMoveSpeed(runtimeEntry.Entry.MoveSpeed);
@@ -417,7 +455,7 @@ namespace Mukseon.Gameplay.Combat
             }
             else
             {
-                spawnedObject = Instantiate(prefabGO, spawnPoint.position, spawnPoint.rotation);
+                spawnedObject = Instantiate(prefabGO, spawnPosition, Quaternion.identity);
                 spawnedEnemy = spawnedObject.GetComponent<EnemyHealth>();
                 spawnedEnemy.ApplyMonsterData(runtimeEntry.Entry.MonsterData);
                 spawnedEnemy.SetMoveSpeed(runtimeEntry.Entry.MoveSpeed);
@@ -435,6 +473,77 @@ namespace Mukseon.Gameplay.Combat
             IncrementAliveCount(runtimeEntry.SpeciesKey);
 
             NotifyRemainingEnemyCountChanged();
+        }
+
+        /// <summary>
+        /// 적 1마리의 스폰 월드 좌표를 결정한다.
+        /// 기본은 화면 바깥 랜덤 위치이며, 비활성화 시 스폰포인트(없으면 자기 위치)로 폴백한다.
+        /// </summary>
+        private Vector3 ResolveSpawnPosition()
+        {
+            if (_spawnOffscreen && TryGetOffscreenSpawnPosition(out Vector3 offscreenPosition))
+            {
+                return offscreenPosition;
+            }
+
+            Transform spawnPoint = ResolveSpawnPoint();
+            return spawnPoint != null ? spawnPoint.position : transform.position;
+        }
+
+        /// <summary>
+        /// 카메라 시야 사각형의 한 변을 랜덤 선택하고, 그 변 바깥(마진만큼)으로 좌표를 잡는다.
+        /// 직교(2D) 카메라에서만 동작하며, 실패 시 false를 반환해 스폰포인트로 폴백하게 한다.
+        /// </summary>
+        private bool TryGetOffscreenSpawnPosition(out Vector3 position)
+        {
+            position = default;
+
+            Camera camera = ResolveSpawnCamera();
+            if (camera == null || !camera.orthographic)
+            {
+                return false;
+            }
+
+            float verticalExtent = camera.orthographicSize;
+            float horizontalExtent = verticalExtent * camera.aspect;
+            float margin = Mathf.Max(0f, _offscreenSpawnMargin);
+            Vector3 center = camera.transform.position;
+
+            float offsetX;
+            float offsetY;
+            switch (UnityEngine.Random.Range(0, 4))
+            {
+                case 0: // 위쪽 바깥
+                    offsetX = UnityEngine.Random.Range(-horizontalExtent, horizontalExtent);
+                    offsetY = verticalExtent + margin;
+                    break;
+                case 1: // 아래쪽 바깥
+                    offsetX = UnityEngine.Random.Range(-horizontalExtent, horizontalExtent);
+                    offsetY = -verticalExtent - margin;
+                    break;
+                case 2: // 왼쪽 바깥
+                    offsetX = -horizontalExtent - margin;
+                    offsetY = UnityEngine.Random.Range(-verticalExtent, verticalExtent);
+                    break;
+                default: // 오른쪽 바깥
+                    offsetX = horizontalExtent + margin;
+                    offsetY = UnityEngine.Random.Range(-verticalExtent, verticalExtent);
+                    break;
+            }
+
+            // 2D 평면(z=0)에 배치. 카메라 z 오프셋은 무시한다.
+            position = new Vector3(center.x + offsetX, center.y + offsetY, 0f);
+            return true;
+        }
+
+        private Camera ResolveSpawnCamera()
+        {
+            if (_spawnCamera == null)
+            {
+                _spawnCamera = Camera.main;
+            }
+
+            return _spawnCamera;
         }
 
         private Transform ResolveSpawnPoint()

--- a/project1/Assets/Scripts/Combat/WaveCombatDirector.cs
+++ b/project1/Assets/Scripts/Combat/WaveCombatDirector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Mukseon.Core.Pool;
 using Mukseon.Gameplay.Progression;
@@ -6,13 +6,20 @@ using UnityEngine;
 
 namespace Mukseon.Gameplay.Combat
 {
+    /// <summary>
+    /// Vampire Survivors 스타일의 타임라인 기반 연속 스포너.
+    /// 웨이브는 시간 경과로만 전환되며(클리어 조건 없음), 각 웨이브는
+    /// 적 종류별 '최소 유지 수'를 채우고, 모두 충족되면 매 간격마다 적을 1마리씩 추가 소환한다.
+    /// 지정한 분 마크에 미니 보스 이벤트를, 보스 마크에 보스 진입 이벤트를 발행한다.
+    /// 미니 보스/보스의 실제 스폰은 별도 시스템(#71/#37)이 구독하여 처리한다.
+    /// </summary>
     [DisallowMultipleComponent]
     public class WaveCombatDirector : MonoBehaviour
     {
         private sealed class SpawnRuntimeEntry
         {
             public WaveEnemySpawnEntry Entry;
-            public int Remaining;
+            public object SpeciesKey;
         }
 
         [Header("References")]
@@ -29,21 +36,25 @@ namespace Mukseon.Gameplay.Combat
         [SerializeField]
         private bool _autoStartOnEnable = true;
 
-        [SerializeField, Min(0f)]
-        private float _interWaveDelaySeconds = 1.5f;
-
+        [Tooltip("마지막 웨이브에 도달한 뒤 보스 마크 전까지 타임라인을 처음부터 반복할지 여부.")]
         [SerializeField]
         private bool _loopWaves;
 
+        [Header("Timeline Marks (minutes)")]
+        [Tooltip("미니 보스 이벤트를 발행할 분 단위 시간 마크. 예: 3, 6, 9")]
         [SerializeField]
-        private bool _despawnActiveEnemiesOnTimeExpired = true;
+        private List<float> _miniBossMinuteMarks = new List<float> { 3f, 6f, 9f };
+
+        [Tooltip("보스 진입 이벤트를 발행할 분 단위 시간 마크. 이 시점 이후 일반 스포닝 중단. 0 이하이면 보스 마크 없음.")]
+        [SerializeField, Min(0f)]
+        private float _bossMinuteMark = 10f;
 
         [Header("Fallback")]
         [SerializeField, Min(0.01f)]
         private float _defaultSpawnIntervalSeconds = 1f;
 
         [SerializeField, Min(1)]
-        private int _defaultMaxAliveEnemies = 5;
+        private int _defaultMaxAliveEnemies = 20;
 
         [Header("Debug")]
         [SerializeField]
@@ -51,28 +62,37 @@ namespace Mukseon.Gameplay.Combat
 
         private readonly List<SpawnRuntimeEntry> _spawnRuntime = new List<SpawnRuntimeEntry>();
         private readonly HashSet<EnemyHealth> _aliveEnemies = new HashSet<EnemyHealth>();
+        private readonly Dictionary<EnemyHealth, object> _enemySpeciesKey = new Dictionary<EnemyHealth, object>(64);
+        private readonly Dictionary<object, int> _aliveBySpecies = new Dictionary<object, int>(16);
         private readonly List<EnemyHealth> _cleanupBuffer = new List<EnemyHealth>(64);
+        private readonly List<bool> _miniBossMarkFired = new List<bool>();
 
         private int _currentWaveIndex = -1;
-        private int _remainingToSpawn;
-        private int _spawnRuntimeCursor;
         private int _spawnPointCursor;
+        private float _timelineElapsedSeconds;
         private float _waveElapsedSeconds;
         private float _spawnElapsedSeconds;
-        private float _nextWaveDelayRemaining;
         private bool _isRunning;
         private bool _isWaveActive;
-        private bool _isWaitingNextWave;
+        private bool _bossPhaseStarted;
 
         public int CurrentWaveNumber => _currentWaveIndex + 1;
-        public int RemainingEnemyCount => Mathf.Max(0, _remainingToSpawn + _aliveEnemies.Count);
+        public int RemainingEnemyCount => _aliveEnemies.Count;
         public bool IsWaveActive => _isWaveActive;
         public bool IsRunning => _isRunning;
+        public float TimelineElapsedSeconds => _timelineElapsedSeconds;
+        public bool IsBossPhase => _bossPhaseStarted;
 
         public event Action<int, WaveDefinition> OnWaveStarted;
         public event Action<int, WaveEndReason> OnWaveEnded;
         public event Action<int, int> OnRemainingEnemyCountChanged;
         public event Action OnAllWavesCompleted;
+
+        /// <summary>지정 분 마크 도달 시 1회 발행. 인자는 도달한 분(mark) 값. 미니 보스 시스템(#71)이 구독.</summary>
+        public event Action<float> OnMiniBossMarkReached;
+
+        /// <summary>보스 마크 도달 시 1회 발행. 일반 스포닝은 이 시점에 중단된다. 보스 시스템(#37)이 구독.</summary>
+        public event Action OnBossPhaseStarted;
 
         private void OnEnable()
         {
@@ -105,32 +125,34 @@ namespace Mukseon.Gameplay.Combat
             }
 
             StopWaves(false);
-            _isRunning = true;
-            _currentWaveIndex = -1;
-            _isWaitingNextWave = false;
-            _nextWaveDelayRemaining = 0f;
 
-            BeginNextWave();
+            _isRunning = true;
+            _bossPhaseStarted = false;
+            _timelineElapsedSeconds = 0f;
+            _currentWaveIndex = -1;
+
+            ResetMiniBossMarks();
+            BeginWave(0);
         }
 
         public void StopWaves(bool publishCancellation = true)
         {
-            if (!_isRunning && !_isWaveActive && !_isWaitingNextWave)
+            if (!_isRunning && !_isWaveActive)
             {
                 return;
             }
 
             if (publishCancellation && _isWaveActive)
             {
-                int waveNumber = CurrentWaveNumber;
-                OnWaveEnded?.Invoke(waveNumber, WaveEndReason.Cancelled);
+                OnWaveEnded?.Invoke(CurrentWaveNumber, WaveEndReason.Cancelled);
             }
 
-            ResetWaveRuntime();
             CleanupAliveEnemies(false);
+            ResetWaveRuntime();
+
             _isWaveActive = false;
-            _isWaitingNextWave = false;
             _isRunning = false;
+            _bossPhaseStarted = false;
             _currentWaveIndex = -1;
         }
 
@@ -142,20 +164,12 @@ namespace Mukseon.Gameplay.Combat
             }
 
             float step = Mathf.Max(0f, deltaTime);
+            _timelineElapsedSeconds += step;
 
-            if (_isWaitingNextWave)
-            {
-                _nextWaveDelayRemaining -= step;
-                if (_nextWaveDelayRemaining <= 0f)
-                {
-                    _isWaitingNextWave = false;
-                    BeginNextWave();
-                }
+            CheckTimelineMarks();
 
-                return;
-            }
-
-            if (!_isWaveActive)
+            // 보스 진입 후에는 일반 스포닝과 웨이브 전환을 모두 중단한다.
+            if (_bossPhaseStarted || !_isWaveActive)
             {
                 return;
             }
@@ -165,48 +179,75 @@ namespace Mukseon.Gameplay.Combat
 
             TrySpawnEnemies();
 
-            if (_remainingToSpawn <= 0 && _aliveEnemies.Count <= 0)
-            {
-                FinishCurrentWave(WaveEndReason.EnemiesCleared);
-                return;
-            }
-
             WaveDefinition currentWave = GetCurrentWave();
-            if (currentWave != null && currentWave.DurationSeconds > 0f && _waveElapsedSeconds >= currentWave.DurationSeconds)
+            if (currentWave != null && _waveElapsedSeconds >= currentWave.DurationSeconds)
             {
-                FinishCurrentWave(WaveEndReason.TimeExpired);
+                AdvanceWave();
             }
         }
 
-        private void BeginNextWave()
+        private void CheckTimelineMarks()
         {
-            if (_waveDatabase == null || _waveDatabase.Waves == null || _waveDatabase.Waves.Count == 0)
+            if (_miniBossMinuteMarks != null)
             {
-                _isRunning = false;
-                return;
+                for (int i = 0; i < _miniBossMinuteMarks.Count; i++)
+                {
+                    if (i >= _miniBossMarkFired.Count || _miniBossMarkFired[i])
+                    {
+                        continue;
+                    }
+
+                    float markMinutes = _miniBossMinuteMarks[i];
+                    if (markMinutes > 0f && _timelineElapsedSeconds >= markMinutes * 60f)
+                    {
+                        _miniBossMarkFired[i] = true;
+                        OnMiniBossMarkReached?.Invoke(markMinutes);
+
+#if UNITY_EDITOR
+                        if (_showDebugLogs)
+                        {
+                            Debug.Log($"[WaveCombatDirector] Mini-boss mark reached: {markMinutes:0.#} min");
+                        }
+#endif
+                    }
+                }
             }
 
-            int nextWaveIndex = _currentWaveIndex + 1;
-            if (nextWaveIndex >= _waveDatabase.Waves.Count)
+            if (!_bossPhaseStarted && _bossMinuteMark > 0f && _timelineElapsedSeconds >= _bossMinuteMark * 60f)
             {
-                if (_loopWaves)
-                {
-                    nextWaveIndex = 0;
-                }
-                else
-                {
-                    _isRunning = false;
-                    _isWaveActive = false;
-                    OnAllWavesCompleted?.Invoke();
-                    return;
-                }
+                EnterBossPhase();
             }
+        }
 
+        private void EnterBossPhase()
+        {
+            _bossPhaseStarted = true;
+
+            int endedWaveNumber = CurrentWaveNumber;
+            _isWaveActive = false;
+            OnWaveEnded?.Invoke(endedWaveNumber, WaveEndReason.Cancelled);
+
+            // 일반 적은 보스 시스템(#37)이 페이드아웃/즉시 제거 방식을 결정하므로
+            // 여기서는 살아있는 적을 강제 정리하지 않고 스포닝만 멈춘다.
+            OnBossPhaseStarted?.Invoke();
+            OnAllWavesCompleted?.Invoke();
+
+#if UNITY_EDITOR
+            if (_showDebugLogs)
+            {
+                Debug.Log($"[WaveCombatDirector] Boss phase started at {_bossMinuteMark:0.#} min.");
+            }
+#endif
+        }
+
+        private void BeginWave(int waveIndex)
+        {
             ResetWaveRuntime();
-            CleanupAliveEnemies(false);
 
-            _currentWaveIndex = nextWaveIndex;
+            _currentWaveIndex = waveIndex;
             _isWaveActive = true;
+            _waveElapsedSeconds = 0f;
+            _spawnElapsedSeconds = 0f;
 
             WaveDefinition currentWave = GetCurrentWave();
             BuildSpawnRuntime(currentWave);
@@ -216,14 +257,39 @@ namespace Mukseon.Gameplay.Combat
 #if UNITY_EDITOR
             if (_showDebugLogs)
             {
-                Debug.Log($"[WaveCombatDirector] Wave {CurrentWaveNumber} started. SpawnCount={_remainingToSpawn}");
+                Debug.Log($"[WaveCombatDirector] Wave {CurrentWaveNumber} started.");
             }
 #endif
+        }
 
-            if (_remainingToSpawn <= 0 && _aliveEnemies.Count <= 0)
+        private void AdvanceWave()
+        {
+            if (_waveDatabase == null || _waveDatabase.Waves == null || _waveDatabase.Waves.Count == 0)
             {
-                FinishCurrentWave(WaveEndReason.EnemiesCleared);
+                return;
             }
+
+            int waveCount = _waveDatabase.Waves.Count;
+            int nextWaveIndex = _currentWaveIndex + 1;
+
+            if (nextWaveIndex >= waveCount)
+            {
+                if (_loopWaves)
+                {
+                    nextWaveIndex = 0;
+                }
+                else
+                {
+                    // 마지막 웨이브는 보스 마크 전까지 그대로 유지(스폰 지속). 전환만 멈춘다.
+                    _waveElapsedSeconds = 0f;
+                    return;
+                }
+            }
+
+            OnWaveEnded?.Invoke(CurrentWaveNumber, WaveEndReason.TimeExpired);
+
+            // VS 스타일: 이전 웨이브의 적은 정리하지 않고 그대로 남긴 채 다음 웨이브로 전환한다.
+            BeginWave(nextWaveIndex);
         }
 
         private WaveDefinition GetCurrentWave()
@@ -244,9 +310,6 @@ namespace Mukseon.Gameplay.Combat
         private void BuildSpawnRuntime(WaveDefinition wave)
         {
             _spawnRuntime.Clear();
-            _spawnRuntimeCursor = 0;
-            _spawnPointCursor = 0;
-            _remainingToSpawn = 0;
 
             if (wave == null || wave.Enemies == null)
             {
@@ -256,7 +319,7 @@ namespace Mukseon.Gameplay.Combat
             for (int i = 0; i < wave.Enemies.Count; i++)
             {
                 WaveEnemySpawnEntry entry = wave.Enemies[i];
-                if (entry == null || entry.Count <= 0)
+                if (entry == null)
                 {
                     continue;
                 }
@@ -270,16 +333,14 @@ namespace Mukseon.Gameplay.Combat
                 _spawnRuntime.Add(new SpawnRuntimeEntry
                 {
                     Entry = entry,
-                    Remaining = entry.Count
+                    SpeciesKey = entry.SpeciesKey
                 });
-
-                _remainingToSpawn += entry.Count;
             }
         }
 
         private void TrySpawnEnemies()
         {
-            if (_spawnRuntime.Count <= 0 || _remainingToSpawn <= 0)
+            if (_spawnRuntime.Count <= 0)
             {
                 return;
             }
@@ -287,73 +348,93 @@ namespace Mukseon.Gameplay.Combat
             float spawnInterval = ResolveSpawnInterval();
             int maxAliveEnemies = ResolveMaxAliveEnemies();
 
-            while (_spawnElapsedSeconds >= spawnInterval && _remainingToSpawn > 0 && _aliveEnemies.Count < maxAliveEnemies)
+            // 간격이 경과한 횟수만큼 소환 라운드를 진행한다.
+            while (_spawnElapsedSeconds >= spawnInterval)
             {
                 _spawnElapsedSeconds -= spawnInterval;
-
-                if (!TrySpawnOneEnemy())
-                {
-                    break;
-                }
+                RunSpawnRound(maxAliveEnemies);
             }
         }
 
-        private bool TrySpawnOneEnemy()
+        /// <summary>
+        /// 1회 소환 라운드.
+        /// 1) 최소 유지 수에 미달한 종류부터 채운다.
+        /// 2) 모든 종류가 최소 수를 충족하면 각 종류를 1마리씩 추가 소환한다(난이도 상승).
+        /// 상한(maxAliveEnemies)에 도달하면 중단한다.
+        /// </summary>
+        private void RunSpawnRound(int maxAliveEnemies)
         {
-            if (_spawnRuntime.Count <= 0)
-            {
-                return false;
-            }
+            bool anyBelowMinimum = false;
 
             for (int i = 0; i < _spawnRuntime.Count; i++)
             {
-                int index = (_spawnRuntimeCursor + i) % _spawnRuntime.Count;
-                SpawnRuntimeEntry runtimeEntry = _spawnRuntime[index];
-                if (runtimeEntry.Remaining <= 0)
+                if (_aliveEnemies.Count >= maxAliveEnemies)
                 {
-                    continue;
+                    return;
                 }
 
-                Transform spawnPoint = ResolveSpawnPoint();
-                GameObject prefabGO = runtimeEntry.Entry.EnemyPrefab.gameObject;
-                GameObject spawnedObject;
-                EnemyHealth spawnedEnemy;
-
-                if (PoolManager.Instance != null)
+                SpawnRuntimeEntry runtimeEntry = _spawnRuntime[i];
+                int aliveOfSpecies = GetAliveCount(runtimeEntry.SpeciesKey);
+                if (aliveOfSpecies < runtimeEntry.Entry.MinAliveCount)
                 {
-                    spawnedObject = PoolManager.Instance.GetInactive(prefabGO, spawnPoint.position, spawnPoint.rotation);
-                    spawnedEnemy = spawnedObject.GetComponent<EnemyHealth>();
-                    spawnedEnemy.ApplyMonsterData(runtimeEntry.Entry.MonsterData);
-                    spawnedEnemy.SetMoveSpeed(runtimeEntry.Entry.MoveSpeed);
-                    spawnedEnemy.PrepareForReuse();
-                    spawnedObject.SetActive(true);
+                    anyBelowMinimum = true;
+                    SpawnEnemy(runtimeEntry);
                 }
-                else
-                {
-                    spawnedObject = Instantiate(prefabGO, spawnPoint.position, spawnPoint.rotation);
-                    spawnedEnemy = spawnedObject.GetComponent<EnemyHealth>();
-                    spawnedEnemy.ApplyMonsterData(runtimeEntry.Entry.MonsterData);
-                    spawnedEnemy.SetMoveSpeed(runtimeEntry.Entry.MoveSpeed);
-                }
-
-                EnemySoulDropper soulDropper = spawnedEnemy.GetComponent<EnemySoulDropper>();
-                if (soulDropper != null)
-                {
-                    soulDropper.ApplyMonsterData(runtimeEntry.Entry.MonsterData);
-                }
-
-                spawnedEnemy.OnDeath += HandleSpawnedEnemyDeath;
-                _aliveEnemies.Add(spawnedEnemy);
-
-                runtimeEntry.Remaining--;
-                _remainingToSpawn--;
-                _spawnRuntimeCursor = (index + 1) % _spawnRuntime.Count;
-
-                NotifyRemainingEnemyCountChanged();
-                return true;
             }
 
-            return false;
+            if (anyBelowMinimum)
+            {
+                return;
+            }
+
+            // 모든 종류가 최소 수를 충족 → 각 종류 1마리씩 추가 소환.
+            for (int i = 0; i < _spawnRuntime.Count; i++)
+            {
+                if (_aliveEnemies.Count >= maxAliveEnemies)
+                {
+                    return;
+                }
+
+                SpawnEnemy(_spawnRuntime[i]);
+            }
+        }
+
+        private void SpawnEnemy(SpawnRuntimeEntry runtimeEntry)
+        {
+            Transform spawnPoint = ResolveSpawnPoint();
+            GameObject prefabGO = runtimeEntry.Entry.EnemyPrefab.gameObject;
+            GameObject spawnedObject;
+            EnemyHealth spawnedEnemy;
+
+            if (PoolManager.Instance != null)
+            {
+                spawnedObject = PoolManager.Instance.GetInactive(prefabGO, spawnPoint.position, spawnPoint.rotation);
+                spawnedEnemy = spawnedObject.GetComponent<EnemyHealth>();
+                spawnedEnemy.ApplyMonsterData(runtimeEntry.Entry.MonsterData);
+                spawnedEnemy.SetMoveSpeed(runtimeEntry.Entry.MoveSpeed);
+                spawnedEnemy.PrepareForReuse();
+                spawnedObject.SetActive(true);
+            }
+            else
+            {
+                spawnedObject = Instantiate(prefabGO, spawnPoint.position, spawnPoint.rotation);
+                spawnedEnemy = spawnedObject.GetComponent<EnemyHealth>();
+                spawnedEnemy.ApplyMonsterData(runtimeEntry.Entry.MonsterData);
+                spawnedEnemy.SetMoveSpeed(runtimeEntry.Entry.MoveSpeed);
+            }
+
+            EnemySoulDropper soulDropper = spawnedEnemy.GetComponent<EnemySoulDropper>();
+            if (soulDropper != null)
+            {
+                soulDropper.ApplyMonsterData(runtimeEntry.Entry.MonsterData);
+            }
+
+            spawnedEnemy.OnDeath += HandleSpawnedEnemyDeath;
+            _aliveEnemies.Add(spawnedEnemy);
+            _enemySpeciesKey[spawnedEnemy] = runtimeEntry.SpeciesKey;
+            IncrementAliveCount(runtimeEntry.SpeciesKey);
+
+            NotifyRemainingEnemyCountChanged();
         }
 
         private Transform ResolveSpawnPoint()
@@ -408,7 +489,7 @@ namespace Mukseon.Gameplay.Combat
                 return Mathf.Max(0.01f, _defaultSpawnIntervalSeconds);
             }
 
-            return Mathf.Max(0.01f, currentWave.SpawnIntervalSeconds);
+            return currentWave.SpawnIntervalSeconds;
         }
 
         private int ResolveMaxAliveEnemies()
@@ -419,7 +500,7 @@ namespace Mukseon.Gameplay.Combat
                 return Mathf.Max(1, _defaultMaxAliveEnemies);
             }
 
-            return Mathf.Max(1, currentWave.MaxAliveEnemies);
+            return currentWave.MaxAliveEnemies;
         }
 
         private void HandleSpawnedEnemyDeath(EnemyHealth enemyHealth)
@@ -431,6 +512,12 @@ namespace Mukseon.Gameplay.Combat
 
             enemyHealth.OnDeath -= HandleSpawnedEnemyDeath;
             _aliveEnemies.Remove(enemyHealth);
+
+            if (_enemySpeciesKey.TryGetValue(enemyHealth, out object speciesKey))
+            {
+                _enemySpeciesKey.Remove(enemyHealth);
+                DecrementAliveCount(speciesKey);
+            }
 
             if (PoolManager.Instance != null)
             {
@@ -444,34 +531,45 @@ namespace Mukseon.Gameplay.Combat
             NotifyRemainingEnemyCountChanged();
         }
 
-        private void FinishCurrentWave(WaveEndReason endReason)
+        private int GetAliveCount(object speciesKey)
         {
-            int waveNumber = CurrentWaveNumber;
-
-            _isWaveActive = false;
-
-            if (endReason == WaveEndReason.TimeExpired && _despawnActiveEnemiesOnTimeExpired)
+            if (speciesKey == null)
             {
-                CleanupAliveEnemies(true);
-                NotifyRemainingEnemyCountChanged();
+                return 0;
             }
 
-            OnWaveEnded?.Invoke(waveNumber, endReason);
+            return _aliveBySpecies.TryGetValue(speciesKey, out int count) ? count : 0;
+        }
 
-#if UNITY_EDITOR
-            if (_showDebugLogs)
+        private void IncrementAliveCount(object speciesKey)
+        {
+            if (speciesKey == null)
             {
-                Debug.Log($"[WaveCombatDirector] Wave {waveNumber} ended. Reason={endReason}");
+                return;
             }
-#endif
 
-            _isWaitingNextWave = true;
-            _nextWaveDelayRemaining = Mathf.Max(0f, _interWaveDelaySeconds);
+            _aliveBySpecies.TryGetValue(speciesKey, out int count);
+            _aliveBySpecies[speciesKey] = count + 1;
+        }
 
-            if (_nextWaveDelayRemaining <= 0f)
+        private void DecrementAliveCount(object speciesKey)
+        {
+            if (speciesKey == null)
             {
-                _isWaitingNextWave = false;
-                BeginNextWave();
+                return;
+            }
+
+            if (_aliveBySpecies.TryGetValue(speciesKey, out int count))
+            {
+                count--;
+                if (count <= 0)
+                {
+                    _aliveBySpecies.Remove(speciesKey);
+                }
+                else
+                {
+                    _aliveBySpecies[speciesKey] = count;
+                }
             }
         }
 
@@ -507,16 +605,26 @@ namespace Mukseon.Gameplay.Combat
             }
 
             _aliveEnemies.Clear();
+            _enemySpeciesKey.Clear();
+            _aliveBySpecies.Clear();
         }
 
         private void ResetWaveRuntime()
         {
             _waveElapsedSeconds = 0f;
             _spawnElapsedSeconds = 0f;
-            _remainingToSpawn = 0;
-            _spawnRuntimeCursor = 0;
             _spawnRuntime.Clear();
             NotifyRemainingEnemyCountChanged();
+        }
+
+        private void ResetMiniBossMarks()
+        {
+            _miniBossMarkFired.Clear();
+            int count = _miniBossMinuteMarks != null ? _miniBossMinuteMarks.Count : 0;
+            for (int i = 0; i < count; i++)
+            {
+                _miniBossMarkFired.Add(false);
+            }
         }
 
         private void NotifyRemainingEnemyCountChanged()

--- a/project1/Assets/Scripts/Combat/WaveDatabase.cs
+++ b/project1/Assets/Scripts/Combat/WaveDatabase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -16,8 +16,9 @@ namespace Mukseon.Gameplay.Combat
         [SerializeField]
         private EnemyHealth _enemyPrefab;
 
-        [SerializeField, Min(1)]
-        private int _count = 1;
+        [Tooltip("화면 내 항상 유지되어야 하는 이 적의 최소 마릿수. 부족하면 소환 간격마다 채워진다.")]
+        [SerializeField, Min(0)]
+        private int _minAliveCount = 2;
 
         [SerializeField, Min(0f)]
         private float _moveSpeed = 1f;
@@ -25,8 +26,24 @@ namespace Mukseon.Gameplay.Combat
         public string EnemyType => string.IsNullOrWhiteSpace(_enemyType) ? "Default" : _enemyType;
         public MonsterData MonsterData => _monsterData;
         public EnemyHealth EnemyPrefab => _monsterData != null && _monsterData.EnemyPrefab != null ? _monsterData.EnemyPrefab : _enemyPrefab;
-        public int Count => Mathf.Max(0, _count);
+        public int MinAliveCount => Mathf.Max(0, _minAliveCount);
         public float MoveSpeed => _monsterData != null ? _monsterData.MoveSpeed : Mathf.Max(0f, _moveSpeed);
+
+        /// <summary>
+        /// 동일 종류 판별 키. 같은 MonsterData(없으면 프리팹)를 공유하면 같은 종류로 본다.
+        /// </summary>
+        public object SpeciesKey
+        {
+            get
+            {
+                if (_monsterData != null)
+                {
+                    return _monsterData;
+                }
+
+                return _enemyPrefab != null ? (object)_enemyPrefab : EnemyType;
+            }
+        }
 
         public bool IsValid(out string reason)
         {
@@ -52,25 +69,33 @@ namespace Mukseon.Gameplay.Combat
         [SerializeField]
         private string _waveName = "Wave";
 
+        [Tooltip("이 웨이브가 유지되는 시간(초). VS 타임라인 기준 보통 60초(1분). 0 이하이면 기본 60초.")]
         [SerializeField, Min(0f)]
-        private float _durationSeconds;
+        private float _durationSeconds = 60f;
 
+        [Tooltip("최소 유지 수를 채우거나 추가 소환할 때의 간격(초).")]
         [SerializeField, Min(0.01f)]
         private float _spawnIntervalSeconds = 1f;
 
+        [Tooltip("이 웨이브에서 화면에 동시에 존재할 수 있는 전체 적의 상한.")]
         [SerializeField, Min(1)]
-        private int _maxAliveEnemies = 5;
+        private int _maxAliveEnemies = 20;
 
         [SerializeField]
         private List<WaveEnemySpawnEntry> _enemies = new List<WaveEnemySpawnEntry>();
 
+        private const float DefaultDurationSeconds = 60f;
+
         public string WaveName => string.IsNullOrWhiteSpace(_waveName) ? "Wave" : _waveName;
-        public float DurationSeconds => Mathf.Max(0f, _durationSeconds);
+        public float DurationSeconds => _durationSeconds <= 0f ? DefaultDurationSeconds : _durationSeconds;
         public float SpawnIntervalSeconds => Mathf.Max(0.01f, _spawnIntervalSeconds);
         public int MaxAliveEnemies => Mathf.Max(1, _maxAliveEnemies);
         public IReadOnlyList<WaveEnemySpawnEntry> Enemies => _enemies;
 
-        public int GetTotalSpawnCount()
+        /// <summary>
+        /// 이 웨이브가 화면에 유지하려는 적의 총 최소 마릿수(모든 종류 합).
+        /// </summary>
+        public int GetTotalMinAliveCount()
         {
             int total = 0;
             for (int i = 0; i < _enemies.Count; i++)
@@ -81,7 +106,7 @@ namespace Mukseon.Gameplay.Combat
                     continue;
                 }
 
-                total += entry.Count;
+                total += entry.MinAliveCount;
             }
 
             return total;
@@ -99,8 +124,9 @@ namespace Mukseon.Gameplay.Combat
 
     public enum WaveEndReason
     {
-        EnemiesCleared = 0,
+        /// <summary>웨이브 지속 시간이 경과하여 다음 웨이브로 전환됨.</summary>
         TimeExpired = 1,
+        /// <summary>외부 요인(보스 진입, 중지 등)으로 웨이브가 종료됨.</summary>
         Cancelled = 2
     }
 }

--- a/project1/Assets/Scripts/Combat/WaveDatabase.cs
+++ b/project1/Assets/Scripts/Combat/WaveDatabase.cs
@@ -31,6 +31,10 @@ namespace Mukseon.Gameplay.Combat
 
         /// <summary>
         /// 동일 종류 판별 키. 같은 MonsterData(없으면 프리팹)를 공유하면 같은 종류로 본다.
+        /// fallback 우선순위: MonsterData → EnemyPrefab → EnemyType 문자열.
+        /// 주의: MonsterData·프리팹을 모두 비워두면 EnemyType 문자열(기본값 "Default")이 키가 되므로,
+        /// 그런 엔트리를 여러 개 추가하면서 EnemyType을 따로 지정하지 않으면 모두 한 종류로 묶인다.
+        /// (현재 IsValid가 MonsterData/프리팹 중 하나는 반드시 요구하므로 유효한 엔트리에서는 EnemyType 폴백까지 가지 않는다.)
         /// </summary>
         public object SpeciesKey
         {

--- a/project1/Assets/Settings/Chapter1_WaveDatabase.asset
+++ b/project1/Assets/Settings/Chapter1_WaveDatabase.asset
@@ -1,0 +1,225 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 60b18302aa41403c80db612f49a0f295, type: 3}
+  m_Name: Chapter1_WaveDatabase
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.WaveDatabase
+  _waves:
+  - _waveName: 0:00-1:00 Sonakssi/AshenClaw
+    _durationSeconds: 60
+    _spawnIntervalSeconds: 3
+    _maxAliveEnemies: 8
+    _enemies:
+    - _enemyType: Sonakssi
+      _monsterData: {fileID: 11400000, guid: fb24fd5e38994de6a94055af52dc5df6, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 1.3
+    - _enemyType: AshenClaw
+      _monsterData: {fileID: 11400000, guid: 77661a277270a784b8c5751d1df4503e, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 1.2
+  - _waveName: 1:00-2:00 Sonakssi/AshenClaw (denser)
+    _durationSeconds: 60
+    _spawnIntervalSeconds: 2.5
+    _maxAliveEnemies: 10
+    _enemies:
+    - _enemyType: Sonakssi
+      _monsterData: {fileID: 11400000, guid: fb24fd5e38994de6a94055af52dc5df6, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 3
+      _moveSpeed: 1.3
+    - _enemyType: AshenClaw
+      _monsterData: {fileID: 11400000, guid: 77661a277270a784b8c5751d1df4503e, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 3
+      _moveSpeed: 1.2
+  - _waveName: 2:00-3:00 +Mangryang
+    _durationSeconds: 60
+    _spawnIntervalSeconds: 2
+    _maxAliveEnemies: 12
+    _enemies:
+    - _enemyType: Sonakssi
+      _monsterData: {fileID: 11400000, guid: fb24fd5e38994de6a94055af52dc5df6, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 1.3
+    - _enemyType: AshenClaw
+      _monsterData: {fileID: 11400000, guid: 77661a277270a784b8c5751d1df4503e, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 1.2
+    - _enemyType: Mangryang
+      _monsterData: {fileID: 11400000, guid: 43506e89a63343819b87c407111527e6, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 1
+  - _waveName: 3:00-4:00 Sonakssi/AshenClaw/Mangryang
+    _durationSeconds: 60
+    _spawnIntervalSeconds: 2
+    _maxAliveEnemies: 14
+    _enemies:
+    - _enemyType: Sonakssi
+      _monsterData: {fileID: 11400000, guid: fb24fd5e38994de6a94055af52dc5df6, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 3
+      _moveSpeed: 1.3
+    - _enemyType: AshenClaw
+      _monsterData: {fileID: 11400000, guid: 77661a277270a784b8c5751d1df4503e, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 3
+      _moveSpeed: 1.2
+    - _enemyType: Mangryang
+      _monsterData: {fileID: 11400000, guid: 43506e89a63343819b87c407111527e6, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 3
+      _moveSpeed: 1
+  - _waveName: 4:00-5:00 AshenClaw/Mangryang/Sangwi
+    _durationSeconds: 60
+    _spawnIntervalSeconds: 2
+    _maxAliveEnemies: 14
+    _enemies:
+    - _enemyType: AshenClaw
+      _monsterData: {fileID: 11400000, guid: 77661a277270a784b8c5751d1df4503e, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 1.2
+    - _enemyType: Mangryang
+      _monsterData: {fileID: 11400000, guid: 43506e89a63343819b87c407111527e6, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 1
+    - _enemyType: Sangwi
+      _monsterData: {fileID: 11400000, guid: 09e5f3c235914a7a86e707991d9982ed, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 0.95
+  - _waveName: 5:00-6:00 +DuskShade(gimmick)
+    _durationSeconds: 60
+    _spawnIntervalSeconds: 1.5
+    _maxAliveEnemies: 16
+    _enemies:
+    - _enemyType: AshenClaw
+      _monsterData: {fileID: 11400000, guid: 77661a277270a784b8c5751d1df4503e, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 1.2
+    - _enemyType: Mangryang
+      _monsterData: {fileID: 11400000, guid: 43506e89a63343819b87c407111527e6, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 1
+    - _enemyType: Sangwi
+      _monsterData: {fileID: 11400000, guid: 09e5f3c235914a7a86e707991d9982ed, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 0.95
+    - _enemyType: DuskShade
+      _monsterData: {fileID: 11400000, guid: 0c9e73336ec6803409b3e8030695eca2, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 1.5
+  - _waveName: 6:00-7:00 +Dureoksini (TODO Dokkaebi-bul)
+    _durationSeconds: 60
+    _spawnIntervalSeconds: 1.5
+    _maxAliveEnemies: 16
+    _enemies:
+    - _enemyType: Mangryang
+      _monsterData: {fileID: 11400000, guid: 43506e89a63343819b87c407111527e6, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 1
+    - _enemyType: Sangwi
+      _monsterData: {fileID: 11400000, guid: 09e5f3c235914a7a86e707991d9982ed, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 0.95
+    - _enemyType: Dureoksini
+      _monsterData: {fileID: 11400000, guid: 29fa4d2c3fd292642baaf7f072b8e86e, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 0.7
+  - _waveName: 7:00-8:00 +BrambleIdol (TODO Dokkaebi-bul)
+    _durationSeconds: 60
+    _spawnIntervalSeconds: 1.5
+    _maxAliveEnemies: 18
+    _enemies:
+    - _enemyType: Sangwi
+      _monsterData: {fileID: 11400000, guid: 09e5f3c235914a7a86e707991d9982ed, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 0.95
+    - _enemyType: Dureoksini
+      _monsterData: {fileID: 11400000, guid: 29fa4d2c3fd292642baaf7f072b8e86e, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 0.7
+    - _enemyType: BrambleIdol
+      _monsterData: {fileID: 11400000, guid: 89dfd2a29b064fa47a88cabf39d5d41b, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 0.85
+  - _waveName: 8:00-9:00 Dureoksini/BrambleIdol (TODO Dokkaebi-bul, Maegu)
+    _durationSeconds: 60
+    _spawnIntervalSeconds: 1
+    _maxAliveEnemies: 18
+    _enemies:
+    - _enemyType: Dureoksini
+      _monsterData: {fileID: 11400000, guid: 29fa4d2c3fd292642baaf7f072b8e86e, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 0.7
+    - _enemyType: BrambleIdol
+      _monsterData: {fileID: 11400000, guid: 89dfd2a29b064fa47a88cabf39d5d41b, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 0.85
+  - _waveName: 9:00-10:00 All enemies (TODO Dokkaebi-bul, Maegu)
+    _durationSeconds: 60
+    _spawnIntervalSeconds: 1
+    _maxAliveEnemies: 24
+    _enemies:
+    - _enemyType: Sonakssi
+      _monsterData: {fileID: 11400000, guid: fb24fd5e38994de6a94055af52dc5df6, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 1
+      _moveSpeed: 1.3
+    - _enemyType: AshenClaw
+      _monsterData: {fileID: 11400000, guid: 77661a277270a784b8c5751d1df4503e, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 1
+      _moveSpeed: 1.2
+    - _enemyType: Mangryang
+      _monsterData: {fileID: 11400000, guid: 43506e89a63343819b87c407111527e6, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 1
+      _moveSpeed: 1
+    - _enemyType: Sangwi
+      _monsterData: {fileID: 11400000, guid: 09e5f3c235914a7a86e707991d9982ed, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 1
+      _moveSpeed: 0.95
+    - _enemyType: Dureoksini
+      _monsterData: {fileID: 11400000, guid: 29fa4d2c3fd292642baaf7f072b8e86e, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 1
+      _moveSpeed: 0.7
+    - _enemyType: DuskShade
+      _monsterData: {fileID: 11400000, guid: 0c9e73336ec6803409b3e8030695eca2, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 1
+      _moveSpeed: 1.5
+    - _enemyType: BrambleIdol
+      _monsterData: {fileID: 11400000, guid: 89dfd2a29b064fa47a88cabf39d5d41b, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 1
+      _moveSpeed: 0.85

--- a/project1/Assets/Settings/Chapter1_WaveDatabase.asset.meta
+++ b/project1/Assets/Settings/Chapter1_WaveDatabase.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 761c6a7730f34dde86070de259bcccd6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/project1/Assets/Settings/Data/Monsters/Monster_Dureoksini.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_Dureoksini.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.MonsterData
   _monsterId: monster.dureoksini
   _displayName: Dureoksini
-  _isBoss: 1
+  _isBoss: 0
   _enemyPrefab: {fileID: 1475677598667535634, guid: 0892b944d90654243b825a22b54ccad7, type: 3}
   _swipeDirectionSequence:
   _randomizeSequence: 1

--- a/project1/Assets/Settings/Data/Monsters/Monster_Mangryang.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_Mangryang.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dad141cadcb6cef41a0c485253bfb68b, type: 3}
+  m_Name: Monster_Mangryang
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.MonsterData
+  _monsterId: monster.mangryang
+  _displayName: Mangryang
+  _isBoss: 0
+  _enemyPrefab: {fileID: 3535088139439741544, guid: 9f359b9056e17c241bc9c9c0ecd3976f, type: 3}
+  _swipeDirectionSequence:
+  _randomizeSequence: 1
+  _maxHealth: 6
+  _moveSpeed: 1
+  _soulDropCount: 2
+  _experiencePerOrb: 2

--- a/project1/Assets/Settings/Data/Monsters/Monster_Mangryang.asset.meta
+++ b/project1/Assets/Settings/Data/Monsters/Monster_Mangryang.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 43506e89a63343819b87c407111527e6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/project1/Assets/Settings/Data/Monsters/Monster_Sangwi.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_Sangwi.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dad141cadcb6cef41a0c485253bfb68b, type: 3}
+  m_Name: Monster_Sangwi
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.MonsterData
+  _monsterId: monster.sangwi
+  _displayName: Sangwi
+  _isBoss: 0
+  _enemyPrefab: {fileID: 3535088139439741544, guid: 9f359b9056e17c241bc9c9c0ecd3976f, type: 3}
+  _swipeDirectionSequence:
+  _randomizeSequence: 1
+  _maxHealth: 7
+  _moveSpeed: 0.95
+  _soulDropCount: 2
+  _experiencePerOrb: 2

--- a/project1/Assets/Settings/Data/Monsters/Monster_Sangwi.asset.meta
+++ b/project1/Assets/Settings/Data/Monsters/Monster_Sangwi.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 09e5f3c235914a7a86e707991d9982ed
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/project1/Assets/Settings/Data/Monsters/Monster_Sonakssi.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_Sonakssi.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dad141cadcb6cef41a0c485253bfb68b, type: 3}
+  m_Name: Monster_Sonakssi
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.MonsterData
+  _monsterId: monster.sonakssi
+  _displayName: Sonakssi
+  _isBoss: 0
+  _enemyPrefab: {fileID: 3535088139439741544, guid: 9f359b9056e17c241bc9c9c0ecd3976f, type: 3}
+  _swipeDirectionSequence:
+  _randomizeSequence: 1
+  _maxHealth: 2
+  _moveSpeed: 1.3
+  _soulDropCount: 1
+  _experiencePerOrb: 1

--- a/project1/Assets/Settings/Data/Monsters/Monster_Sonakssi.asset.meta
+++ b/project1/Assets/Settings/Data/Monsters/Monster_Sonakssi.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fb24fd5e38994de6a94055af52dc5df6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/project1/Assets/Tests/EditMode/WaveDefinitionTests.cs
+++ b/project1/Assets/Tests/EditMode/WaveDefinitionTests.cs
@@ -8,14 +8,14 @@ namespace Mukseon.Tests.EditMode
     public class WaveDefinitionTests
     {
         [Test]
-        public void GetTotalSpawnCount_SumsOnlyValidCounts()
+        public void GetTotalMinAliveCount_SumsOnlyValidEntriesAndClampsNegatives()
         {
             var wave = new WaveDefinition();
             var entryA = new WaveEnemySpawnEntry();
             var entryB = new WaveEnemySpawnEntry();
 
-            SetPrivateField(entryA, "_count", 3);
-            SetPrivateField(entryB, "_count", -7);
+            SetPrivateField(entryA, "_minAliveCount", 3);
+            SetPrivateField(entryB, "_minAliveCount", -7);
 
             SetPrivateField(
                 wave,
@@ -27,7 +27,8 @@ namespace Mukseon.Tests.EditMode
                     entryB
                 });
 
-            Assert.That(wave.GetTotalSpawnCount(), Is.EqualTo(3));
+            // 음수는 0으로 클램프되고 null 항목은 무시되므로 3만 합산된다.
+            Assert.That(wave.GetTotalMinAliveCount(), Is.EqualTo(3));
         }
 
         private static void SetPrivateField<T>(object target, string fieldName, T value)


### PR DESCRIPTION
## 개요

Day 1 작업: 웨이브 시스템을 Vampire Survivors 스타일 타임라인으로 전환하고, 챕터 1(신림)의 기본 접촉 적과 분 단위 타임라인을 구성합니다.

플레이 테스트 완료 (스폰 / 최소 유지 수 / 1분 단위 웨이브 전환 / 미니보스·보스 마크 이벤트 발행 확인).

---

## 변경 사항

### 1. 기본 접촉 적 3종 추가 (#62 관련)
- `Monster_Sonakssi`(손각시), `Monster_Mangryang`(망량), `Monster_Sangwi`(산귀) MonsterData + meta
- `enemy_design.md`의 속도/체력 분류 기준 스탯 설정
- ⚠️ 비주얼은 기존 적 프리팹 임시 참조 → 스프라이트는 추후 에디터에서 교체

### 2. 웨이브 시스템 VS 타임라인 전환 (#62)
- `WaveCombatDirector` 전면 재작성
  - 웨이브 클리어 조건 제거 → 시간 경과 기반 자동 전환
  - 적 종류별 '최소 유지 수' 충족, 모두 충족 시 매 간격 1마리씩 추가 소환
  - 미니보스 마크(3/6/9분) / 보스 마크(10분) 타임 이벤트 발행
  - 보스 진입 시 일반 스포닝 중단 (적 정리는 보스 시스템 #37에 위임)
  - HUD 의존 공개 API 유지
- `WaveDatabase` 데이터 모델 재설계 (`_count` → `_minAliveCount`)
- `WaveDefinitionTests` 신규 API 대응

### 3. 챕터 1 신림 타임라인 (#70)
- `Chapter1_WaveDatabase.asset`: 0:00~10:00 분 단위 10웨이브
  - 손각시/창귀/망량/산귀/두억시니/어둑시니/목귀 배치
  - 도깨비불·매구는 에셋 미구현으로 제외 (Day 2-3 추가 예정, 웨이브명에 TODO 표기)
- `SampleScene`의 WaveCombatDirector를 Chapter1_WaveDatabase로 재연결
- `Monster_Dureoksini._isBoss` 1→0: 두억시니는 기본 탱커이므로 보스 HP바 오인 방지

---

## 미니보스/보스 마크 관련

마크 이벤트는 발행되지만 **구독자(미니보스 #71 / 보스 #37)는 아직 미구현**이라 현재는 로그로만 확인됩니다. 실제 미니보스·보스 스폰은 후속 작업에서 연결됩니다.

---

## 후속 작업
- 특수 적 구현 (도깨비불·매구·어둑시니·목귀 기믹) → 챕터 1 타임라인의 TODO 채우기
- 신규 적 3종 스프라이트 교체
- 적 공격 방향 시퀀스 시스템 제거 (별도 브랜치 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)