### PR TITLE
refactor: 전투 시스템 재점검 — 시퀀스 보스 전용 축소(#84) + 끝점 타겟팅 정렬

### DIFF
--- a/project1/Assets/Scripts/Combat/EnemyHealth.cs
+++ b/project1/Assets/Scripts/Combat/EnemyHealth.cs
@@ -9,6 +9,15 @@ namespace Mukseon.Gameplay.Combat
     public class EnemyHealth : MonoBehaviour
     {
         private static readonly List<EnemyHealth> _activeEnemies = new List<EnemyHealth>();
+
+        private static readonly SwipeDirection[] DirectionPool =
+        {
+            SwipeDirection.Up,
+            SwipeDirection.Down,
+            SwipeDirection.Left,
+            SwipeDirection.Right
+        };
+
         public static event Action<EnemyHealth> AnyEnemyDied;
         public static event Action<EnemyHealth, float> AnyEnemyDamaged;
 
@@ -57,11 +66,17 @@ namespace Mukseon.Gameplay.Combat
             }
         }
 
+        /// <summary>
+        /// 방향 시퀀스 시스템은 보스 전용이다(#84). 비어 있지 않은 시퀀스를 가진 적만
+        /// 시퀀스 기반(타격당 데미지 1 + 인덱스 전진)으로 동작하며, 그 외 적은 단일 방향 속성을 사용한다.
+        /// </summary>
+        public bool UsesAttackSequence => AttackSequence != null && _attackSequence.SequenceLength > 0;
+
         public SwipeDirection SwipeDirection
         {
             get
             {
-                if (AttackSequence != null)
+                if (UsesAttackSequence)
                 {
                     return _attackSequence.CurrentDirection;
                 }
@@ -212,14 +227,7 @@ namespace Mukseon.Gameplay.Combat
             IsTargetable = true;
             ResetHealth();
 
-            if (_attackSequence != null && _monsterData != null && _monsterData.RandomizeSequence)
-            {
-                _attackSequence.SetSequence(EnemyAttackSequence.GenerateRandomSequence((int)_maxHealth));
-            }
-            else
-            {
-                _attackSequence?.ResetSequence();
-            }
+            ConfigureDirectionForSpawn();
 
             if (_disableCollidersOnDeath)
             {
@@ -251,7 +259,19 @@ namespace Mukseon.Gameplay.Combat
             _maxHealth = _monsterData.MaxHealth;
             _moveSpeed = _monsterData.MoveSpeed;
 
-            if (_attackSequence != null)
+            ConfigureDirectionForSpawn();
+        }
+
+        /// <summary>
+        /// 스폰 시 방향 상태를 구성한다(#84).
+        /// 보스: 방향 시퀀스를 구성한다(랜덤 또는 명시 시퀀스).
+        /// 그 외 적: 시퀀스를 비우고 단일 방향 속성을 랜덤 배정한다(`combat_system.md` §1).
+        /// </summary>
+        private void ConfigureDirectionForSpawn()
+        {
+            bool isBoss = _monsterData != null && _monsterData.IsBoss;
+
+            if (isBoss && _attackSequence != null)
             {
                 if (_monsterData.RandomizeSequence)
                 {
@@ -261,6 +281,21 @@ namespace Mukseon.Gameplay.Combat
                 {
                     _attackSequence.SetSequence(_monsterData.SwipeDirectionSequence);
                 }
+                else
+                {
+                    _attackSequence.SetSequence(Array.Empty<SwipeDirection>());
+                }
+
+                return;
+            }
+
+            // 비보스: 시퀀스 미사용. 단일 방향 속성을 랜덤 배정한다.
+            // (MokgwiRoot / MaeguProjectile 등은 이후 SetSwipeDirection으로 자체 방향을 덮어쓴다.)
+            _attackSequence?.SetSequence(Array.Empty<SwipeDirection>());
+
+            if (_monsterData != null)
+            {
+                _swipeDirection = DirectionPool[UnityEngine.Random.Range(0, DirectionPool.Length)];
             }
         }
 

--- a/project1/Assets/Scripts/Combat/MonsterData.cs
+++ b/project1/Assets/Scripts/Combat/MonsterData.cs
@@ -20,6 +20,7 @@ namespace Mukseon.Gameplay.Combat
 
         // 방향 시퀀스는 보스 전용이다(#84). 비보스 적은 이 값과 무관하게 단일 방향 속성으로 동작한다.
         // (EnemyHealth.ConfigureDirectionForSpawn 에서 IsBoss로 게이팅)
+        [Header("보스 전용 — 비보스 적에는 무시됨 (#84)")]
         [SerializeField]
         private SwipeDirection[] _swipeDirectionSequence = new SwipeDirection[0];
 

--- a/project1/Assets/Scripts/Combat/MonsterData.cs
+++ b/project1/Assets/Scripts/Combat/MonsterData.cs
@@ -18,6 +18,8 @@ namespace Mukseon.Gameplay.Combat
         [SerializeField]
         private EnemyHealth _enemyPrefab;
 
+        // 방향 시퀀스는 보스 전용이다(#84). 비보스 적은 이 값과 무관하게 단일 방향 속성으로 동작한다.
+        // (EnemyHealth.ConfigureDirectionForSpawn 에서 IsBoss로 게이팅)
         [SerializeField]
         private SwipeDirection[] _swipeDirectionSequence = new SwipeDirection[0];
 

--- a/project1/Assets/Scripts/Combat/PlayerSwipeAttackController.cs
+++ b/project1/Assets/Scripts/Combat/PlayerSwipeAttackController.cs
@@ -22,7 +22,8 @@ namespace Mukseon.Gameplay.Combat
         [SerializeField]
         private string _rightAttackTrigger = "AttackRight";
 
-        public event Action<SwipeDirection> OnAttackExecuted;
+        /// <summary>공격 실행 시 발생. 방향과 스와이프 끝점(스크린 좌표)을 전달합니다.</summary>
+        public event Action<SwipeDirection, Vector2> OnAttackExecuted;
 
         private Animator _animator;
         private int _upAttackTriggerHash;
@@ -71,15 +72,15 @@ namespace Mukseon.Gameplay.Combat
             }
         }
 
-        private void HandleSwipeDetected(SwipeDirection direction)
+        private void HandleSwipeDetected(SwipeDirection direction, Vector2 endScreenPosition)
         {
-            ExecuteAttack(direction);
+            ExecuteAttack(direction, endScreenPosition);
             TriggerAttackAnimation(direction);
         }
 
-        private void ExecuteAttack(SwipeDirection direction)
+        private void ExecuteAttack(SwipeDirection direction, Vector2 endScreenPosition)
         {
-            OnAttackExecuted?.Invoke(direction);
+            OnAttackExecuted?.Invoke(direction, endScreenPosition);
 
 #if UNITY_EDITOR
             Debug.Log($"[PlayerSwipeAttackController] Attack executed by swipe: {direction}");

--- a/project1/Assets/Scripts/Combat/SwipeAttackEventListener.cs
+++ b/project1/Assets/Scripts/Combat/SwipeAttackEventListener.cs
@@ -114,13 +114,16 @@ namespace Mukseon.Gameplay.Combat
             for (int i = 0; i < selectedCount; i++)
             {
                 EnemyHealth enemyHealth = _targetBuffer[i];
-                EnemyAttackSequence attackSequence = enemyHealth.AttackSequence;
-                float actualDamage = attackSequence != null ? 1f : damage;
+
+                // 방향 시퀀스는 보스 전용(#84). 시퀀스 적은 타격당 데미지 1 + 인덱스 전진,
+                // 그 외 적은 단일 방향 타격으로 정상 데미지를 적용한다.
+                bool usesSequence = enemyHealth.UsesAttackSequence;
+                float actualDamage = usesSequence ? 1f : damage;
                 enemyHealth.ApplyDamage(actualDamage, this);
 
-                if (enemyHealth.IsAlive && attackSequence != null)
+                if (enemyHealth.IsAlive && usesSequence)
                 {
-                    attackSequence.Advance();
+                    enemyHealth.AttackSequence.Advance();
                 }
             }
 

--- a/project1/Assets/Scripts/Combat/SwipeAttackEventListener.cs
+++ b/project1/Assets/Scripts/Combat/SwipeAttackEventListener.cs
@@ -53,11 +53,6 @@ namespace Mukseon.Gameplay.Combat
                 _attackOrigin = transform;
             }
 
-            if (_camera == null)
-            {
-                _camera = Camera.main;
-            }
-
             ValidateCharacterData();
         }
 
