### PR TITLE
feat: 목귀 적 패턴 구현 — MokgwiEnemy / MokgwiRoot (#58)

### DIFF
--- a/project1/Assets/Prefabs/Enemies/MokgwiEnemy.prefab
+++ b/project1/Assets/Prefabs/Enemies/MokgwiEnemy.prefab
@@ -1,0 +1,178 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7157714492135509594
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8316608781514299578}
+  - component: {fileID: 6335133232443173733}
+  - component: {fileID: 287392638280517337}
+  - component: {fileID: 8322485774661296830}
+  - component: {fileID: 6758741756703222207}
+  m_Layer: 0
+  m_Name: MokgwiEnemy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8316608781514299578
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7157714492135509594}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &6335133232443173733
+SpriteRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7157714492135509594}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_Sprite: {fileID: 935252494, guid: d009999f57b17024893afbf8af587f02, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2.56, y: 2.56}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_SpriteSortPoint: 0
+--- !u!61 &287392638280517337
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7157714492135509594}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2.56, y: 2.56}
+    newSize: {x: 2.56, y: 2.56}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 2.56, y: 2.56}
+  m_EdgeRadius: 0
+--- !u!114 &8322485774661296830
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7157714492135509594}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2c6d5a7ef7a14cf0b98f6d9381d7a201, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyHealth
+  _maxHealth: 10
+  _destroyOnDeath: 0
+  _disableCollidersOnDeath: 1
+  _swipeDirection: 0
+  _monsterData: {fileID: 0}
+  _moveSpeed: 1
+--- !u!114 &6758741756703222207
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7157714492135509594}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b9aeeb83f0fc0d4459780e893adf057a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.MokgwiEnemy
+  _waitDuration: 1.5
+  _waypointReachDistance: 0.2
+  _playerAvoidRadius: 2
+  _rootPrefab: {fileID: 386968887035504875, guid: 54e93149305e511448590bfb9763acaf, type: 3}
+  _rootSpawnInterval: 3
+  _maxRootsOnMap: 20

--- a/project1/Assets/Prefabs/Enemies/MokgwiEnemy.prefab.meta
+++ b/project1/Assets/Prefabs/Enemies/MokgwiEnemy.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 17229571043f4af43a98eb688f1a83e5
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/project1/Assets/Prefabs/Enemies/MokgwiRoot.prefab
+++ b/project1/Assets/Prefabs/Enemies/MokgwiRoot.prefab
@@ -1,0 +1,172 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &386968887035504875
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2677368357123878609}
+  - component: {fileID: 1207403830801882080}
+  - component: {fileID: 665222801325094029}
+  - component: {fileID: 2152396636063808086}
+  - component: {fileID: 9185215621374291727}
+  m_Layer: 0
+  m_Name: MokgwiRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2677368357123878609
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 386968887035504875}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1207403830801882080
+SpriteRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 386968887035504875}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_Sprite: {fileID: 1907901286, guid: 3c13f544f65b38b4fb532a402b70a7d4, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2.56, y: 2.56}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_SpriteSortPoint: 0
+--- !u!61 &665222801325094029
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 386968887035504875}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2.56, y: 2.56}
+    newSize: {x: 2.56, y: 2.56}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 2.56, y: 2.56}
+  m_EdgeRadius: 0
+--- !u!114 &2152396636063808086
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 386968887035504875}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2c6d5a7ef7a14cf0b98f6d9381d7a201, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyHealth
+  _maxHealth: 10
+  _destroyOnDeath: 0
+  _disableCollidersOnDeath: 1
+  _swipeDirection: 0
+  _monsterData: {fileID: 0}
+  _moveSpeed: 1
+--- !u!114 &9185215621374291727
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 386968887035504875}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 77e5393b47c84da4491911c9c98b12d9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.MokgwiRoot

--- a/project1/Assets/Prefabs/Enemies/MokgwiRoot.prefab.meta
+++ b/project1/Assets/Prefabs/Enemies/MokgwiRoot.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 54e93149305e511448590bfb9763acaf
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/project1/Assets/Scripts/Combat/EnemyHealth.cs
+++ b/project1/Assets/Scripts/Combat/EnemyHealth.cs
@@ -37,6 +37,7 @@ namespace Mukseon.Gameplay.Combat
         public float MaxHealth => _maxHealth;
         public float CurrentHealth { get; private set; }
         public bool IsAlive { get; private set; }
