### PR TITLE
feat: 보장 스킬 선택 시스템 구현 (#63)

### DIFF
--- a/project1/Assets/SampleScene.unity
+++ b/project1/Assets/SampleScene.unity
@@ -1100,6 +1100,7 @@ GameObject:
   - component: {fileID: 1453966978}
   - component: {fileID: 1453966977}
   - component: {fileID: 1453966979}
+  - component: {fileID: 1453966980}
   m_Layer: 0
   m_Name: WaveSystem
   m_TagString: Untagged
@@ -1227,6 +1228,20 @@ MonoBehaviour:
   _knockbackDistance: 3
   _knockbackDuration: 0.25
   _showDebugLogs: 0
+--- !u!114 &1453966980
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1453966975}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f4a4bc152b61ad469d158d196bdd1dc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Progression.GuaranteedSkillSelector
+  _miniBossSpawner: {fileID: 1453966979}
+  _playerLevelSystem: {fileID: 187285035}
 --- !u!1 &1748205191
 GameObject:
   m_ObjectHideFlags: 0

--- a/project1/Assets/Scripts/Progression/GuaranteedSkillSelector.cs
+++ b/project1/Assets/Scripts/Progression/GuaranteedSkillSelector.cs
@@ -17,6 +17,32 @@ namespace Mukseon.Gameplay.Progression
         [SerializeField]
         private PlayerLevelSystem _playerLevelSystem;
 
+        private void Awake()
+        {
+            if (_miniBossSpawner == null)
+            {
+                _miniBossSpawner = GetComponent<MiniBossSpawner>();
+            }
+
+            if (_playerLevelSystem == null)
+            {
+                _playerLevelSystem = FindFirstObjectByType<PlayerLevelSystem>();
+            }
+        }
+
+        private void Start()
+        {
+            if (_miniBossSpawner == null)
+            {
+                Debug.LogError("[GuaranteedSkillSelector] MiniBossSpawner 참조가 누락되었습니다.", this);
+            }
+
+            if (_playerLevelSystem == null)
+            {
+                Debug.LogError("[GuaranteedSkillSelector] PlayerLevelSystem 참조가 누락되었습니다.", this);
+            }
+        }
+
         private void OnEnable()
         {
             if (_miniBossSpawner != null)

--- a/project1/Assets/Scripts/Progression/GuaranteedSkillSelector.cs
+++ b/project1/Assets/Scripts/Progression/GuaranteedSkillSelector.cs
@@ -1,0 +1,47 @@
+using Mukseon.Gameplay.Combat;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Progression
+{
+    /// <summary>
+    /// 미니 보스 처치 시 보장 스킬 선택 1회를 PlayerLevelSystem 큐에 추가한다.
+    /// 레벨업 선택과 동일한 큐(PendingLevelUps)를 공유하므로 처리 순서가 자동으로 보장된다.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class GuaranteedSkillSelector : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField]
+        private MiniBossSpawner _miniBossSpawner;
+
+        [SerializeField]
+        private PlayerLevelSystem _playerLevelSystem;
+
+        private void OnEnable()
+        {
+            if (_miniBossSpawner != null)
+            {
+                _miniBossSpawner.OnMiniBossDefeated += HandleMiniBossDefeated;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (_miniBossSpawner != null)
+            {
+                _miniBossSpawner.OnMiniBossDefeated -= HandleMiniBossDefeated;
+            }
+        }
+
+        private void HandleMiniBossDefeated(int stageIndex, MiniBossStageData stageData)
+        {
+            if (_playerLevelSystem == null)
+            {
+                Debug.LogWarning("[GuaranteedSkillSelector] PlayerLevelSystem 참조가 없습니다.");
+                return;
+            }
+
+            _playerLevelSystem.AddGuaranteedSkillSelection();
+        }
+    }
+}

--- a/project1/Assets/Scripts/Progression/GuaranteedSkillSelector.cs.meta
+++ b/project1/Assets/Scripts/Progression/GuaranteedSkillSelector.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6f4a4bc152b61ad469d158d196bdd1dc

--- a/project1/Assets/Scripts/Progression/LevelProgressionModel.cs
+++ b/project1/Assets/Scripts/Progression/LevelProgressionModel.cs
@@ -60,5 +60,14 @@ namespace Mukseon.Gameplay.Progression
             PendingLevelUps--;
             return true;
         }
+
+        /// <summary>
+        /// 경험치/레벨업과 무관하게 스킬 선택 1회를 큐에 추가한다.
+        /// 미니 보스 처치 등 외부 트리거에 의한 보장 선택에 사용한다.
+        /// </summary>
+        public void AddGuaranteedSelection()
+        {
+            PendingLevelUps++;
+        }
     }
 }

--- a/project1/Assets/Scripts/Progression/PlayerLevelSystem.cs
+++ b/project1/Assets/Scripts/Progression/PlayerLevelSystem.cs
@@ -155,6 +155,25 @@ namespace Mukseon.Gameplay.Progression
             return true;
         }
 
+        /// <summary>
+        /// 경험치/레벨업과 무관하게 스킬 선택 1회를 큐에 추가한다.
+        /// 미니 보스 처치 트리거에서 호출한다.
+        /// </summary>
+        public void AddGuaranteedSkillSelection()
+        {
+            if (_progressionModel == null)
+            {
+                return;
+            }
+
+            _progressionModel.AddGuaranteedSelection();
+
+            if (!IsSelectionOpen)
+            {
+                OpenNextSelection();
+            }
+        }
+
         public int GetSkillLevel(string skillId)
         {
             if (string.IsNullOrWhiteSpace(skillId))


### PR DESCRIPTION
## Summary

- `LevelProgressionModel`: `AddGuaranteedSelection()` 추가 — 경험치/레벨업과 무관하게 `PendingLevelUps` 직접 증가
- `PlayerLevelSystem`: `AddGuaranteedSkillSelection()` 공개 메서드 추가 — 미니 보스 처치 등 외부 트리거에서 보장 선택 1회를 기존 레벨업 큐에 삽입
- `GuaranteedSkillSelector` (신규): `MiniBossSpawner.OnMiniBossDefeated` 구독 → `PlayerLevelSystem.AddGuaranteedSkillSelection()` 호출
- `SampleScene`: `WaveSystem`에 `GuaranteedSkillSelector` 컴포넌트 추가 및 참조 연결

레벨업과 미니 보스 처치가 동일한 `PendingLevelUps` 큐를 공유하므로 겹치는 경우에도 순서대로 처리되며, `Time.timeScale` 관리·카드 UI·스킬 효과 적용은 기존 `PlayerLevelSystem` 흐름이 그대로 담당한다.

## Test plan

- [x] 미니 보스 처치 시 스킬 강화 카드 UI가 표시됨
- [x] 레벨업과 미니 보스 처치가 겹칠 경우 순서대로 처리됨
- [x] 카드 선택 완료 후 즉시 효과 적용 및 게임 재개됨
- [x] 선택 중 `Time.timeScale = 0` 적용 확인

## 관련 이슈

- Closes #63
- 연동: #71 (`MiniBossSpawner.OnMiniBossDefeated` 이벤트 발행 측)

🤖 Generated with [Claude Code](https://claude.com/claude-code)