@@ -102,13 +97,25 @@ namespace Mukseon.Gameplay.Combat
         /// </summary>
         private Vector2 ResolveAttackOrigin(Vector2 endScreenPosition)
         {
+            // Camera.main은 Awake 시점에 아직 null일 수 있으므로 사용 시점에 지연 해석한다.
+            if (_camera == null)
+            {
+                _camera = Camera.main;
+            }
+
             if (_camera != null)
             {
                 Vector3 world = _camera.ScreenToWorldPoint(endScreenPosition);
                 return new Vector2(world.x, world.y);
             }
 
-            return _attackOrigin != null ? (Vector2)_attackOrigin.position : Vector2.zero;
+            if (_attackOrigin != null)
+            {
+                return _attackOrigin.position;
+            }
+
+            Debug.LogWarning("[SwipeAttackEventListener] 카메라와 _attackOrigin이 모두 없어 월드 원점(0,0)으로 타겟팅합니다. 씬 설정을 확인하세요.");
+            return Vector2.zero;
         }
 
         private int ApplyDamage(SwipeDirection swipeDirection, Vector2 origin)

--- a/project1/Assets/Scripts/Combat/SwipeAttackEventListener.cs
+++ b/project1/Assets/Scripts/Combat/SwipeAttackEventListener.cs
@@ -18,6 +18,9 @@ namespace Mukseon.Gameplay.Combat
         [SerializeField]
         private Transform _attackOrigin;
 