+        public bool IsTargetable { get; set; } = true;
         public float MoveSpeed => Mathf.Max(0f, _moveSpeed);
         public static IReadOnlyList<EnemyHealth> ActiveEnemies => _activeEnemies;
         public MonsterData MonsterData => _monsterData;
@@ -115,7 +116,7 @@ namespace Mukseon.Gameplay.Combat
 
         public void ApplyDamage(float amount, object source = null)
         {
-            if (!IsAlive || amount <= 0f)
+            if (!IsAlive || !IsTargetable || amount <= 0f)
             {
                 return;
             }
@@ -199,6 +200,7 @@ namespace Mukseon.Gameplay.Combat
         public void PrepareForReuse()
         {
             _destroyOnDeath = false;
+            IsTargetable = true;
             ResetHealth();
 
             if (_attackSequence != null && _monsterData != null && _monsterData.RandomizeSequence)

--- a/project1/Assets/Scripts/Combat/MokgwiEnemy.cs
+++ b/project1/Assets/Scripts/Combat/MokgwiEnemy.cs
@@ -166,10 +166,12 @@ namespace Mukseon.Gameplay.Combat
                 _rootPrefab, transform.position, Quaternion.identity);
 
             EnemyHealth rootHealth = rootObj.GetComponent<EnemyHealth>();
-            if (rootHealth != null)
+            MokgwiRoot root = rootObj.GetComponent<MokgwiRoot>();
+            if (rootHealth != null && root != null)
             {
                 rootHealth.PrepareForReuse();
                 rootHealth.OnDeath += HandleRootDied;
+                root.OnDisabled += HandleRootDisabled;
                 _spawnedRoots.Add(rootHealth);
             }
 
@@ -185,6 +187,22 @@ namespace Mukseon.Gameplay.Combat
         {
             rootHealth.OnDeath -= HandleRootDied;
             _spawnedRoots.Remove(rootHealth);
+
+            MokgwiRoot root = rootHealth.GetComponent<MokgwiRoot>();
+            if (root != null)
+                root.OnDisabled -= HandleRootDisabled;
+        }
+
+        private void HandleRootDisabled(MokgwiRoot root)
+        {
+            root.OnDisabled -= HandleRootDisabled;
+
+            EnemyHealth rootHealth = root.GetComponent<EnemyHealth>();
+            if (rootHealth != null)
+            {
+                rootHealth.OnDeath -= HandleRootDied;
+                _spawnedRoots.Remove(rootHealth);
+            }
         }
 
         private void KillSpawnedRoots()
@@ -195,6 +213,11 @@ namespace Mukseon.Gameplay.Combat
                 if (rootHealth != null && rootHealth.IsAlive)
                 {
                     rootHealth.OnDeath -= HandleRootDied;
+
+                    MokgwiRoot root = rootHealth.GetComponent<MokgwiRoot>();
+                    if (root != null)
+                        root.OnDisabled -= HandleRootDisabled;
+
                     rootHealth.Kill(countAsKill: false);
                 }
             }
@@ -244,7 +267,11 @@ namespace Mukseon.Gameplay.Combat
                 }
             }
 
-            return transform.position;
+            // 10회 시도 실패 시 — 회피 조건 없이 임의 위치 반환 (제자리 즉시 전환 방지)
+            return new Vector3(
+                Random.Range(camPos.x - halfW * 0.7f, camPos.x + halfW * 0.7f),
+                Random.Range(camPos.y - halfH * 0.7f, camPos.y + halfH * 0.7f),
+                0f);
         }
     }
 }

--- a/project1/Assets/Scripts/Combat/MokgwiEnemy.cs
+++ b/project1/Assets/Scripts/Combat/MokgwiEnemy.cs
@@ -6,38 +6,47 @@ namespace Mukseon.Gameplay.Combat
 {
     /// <summary>
     /// 목귀 적 컴포넌트.
-    /// 화면 내를 자유롭게 배회하며 쿨타임마다 나무뿌리 장애물을 소환한다.
-    /// 뿌리는 스와이프 공격을 흡수해 다른 적을 보호하는 동선 방해 기믹이다.
-    /// 처치 시 자신이 소환한 모든 뿌리가 함께 소멸한다.
+    /// 땅속을 이동하며 나무뿌리 장애물을 설치하는 기믹형 적.
+    /// 이동 중에는 잠복(무적·비타겟)이고, 지표에 멈출 때만 공격 가능하다.
     /// </summary>
     [DisallowMultipleComponent]
     [RequireComponent(typeof(EnemyHealth))]
     public class MokgwiEnemy : MonoBehaviour
     {
-        [Header("Wandering")]
-        [SerializeField, Min(0.5f)]
-        private float _playerAvoidRadius = 2f;
+        private enum State
+        {
+            EnteringScreen,    // 화면 밖 스폰 위치 → 가장자리 진입 (잠복·무적)
+            WaitingAtEdge,     // 가장자리 정지 — 공격 가능
+            MovingUnderground, // 화면 내 이동 (잠복·무적, 이동 경로에 뿌리 소환)
+            Surfaced,          // 목표 지점 정지 — 공격 가능
+        }
+
+        [Header("Movement")]
+        [SerializeField, Min(0f)]
+        private float _waitDuration = 1.5f;
 
         [SerializeField, Min(0.05f)]
-        private float _waypointReachDistance = 0.2f;
+        private float _waypointReachDistance = 0.15f;
+
+        [SerializeField, Min(0.5f)]
+        private float _playerAvoidRadius = 2f;
 
         [Header("Root Spawning")]
         [SerializeField]
         private GameObject _rootPrefab;
 
         [SerializeField, Min(0.1f)]
-        private float _rootSpawnInterval = 3f;
+        private float _rootSpawnInterval = 1f;
 
         [SerializeField, Min(1)]
         private int _maxRootsOnMap = 5;
 
-        [SerializeField, Min(0.5f)]
-        private float _minRootDistanceFromBody = 1.5f;
-
         private EnemyHealth _enemyHealth;
         private Transform _playerTarget;
-        private Vector3 _wanderTarget;
-        private float _spawnTimer;
+        private Vector3 _moveTarget;
+        private State _state;
+        private float _stateTimer;
+        private float _rootSpawnTimer;
         private readonly List<EnemyHealth> _spawnedRoots = new List<EnemyHealth>();
 
         private void Awake()
@@ -49,7 +58,6 @@ namespace Mukseon.Gameplay.Combat
         {
             _enemyHealth.OnDied += HandleDied;
             _spawnedRoots.Clear();
-            _spawnTimer = _rootSpawnInterval;
 
             if (_playerTarget == null)
             {
@@ -58,12 +66,13 @@ namespace Mukseon.Gameplay.Combat
                     _playerTarget = ph.transform;
             }
 
-            _wanderTarget = PickWanderTarget();
+            EnterState(State.EnteringScreen);
         }
 
         private void OnDisable()
         {
             _enemyHealth.OnDied -= HandleDied;
+            _enemyHealth.IsTargetable = true;
             KillSpawnedRoots();
         }
 
@@ -72,26 +81,76 @@ namespace Mukseon.Gameplay.Combat
             if (!_enemyHealth.IsAlive)
                 return;
 
-            UpdateMovement();
-            UpdateSpawnTimer();
+            _stateTimer += Time.deltaTime;
+
+            switch (_state)
+            {
+                case State.EnteringScreen:
+                    MoveToward(_moveTarget);
+                    if (Vector2.Distance(transform.position, _moveTarget) < _waypointReachDistance)
+                        EnterState(State.WaitingAtEdge);
+                    break;
+
+                case State.WaitingAtEdge:
+                    if (_stateTimer >= _waitDuration)
+                        EnterState(State.MovingUnderground);
+                    break;
+
+                case State.MovingUnderground:
+                    MoveToward(_moveTarget);
+                    UpdateRootSpawn();
+                    if (Vector2.Distance(transform.position, _moveTarget) < _waypointReachDistance)
+                        EnterState(State.Surfaced);
+                    break;
+
+                case State.Surfaced:
+                    if (_stateTimer >= _waitDuration)
+                        EnterState(State.MovingUnderground);
+                    break;
+            }
         }
 
-        private void UpdateMovement()
+        private void EnterState(State next)
+        {
+            _state = next;
+            _stateTimer = 0f;
+
+            switch (next)
+            {
+                case State.EnteringScreen:
+                    _enemyHealth.IsTargetable = false;
+                    _moveTarget = PickScreenEdgeTarget();
+                    break;
+
+                case State.WaitingAtEdge:
+                    _enemyHealth.IsTargetable = true;
+                    break;
+
+                case State.MovingUnderground:
+                    _enemyHealth.IsTargetable = false;
+                    _rootSpawnTimer = 0f; // 이동 시작 즉시 첫 뿌리 소환
+                    _moveTarget = PickInsideTarget();
+                    break;
+
+                case State.Surfaced:
+                    _enemyHealth.IsTargetable = true;
+                    break;
+            }
+        }
+
+        private void MoveToward(Vector3 target)
         {
             float step = _enemyHealth.MoveSpeed * Time.deltaTime;
-            transform.position = Vector3.MoveTowards(transform.position, _wanderTarget, step);
-
-            if (Vector2.Distance(transform.position, _wanderTarget) < _waypointReachDistance)
-                _wanderTarget = PickWanderTarget();
+            transform.position = Vector3.MoveTowards(transform.position, target, step);
         }
 
-        private void UpdateSpawnTimer()
+        private void UpdateRootSpawn()
         {
-            _spawnTimer -= Time.deltaTime;
-            if (_spawnTimer <= 0f)
+            _rootSpawnTimer -= Time.deltaTime;
+            if (_rootSpawnTimer <= 0f)
             {
                 TrySpawnRoot();
-                _spawnTimer = _rootSpawnInterval;
+                _rootSpawnTimer = _rootSpawnInterval;
             }
         }
 
@@ -103,9 +162,8 @@ namespace Mukseon.Gameplay.Combat
             if (MokgwiRoot.ActiveRootCount >= _maxRootsOnMap)
                 return;
 
-            Vector3 spawnPos = PickRootSpawnPosition();
             GameObject rootObj = PoolManager.Instance.GetInactive(
-                _rootPrefab, spawnPos, Quaternion.identity);
+                _rootPrefab, transform.position, Quaternion.identity);
 
             EnemyHealth rootHealth = rootObj.GetComponent<EnemyHealth>();
             if (rootHealth != null)