+        [SerializeField]
+        private Camera _camera;
+
         [Header("Attack Settings")]
         [SerializeField, Min(0f)]
         private float _baseDamage = 1f;
@@ -50,6 +53,11 @@ namespace Mukseon.Gameplay.Combat
                 _attackOrigin = transform;
             }
 
+            if (_camera == null)
+            {
+                _camera = Camera.main;
+            }
+
             ValidateCharacterData();
         }
 
@@ -69,14 +77,16 @@ namespace Mukseon.Gameplay.Combat
             }
         }
 
-        private void HandleAttackExecuted(SwipeDirection direction)
+        private void HandleAttackExecuted(SwipeDirection direction, Vector2 endScreenPosition)
         {
             if (direction == SwipeDirection.None)
             {
                 return;
             }
 
-            int hitCount = ApplyDamage(direction);
+            // combat_system.md §2: 스와이프 끝점(Touch Up 좌표)에 가장 가까운 적을 우선 타격한다.
+            Vector2 attackOrigin = ResolveAttackOrigin(endScreenPosition);
+            int hitCount = ApplyDamage(direction, attackOrigin);
 
 #if UNITY_EDITOR
             if (_showDebugLogs)
@@ -86,13 +96,23 @@ namespace Mukseon.Gameplay.Combat
 #endif
         }
 