@@ -143,7 +201,27 @@ namespace Mukseon.Gameplay.Combat
             _spawnedRoots.Clear();
         }
 
-        private Vector3 PickWanderTarget()
+        private Vector3 PickScreenEdgeTarget()
+        {
+            Camera cam = Camera.main;
+            if (cam == null)
+                return transform.position;
+
+            float halfH = cam.orthographicSize;
+            float halfW = halfH * cam.aspect;
+            Vector3 camPos = cam.transform.position;
+
+            int side = Random.Range(0, 4);
+            switch (side)
+            {
+                case 0: return new Vector3(Random.Range(camPos.x - halfW * 0.8f, camPos.x + halfW * 0.8f), camPos.y + halfH * 0.85f, 0f); // 상
+                case 1: return new Vector3(Random.Range(camPos.x - halfW * 0.8f, camPos.x + halfW * 0.8f), camPos.y - halfH * 0.85f, 0f); // 하
+                case 2: return new Vector3(camPos.x - halfW * 0.85f, Random.Range(camPos.y - halfH * 0.8f, camPos.y + halfH * 0.8f), 0f); // 좌
+                default: return new Vector3(camPos.x + halfW * 0.85f, Random.Range(camPos.y - halfH * 0.8f, camPos.y + halfH * 0.8f), 0f); // 우
+            }
+        }
+
+        private Vector3 PickInsideTarget()
         {
             Camera cam = Camera.main;
             if (cam == null)
@@ -155,8 +233,8 @@ namespace Mukseon.Gameplay.Combat
 
             for (int i = 0; i < 10; i++)
             {
-                float x = Random.Range(camPos.x - halfW * 0.85f, camPos.x + halfW * 0.85f);
-                float y = Random.Range(camPos.y - halfH * 0.85f, camPos.y + halfH * 0.85f);
+                float x = Random.Range(camPos.x - halfW * 0.7f, camPos.x + halfW * 0.7f);
+                float y = Random.Range(camPos.y - halfH * 0.7f, camPos.y + halfH * 0.7f);
                 Vector3 candidate = new Vector3(x, y, 0f);
 
                 if (_playerTarget == null ||
@@ -166,34 +244,7 @@ namespace Mukseon.Gameplay.Combat
                 }
             }
 
-            // 10회 시도 실패 시 현재 위치 유지 (플레이어가 화면 대부분을 점유하는 극단적 케이스)
             return transform.position;
-        }
-
-        private Vector3 PickRootSpawnPosition()
-        {
-            Camera cam = Camera.main;
-            Vector3 fallback = transform.position +
-                (Vector3)(Random.insideUnitCircle.normalized * _minRootDistanceFromBody * 2f);
-
-            if (cam == null)
-                return fallback;
-
-            float halfH = cam.orthographicSize;
-            float halfW = halfH * cam.aspect;
-            Vector3 camPos = cam.transform.position;
-
-            for (int i = 0; i < 10; i++)
-            {
-                float x = Random.Range(camPos.x - halfW * 0.8f, camPos.x + halfW * 0.8f);
-                float y = Random.Range(camPos.y - halfH * 0.8f, camPos.y + halfH * 0.8f);
-                Vector3 candidate = new Vector3(x, y, 0f);
-
-                if (Vector2.Distance(candidate, transform.position) >= _minRootDistanceFromBody)
-                    return candidate;
-            }
-
-            return fallback;
         }
     }
 }

--- a/project1/Assets/Scripts/Combat/MokgwiEnemy.cs
+++ b/project1/Assets/Scripts/Combat/MokgwiEnemy.cs
@@ -1,0 +1,199 @@
+using System.Collections.Generic;
+using Mukseon.Core.Pool;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 목귀 적 컴포넌트.
+    /// 화면 내를 자유롭게 배회하며 쿨타임마다 나무뿌리 장애물을 소환한다.
+    /// 뿌리는 스와이프 공격을 흡수해 다른 적을 보호하는 동선 방해 기믹이다.
+    /// 처치 시 자신이 소환한 모든 뿌리가 함께 소멸한다.
+    /// </summary>
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(EnemyHealth))]
+    public class MokgwiEnemy : MonoBehaviour
+    {
+        [Header("Wandering")]
+        [SerializeField, Min(0.5f)]
+        private float _playerAvoidRadius = 2f;
+
+        [SerializeField, Min(0.05f)]
+        private float _waypointReachDistance = 0.2f;
+
+        [Header("Root Spawning")]
+        [SerializeField]
+        private GameObject _rootPrefab;
+
+        [SerializeField, Min(0.1f)]
+        private float _rootSpawnInterval = 3f;
+
+        [SerializeField, Min(1)]
+        private int _maxRootsOnMap = 5;
+
+        [SerializeField, Min(0.5f)]
+        private float _minRootDistanceFromBody = 1.5f;
+
+        private EnemyHealth _enemyHealth;
+        private Transform _playerTarget;
+        private Vector3 _wanderTarget;
+        private float _spawnTimer;
+        private readonly List<EnemyHealth> _spawnedRoots = new List<EnemyHealth>();
+
+        private void Awake()
+        {
+            _enemyHealth = GetComponent<EnemyHealth>();
+        }
+
+        private void OnEnable()
+        {
+            _enemyHealth.OnDied += HandleDied;
+            _spawnedRoots.Clear();
+            _spawnTimer = _rootSpawnInterval;
+
+            if (_playerTarget == null)
+            {
+                PlayerHealth ph = FindAnyObjectByType<PlayerHealth>();
+                if (ph != null)
+                    _playerTarget = ph.transform;
+            }
+
+            _wanderTarget = PickWanderTarget();
+        }
+
+        private void OnDisable()
+        {
+            _enemyHealth.OnDied -= HandleDied;
+            KillSpawnedRoots();
+        }
+
+        private void Update()
+        {
+            if (!_enemyHealth.IsAlive)
+                return;
+
+            UpdateMovement();
+            UpdateSpawnTimer();
+        }
+
+        private void UpdateMovement()
+        {
+            float step = _enemyHealth.MoveSpeed * Time.deltaTime;
+            transform.position = Vector3.MoveTowards(transform.position, _wanderTarget, step);
+
+            if (Vector2.Distance(transform.position, _wanderTarget) < _waypointReachDistance)
+                _wanderTarget = PickWanderTarget();
+        }
+
+        private void UpdateSpawnTimer()
+        {
+            _spawnTimer -= Time.deltaTime;
+            if (_spawnTimer <= 0f)
+            {
+                TrySpawnRoot();
+                _spawnTimer = _rootSpawnInterval;
+            }
+        }
+
+        private void TrySpawnRoot()
+        {
+            if (_rootPrefab == null || PoolManager.Instance == null)
+                return;
+
+            if (MokgwiRoot.ActiveRootCount >= _maxRootsOnMap)
+                return;
+
+            Vector3 spawnPos = PickRootSpawnPosition();
+            GameObject rootObj = PoolManager.Instance.GetInactive(
+                _rootPrefab, spawnPos, Quaternion.identity);
+
+            EnemyHealth rootHealth = rootObj.GetComponent<EnemyHealth>();
+            if (rootHealth != null)
+            {
+                rootHealth.PrepareForReuse();
+                rootHealth.OnDeath += HandleRootDied;
+                _spawnedRoots.Add(rootHealth);
+            }
+
+            rootObj.SetActive(true);
+        }
+
+        private void HandleDied()
+        {
+            KillSpawnedRoots();
+        }
+
+        private void HandleRootDied(EnemyHealth rootHealth)
+        {
+            rootHealth.OnDeath -= HandleRootDied;
+            _spawnedRoots.Remove(rootHealth);
+        }
+
+        private void KillSpawnedRoots()
+        {
+            for (int i = _spawnedRoots.Count - 1; i >= 0; i--)
+            {
+                EnemyHealth rootHealth = _spawnedRoots[i];
+                if (rootHealth != null && rootHealth.IsAlive)
+                {
+                    rootHealth.OnDeath -= HandleRootDied;
+                    rootHealth.Kill(countAsKill: false);
+                }
+            }
+            _spawnedRoots.Clear();
+        }
+
+        private Vector3 PickWanderTarget()
+        {
+            Camera cam = Camera.main;
+            if (cam == null)
+                return transform.position;
+
+            float halfH = cam.orthographicSize;
+            float halfW = halfH * cam.aspect;
+            Vector3 camPos = cam.transform.position;
+
+            for (int i = 0; i < 10; i++)
+            {
+                float x = Random.Range(camPos.x - halfW * 0.85f, camPos.x + halfW * 0.85f);
+                float y = Random.Range(camPos.y - halfH * 0.85f, camPos.y + halfH * 0.85f);
+                Vector3 candidate = new Vector3(x, y, 0f);
+
+                if (_playerTarget == null ||
+                    Vector2.Distance(candidate, _playerTarget.position) >= _playerAvoidRadius)
+                {
+                    return candidate;
+                }
+            }
+
+            // 10회 시도 실패 시 현재 위치 유지 (플레이어가 화면 대부분을 점유하는 극단적 케이스)
+            return transform.position;
+        }
+
+        private Vector3 PickRootSpawnPosition()
+        {
+            Camera cam = Camera.main;
+            Vector3 fallback = transform.position +
+                (Vector3)(Random.insideUnitCircle.normalized * _minRootDistanceFromBody * 2f);
+
+            if (cam == null)
+                return fallback;
+
+            float halfH = cam.orthographicSize;
+            float halfW = halfH * cam.aspect;
+            Vector3 camPos = cam.transform.position;
+
+            for (int i = 0; i < 10; i++)
+            {
+                float x = Random.Range(camPos.x - halfW * 0.8f, camPos.x + halfW * 0.8f);
+                float y = Random.Range(camPos.y - halfH * 0.8f, camPos.y + halfH * 0.8f);
+                Vector3 candidate = new Vector3(x, y, 0f);
+
+                if (Vector2.Distance(candidate, transform.position) >= _minRootDistanceFromBody)
+                    return candidate;
+            }
+
+            return fallback;
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/MokgwiEnemy.cs.meta
+++ b/project1/Assets/Scripts/Combat/MokgwiEnemy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b9aeeb83f0fc0d4459780e893adf057a

--- a/project1/Assets/Scripts/Combat/MokgwiRoot.cs
+++ b/project1/Assets/Scripts/Combat/MokgwiRoot.cs
@@ -13,14 +13,18 @@ namespace Mukseon.Gameplay.Combat
     [RequireComponent(typeof(EnemyHealth))]
     public class MokgwiRoot : MonoBehaviour
     {
-        private static readonly SwipeDirection[] _swipeDirections =
-            (SwipeDirection[])System.Enum.GetValues(typeof(SwipeDirection));
+        // SwipeDirection.None 제외 — None이 할당되면 스와이프로 파괴 불가
+        private static readonly SwipeDirection[] _swipeDirections = System.Array.FindAll(
+            (SwipeDirection[])System.Enum.GetValues(typeof(SwipeDirection)),
+            d => d != SwipeDirection.None);
 
         /// <summary>현재 씬에 활성화된 나무뿌리 총 개수.</summary>
         public static int ActiveRootCount { get; private set; }
 
+        /// <summary>비활성화(풀 반환 포함) 직전 발행. 구독자는 이벤트 내에서 해제해야 한다.</summary>
+        public event System.Action<MokgwiRoot> OnDisabled;
+
         private EnemyHealth _enemyHealth;
-        private bool _counted;
 
         private void Awake()
         {
@@ -32,32 +36,18 @@ namespace Mukseon.Gameplay.Combat
             _enemyHealth.OnDeath += HandleDeath;
             _enemyHealth.SetSwipeDirection(_swipeDirections[Random.Range(0, _swipeDirections.Length)]);
             ActiveRootCount++;
-            _counted = true;
         }
 
         private void OnDisable()
         {
             _enemyHealth.OnDeath -= HandleDeath;
-        }
-
-        private void OnDestroy()
-        {
-            // Kill 없이 파괴되는 경우(씬 언로드 등) 카운터 보정
-            if (_counted)
-            {
-                ActiveRootCount--;
-                _counted = false;
-            }
+            ActiveRootCount--;
+            OnDisabled?.Invoke(this);
+            OnDisabled = null; // 풀 반환 후 재사용 시 이전 구독 잔존 방지
         }
 
         private void HandleDeath(EnemyHealth _)
         {
-            if (_counted)
-            {
-                ActiveRootCount--;
-                _counted = false;
-            }
-
             if (PoolManager.Instance != null)
                 PoolManager.Instance.Release(gameObject);
             else

--- a/project1/Assets/Scripts/Combat/MokgwiRoot.cs
+++ b/project1/Assets/Scripts/Combat/MokgwiRoot.cs
@@ -1,0 +1,67 @@
+using Mukseon.Core.Input;
+using Mukseon.Core.Pool;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 목귀가 소환하는 나무뿌리 장애물.
+    /// 활성화 시 방향 속성을 랜덤 할당받아 해당 방향 스와이프의 타격 후보가 된다.
+    /// 체력 소진 시 제거되며 전역 뿌리 카운터를 감소시킨다.
+    /// </summary>
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(EnemyHealth))]
+    public class MokgwiRoot : MonoBehaviour
+    {
+        private static readonly SwipeDirection[] _swipeDirections =
+            (SwipeDirection[])System.Enum.GetValues(typeof(SwipeDirection));
+
+        /// <summary>현재 씬에 활성화된 나무뿌리 총 개수.</summary>
+        public static int ActiveRootCount { get; private set; }
+
+        private EnemyHealth _enemyHealth;
+        private bool _counted;
+
+        private void Awake()
+        {
+            _enemyHealth = GetComponent<EnemyHealth>();
+        }
+
+        private void OnEnable()
+        {
+            _enemyHealth.OnDeath += HandleDeath;
+            _enemyHealth.SetSwipeDirection(_swipeDirections[Random.Range(0, _swipeDirections.Length)]);
+            ActiveRootCount++;
+            _counted = true;
+        }
+
+        private void OnDisable()
+        {
+            _enemyHealth.OnDeath -= HandleDeath;
+        }
+
+        private void OnDestroy()
+        {
+            // Kill 없이 파괴되는 경우(씬 언로드 등) 카운터 보정
+            if (_counted)
+            {
+                ActiveRootCount--;
+                _counted = false;
+            }
+        }
+
+        private void HandleDeath(EnemyHealth _)
+        {
+            if (_counted)
+            {
+                ActiveRootCount--;
+                _counted = false;
+            }
+
+            if (PoolManager.Instance != null)
+                PoolManager.Instance.Release(gameObject);
+            else
+                gameObject.SetActive(false);
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/MokgwiRoot.cs.meta
+++ b/project1/Assets/Scripts/Combat/MokgwiRoot.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 77e5393b47c84da4491911c9c98b12d9

--- a/project1/Assets/Scripts/Combat/SwipeAttackTargeting.cs
+++ b/project1/Assets/Scripts/Combat/SwipeAttackTargeting.cs
@@ -31,7 +31,7 @@ namespace Mukseon.Gameplay.Combat
             for (int i = 0; i < enemies.Count; i++)
             {
                 EnemyHealth enemy = enemies[i];
-                if (enemy == null || !enemy.IsAlive || enemy.SwipeDirection != swipeDirection)
+                if (enemy == null || !enemy.IsAlive || !enemy.IsTargetable || enemy.SwipeDirection != swipeDirection)
                 {
                     continue;
                 }


### PR DESCRIPTION
## Summary

- **MokgwiRoot** (나무뿌리 장애물): 활성화 시 랜덤 방향 속성 할당, 기존 `SwipeAttackTargeting` 우선순위 규칙 그대로 타격 후보 편입, 전역 카운터(`ActiveRootCount`)로 맵 전체 뿌리 개수 제한
- **MokgwiEnemy** (본체): 잠복/지표 상태 머신으로 이동 중 무적·뿌리 소환, 정지 중 공격 가능 기믹 구현. 본체 처치 시 소환한 모든 뿌리 일괄 소멸
- **EnemyHealth**: `IsTargetable` 프로퍼티 추가 — `false` 시 `ApplyDamage` 차단 및 `SwipeAttackTargeting` 제외
- **SwipeAttackTargeting**: `!enemy.IsTargetable` 필터 추가

## 상태 머신

| 상태 | 설명 | 공격 가능 | 뿌리 소환 |
|------|------|:---------:|:---------:|
| `EnteringScreen` | 화면 밖 → 가장자리 이동 | ✗ | ✗ |
| `WaitingAtEdge` | 가장자리 정지 | ✓ | ✗ |
| `MovingUnderground` | 화면 내 이동 (이동 경로에 뿌리 설치) | ✗ | ✓ |
| `Surfaced` | 목표 지점 정지 | ✓ | ✗ |

## Test plan

- [ ] 목귀가 화면 밖에서 스폰되어 가장자리로 이동하는지 확인
- [ ] `WaitingAtEdge` / `Surfaced` 상태에서만 스와이프 공격이 적중하는지 확인
- [ ] `MovingUnderground` 중 이동 경로에 뿌리가 소환되는지 확인
- [ ] 맵 전체 뿌리 개수가 `_maxRootsOnMap` 초과 시 소환이 중단되는지 확인
- [ ] 뿌리를 스와이프로 처치하면 카운터가 감소하고 추가 소환이 재개되는지 확인
- [ ] 목귀 본체 처치 시 자신이 소환한 모든 뿌리가 함께 소멸하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)