-        private int ApplyDamage(SwipeDirection swipeDirection)
+        /// <summary>
+        /// 타겟팅 기준점을 스와이프 끝점의 월드 좌표로 변환한다(`combat_system.md` §2).
+        /// 카메라가 없으면 공격 원점(_attackOrigin)으로 폴백한다.
+        /// </summary>
+        private Vector2 ResolveAttackOrigin(Vector2 endScreenPosition)
         {
-            if (_attackOrigin == null)
+            if (_camera != null)
             {
-                return 0;
+                Vector3 world = _camera.ScreenToWorldPoint(endScreenPosition);
+                return new Vector2(world.x, world.y);
             }
 
+            return _attackOrigin != null ? (Vector2)_attackOrigin.position : Vector2.zero;
+        }
+
+        private int ApplyDamage(SwipeDirection swipeDirection, Vector2 origin)
+        {
             float damage = ResolveDamage();
             if (damage <= 0f)
             {
@@ -100,7 +120,7 @@ namespace Mukseon.Gameplay.Combat
             }
 
             int selectedCount = SwipeAttackTargeting.SelectNearestTargets(
-                _attackOrigin.position,
+                origin,
                 swipeDirection,
                 EnemyHealth.ActiveEnemies,
                 Mathf.Max(1, ResolveTargetsPerAttack() + _bonusTargets),

--- a/project1/Assets/Scripts/Input/SwipeInputDetector.cs
+++ b/project1/Assets/Scripts/Input/SwipeInputDetector.cs
@@ -11,7 +11,8 @@ namespace Mukseon.Core.Input
         public float MinimumSwipeDistance => _minimumSwipeDistance;
         public SwipeDirection LastDetectedDirection { get; private set; } = SwipeDirection.None;
 
-        public event Action<SwipeDirection> OnSwipeDetected;
+        /// <summary>스와이프 방향이 확정된 순간 발생. 방향과 스와이프 끝점(스크린 좌표)을 전달합니다.</summary>
+        public event Action<SwipeDirection, Vector2> OnSwipeDetected;
 
         /// <summary>터치/마우스 버튼이 눌린 순간 발생. 스크린 좌표를 전달합니다.</summary>
         public event Action<Vector2> OnSwipeBegan;
@@ -104,7 +105,7 @@ namespace Mukseon.Core.Input
             }
 
             LastDetectedDirection = direction;
-            OnSwipeDetected?.Invoke(direction);
+            OnSwipeDetected?.Invoke(direction, endPosition);
 
 #if UNITY_EDITOR
             Debug.Log($"[SwipeInputDetector] Swipe detected: {direction}");

--- a/project1/Assets/Scripts/UI/GameplayHudBootstrapper.cs
+++ b/project1/Assets/Scripts/UI/GameplayHudBootstrapper.cs
@@ -742,7 +742,7 @@ namespace Mukseon.Gameplay.UI
             _sequenceHuds[enemy] = hud;
 
             EnemyAttackSequence seq = enemy.AttackSequence;
-            if (seq != null)
+            if (seq != null && enemy.UsesAttackSequence)
             {
                 hud.AdvancedHandler = _ => RefreshSequenceHud(enemy);
                 seq.OnAdvanced += hud.AdvancedHandler;
@@ -763,7 +763,7 @@ namespace Mukseon.Gameplay.UI
 
             EnemyAttackSequence seq = enemy.AttackSequence;
 
-            if (seq == null)
+            if (!enemy.UsesAttackSequence)
             {
                 hud.ArrowLabels[0].text = Arrow(enemy.SwipeDirection);
                 hud.ArrowLabels[0].style.display = DisplayStyle.Flex;

--- a/project1/Assets/Settings/Data/Monsters/Monster_AshenClaw.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_AshenClaw.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   _isBoss: 0
   _enemyPrefab: {fileID: 3535088139439741544, guid: 9f359b9056e17c241bc9c9c0ecd3976f, type: 3}
   _swipeDirectionSequence: 
-  _randomizeSequence: 1
+  _randomizeSequence: 0
   _maxHealth: 3
   _moveSpeed: 1.2
   _soulDropCount: 1

--- a/project1/Assets/Settings/Data/Monsters/Monster_BrambleIdol.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_BrambleIdol.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   _displayName: Bramble Idol
   _enemyPrefab: {fileID: 1475677598667535634, guid: dd3d8ac0cb439f64bbbaa2bbe5d1ccc0, type: 3}
   _swipeDirectionSequence:
-  _randomizeSequence: 1
+  _randomizeSequence: 0
   _maxHealth: 5
   _moveSpeed: 0.85
   _soulDropCount: 3

--- a/project1/Assets/Settings/Data/Monsters/Monster_Dureoksini.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_Dureoksini.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   _isBoss: 0
   _enemyPrefab: {fileID: 1475677598667535634, guid: 0892b944d90654243b825a22b54ccad7, type: 3}
   _swipeDirectionSequence:
-  _randomizeSequence: 1
+  _randomizeSequence: 0
   _maxHealth: 20
   _moveSpeed: 0.7
   _soulDropCount: 8

--- a/project1/Assets/Settings/Data/Monsters/Monster_DuskShade.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_DuskShade.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   _displayName: Dusk Shade
   _enemyPrefab: {fileID: 4368540737326870438, guid: 4d75fb8dd84b9fb40bbaace1f8a21592, type: 3}
   _swipeDirectionSequence:
-  _randomizeSequence: 1
+  _randomizeSequence: 0
   _maxHealth: 4
   _moveSpeed: 1.5
   _soulDropCount: 2

--- a/project1/Assets/Settings/Data/Monsters/Monster_Mangryang.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_Mangryang.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   _isBoss: 0
   _enemyPrefab: {fileID: 3535088139439741544, guid: 9f359b9056e17c241bc9c9c0ecd3976f, type: 3}
   _swipeDirectionSequence:
-  _randomizeSequence: 1
+  _randomizeSequence: 0
   _maxHealth: 6
   _moveSpeed: 1
   _soulDropCount: 2

--- a/project1/Assets/Settings/Data/Monsters/Monster_Sangwi.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_Sangwi.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   _isBoss: 0
   _enemyPrefab: {fileID: 3535088139439741544, guid: 9f359b9056e17c241bc9c9c0ecd3976f, type: 3}
   _swipeDirectionSequence:
-  _randomizeSequence: 1
+  _randomizeSequence: 0
   _maxHealth: 7
   _moveSpeed: 0.95
   _soulDropCount: 2

--- a/project1/Assets/Settings/Data/Monsters/Monster_Sonakssi.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_Sonakssi.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   _isBoss: 0
   _enemyPrefab: {fileID: 3535088139439741544, guid: 9f359b9056e17c241bc9c9c0ecd3976f, type: 3}
   _swipeDirectionSequence:
-  _randomizeSequence: 1
+  _randomizeSequence: 0
   _maxHealth: 2
   _moveSpeed: 1.3
   _soulDropCount: 1


### PR DESCRIPTION
## 개요

전투 시스템 재점검 1차. `combat_system.md` 도입으로 드러난 **현재 구현 ↔ 설계 불일치**를 정리합니다.

두 가지 변경을 한 묶음으로 다룹니다:

### 1. 방향 시퀀스 시스템 보스 전용 축소 (#84)

`combat_system.md` §5는 시퀀스를 **보스 전용**으로 정의하지만, 현재는 모든 일반 적이 시퀀스로 동작(체력=시퀀스 길이)하고 있었습니다. 일반 적·미니 보스를 **단일 방향 속성**으로 되돌립니다.

- `EnemyHealth`: `UsesAttackSequence` 도입, `ConfigureDirectionForSpawn`에서 `IsBoss`면 시퀀스 구성, 아니면 시퀀스를 비우고 **단일 방향 랜덤 배정**
- `SwipeAttackEventListener`: 시퀀스 적만 타격당 데미지 1 + 인덱스 전진, 일반 적은 **정상 데미지** 적용
- `GameplayHudBootstrapper`: 단일/시퀀스 표시 분기를 `UsesAttackSequence`로 통일
- `MonsterData`: 시퀀스 필드가 보스 전용임을 명시 (주석)
- `Monster_*.asset` 7종: `_randomizeSequence` → 0 (전부 비보스)

### 2. 스와이프 공격 타겟팅 기준을 끝점으로 변경 (combat_system.md §2)

기존엔 플레이어 중심 기준으로 가까운 적을 골랐으나, 문서는 **스와이프 끝점(Touch Up 좌표)에 가장 가까운 적** 우선 타격을 정의합니다. 해당 동작을 명세한 이슈가 없어 본 재점검 작업에 포함했습니다.

- `SwipeInputDetector`/`PlayerSwipeAttackController`: 끝점(스크린 좌표)을 이벤트 체인으로 전파
- `SwipeAttackEventListener`: 끝점을 월드 좌표로 변환해 타겟팅 기준점으로 사용 (카메라 미지정 시 `_attackOrigin` 폴백)

---

## 검증

- ✅ Unity 컴파일 오류 없음
- 보스 시퀀스/연속 할퀴기 검증은 보스 구현(#69) 영역이라 제외 (현재 보스 없음)

## 짚어둘 점

- **밸런스 변화**: 일반 적이 타격당 데미지 1 → 공격력 기반 정상 데미지로 바뀜. 특히 두억시니(HP 20)는 훨씬 빨리 죽음. 의도된 방향이나 별도 밸런스 패스(플레이테스트) 권장.
- **`EnemyAttackSequence` 컴포넌트**: 코드 게이팅으로 무력화. 보스 재사용을 위해 프리팹에서 물리적으로 제거하지 않음.

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)
