### PR TITLE
feat: 방향 속성 색상 표시 시스템 — 외곽선 글로우 + HUD 색 오브 (#82)

### DIFF
--- a/project1/Assets/Art/Materials.meta
+++ b/project1/Assets/Art/Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0e4d9c0c150cdaf47a0fb2e3ddd92046
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/project1/Assets/Art/Materials/DirectionGlow.mat
+++ b/project1/Assets/Art/Materials/DirectionGlow.mat
@@ -1,0 +1,38 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: DirectionGlow
+  m_Shader: {fileID: 4800000, guid: a9076a00fced08b449ca56c7d33116f0, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _GlowIntensity: 1.6
+    - _GlowThickness: 2.5
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _GlowColor: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/project1/Assets/Art/Materials/DirectionGlow.mat.meta
+++ b/project1/Assets/Art/Materials/DirectionGlow.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d1800a8365fe0a64a8e1ba8ad3f072af
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/project1/Assets/Art/Shaders.meta
+++ b/project1/Assets/Art/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ce056a05c28937b44ae8ddd66937ae08
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/project1/Assets/Art/Shaders/DirectionOutlineGlow.shader
+++ b/project1/Assets/Art/Shaders/DirectionOutlineGlow.shader
@@ -10,6 +10,9 @@ Shader "Mukseon/DirectionOutlineGlow"
         _GlowColor ("Glow Color", Color) = (1,1,1,1)
         _GlowThickness ("Glow Thickness (texels)", Range(0,8)) = 2.5
         _GlowIntensity ("Glow Intensity", Range(0,4)) = 1.6
+        // 아틀라스 내 스프라이트 UV 바운드(min.xy, max.xy). EnemyDirectionColorView가 주입한다.
+        // 미설정 시 전체 텍스처(0..1)로 클램핑 → 비아틀라스 단일 텍스처와 동일하게 동작.
+        _SpriteRect ("Sprite UV Rect", Vector) = (0,0,1,1)
     }
 
     SubShader
@@ -55,6 +58,7 @@ Shader "Mukseon/DirectionOutlineGlow"
             fixed4 _GlowColor;
             float _GlowThickness;
             float _GlowIntensity;
+            float4 _SpriteRect;
 
             v2f vert(appdata IN)
             {
@@ -70,16 +74,20 @@ Shader "Mukseon/DirectionOutlineGlow"
                 fixed4 tex = tex2D(_MainTex, IN.uv) * _Color * IN.color;
 
                 // 8방향 주변 알파를 샘플링해 스프라이트 바깥 외곽 글로우 강도를 계산한다.
+                // 샘플 UV를 스프라이트 자신의 UV 바운드(_SpriteRect)로 클램핑해, 아틀라스 패킹 시
+                // 오프셋이 이웃 스프라이트의 알파를 침범(bleeding)하지 않도록 한다.
                 float2 o = _MainTex_TexelSize.xy * _GlowThickness;
+                float2 uvMin = _SpriteRect.xy;
+                float2 uvMax = _SpriteRect.zw;
                 float a = 0;
-                a += tex2D(_MainTex, IN.uv + float2( o.x, 0)).a;
-                a += tex2D(_MainTex, IN.uv + float2(-o.x, 0)).a;
-                a += tex2D(_MainTex, IN.uv + float2( 0,  o.y)).a;
-                a += tex2D(_MainTex, IN.uv + float2( 0, -o.y)).a;
-                a += tex2D(_MainTex, IN.uv + float2( o.x,  o.y)).a;
-                a += tex2D(_MainTex, IN.uv + float2(-o.x, -o.y)).a;
-                a += tex2D(_MainTex, IN.uv + float2( o.x, -o.y)).a;
-                a += tex2D(_MainTex, IN.uv + float2(-o.x,  o.y)).a;
+                a += tex2D(_MainTex, clamp(IN.uv + float2( o.x, 0), uvMin, uvMax)).a;
+                a += tex2D(_MainTex, clamp(IN.uv + float2(-o.x, 0), uvMin, uvMax)).a;
+                a += tex2D(_MainTex, clamp(IN.uv + float2( 0,  o.y), uvMin, uvMax)).a;
+                a += tex2D(_MainTex, clamp(IN.uv + float2( 0, -o.y), uvMin, uvMax)).a;
+                a += tex2D(_MainTex, clamp(IN.uv + float2( o.x,  o.y), uvMin, uvMax)).a;
+                a += tex2D(_MainTex, clamp(IN.uv + float2(-o.x, -o.y), uvMin, uvMax)).a;
+                a += tex2D(_MainTex, clamp(IN.uv + float2( o.x, -o.y), uvMin, uvMax)).a;
+                a += tex2D(_MainTex, clamp(IN.uv + float2(-o.x,  o.y), uvMin, uvMax)).a;
 
                 // 스프라이트 본체 바깥(현재 알파가 낮은 곳)에서만 글로우가 보이도록 한다.
                 float outline = saturate(a) * (1.0 - tex.a);

--- a/project1/Assets/Art/Shaders/DirectionOutlineGlow.shader
+++ b/project1/Assets/Art/Shaders/DirectionOutlineGlow.shader
@@ -1,0 +1,101 @@
+Shader "Mukseon/DirectionOutlineGlow"
+{
+    // 방향 속성 색상 외곽선 글로우(#82, combat_system.md §3).
+    // _GlowColor는 EnemyDirectionColorView에서 MaterialPropertyBlock으로 주입한다.
+    // 파이프라인 비의존(UnityCG) 언릿 스프라이트 셰이더 — URP 2D에서도 렌더된다.
+    Properties
+    {
+        [PerRendererData] _MainTex ("Sprite Texture", 2D) = "white" {}
+        _Color ("Tint", Color) = (1,1,1,1)
+        _GlowColor ("Glow Color", Color) = (1,1,1,1)
+        _GlowThickness ("Glow Thickness (texels)", Range(0,8)) = 2.5
+        _GlowIntensity ("Glow Intensity", Range(0,4)) = 1.6
+    }
+
+    SubShader
+    {
+        Tags
+        {
+            "Queue"="Transparent"
+            "RenderType"="Transparent"
+            "IgnoreProjector"="True"
+            "PreviewType"="Plane"
+            "CanUseSpriteAtlas"="True"
+        }
+
+        Cull Off
+        Lighting Off
+        ZWrite Off
+        Blend SrcAlpha OneMinusSrcAlpha
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float4 color  : COLOR;
+                float2 uv     : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float4 pos   : SV_POSITION;
+                float4 color : COLOR;
+                float2 uv    : TEXCOORD0;
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_TexelSize;
+            fixed4 _Color;
+            fixed4 _GlowColor;
+            float _GlowThickness;
+            float _GlowIntensity;
+
+            v2f vert(appdata IN)
+            {
+                v2f o;
+                o.pos = UnityObjectToClipPos(IN.vertex);
+                o.uv = IN.uv;
+                o.color = IN.color;
+                return o;
+            }
+
+            fixed4 frag(v2f IN) : SV_Target
+            {
+                fixed4 tex = tex2D(_MainTex, IN.uv) * _Color * IN.color;
+
+                // 8방향 주변 알파를 샘플링해 스프라이트 바깥 외곽 글로우 강도를 계산한다.
+                float2 o = _MainTex_TexelSize.xy * _GlowThickness;
+                float a = 0;
+                a += tex2D(_MainTex, IN.uv + float2( o.x, 0)).a;
+                a += tex2D(_MainTex, IN.uv + float2(-o.x, 0)).a;
+                a += tex2D(_MainTex, IN.uv + float2( 0,  o.y)).a;
+                a += tex2D(_MainTex, IN.uv + float2( 0, -o.y)).a;
+                a += tex2D(_MainTex, IN.uv + float2( o.x,  o.y)).a;
+                a += tex2D(_MainTex, IN.uv + float2(-o.x, -o.y)).a;
+                a += tex2D(_MainTex, IN.uv + float2( o.x, -o.y)).a;
+                a += tex2D(_MainTex, IN.uv + float2(-o.x,  o.y)).a;
+
+                // 스프라이트 본체 바깥(현재 알파가 낮은 곳)에서만 글로우가 보이도록 한다.
+                float outline = saturate(a) * (1.0 - tex.a);
+                float glowAlpha = saturate(outline * _GlowIntensity) * _GlowColor.a;
+
+                // 본체 색을 글로우 위에 합성 (스프라이트가 글로우를 가린다).
+                fixed3 rgb = tex.rgb * tex.a + _GlowColor.rgb * glowAlpha * (1.0 - tex.a);
+                fixed outA = saturate(tex.a + glowAlpha);
+
+                // Blend가 SrcAlpha 기준이므로 스트레이트 컬러로 되돌린다.
+                fixed3 outRGB = outA > 1e-4 ? rgb / outA : fixed3(0, 0, 0);
+                return fixed4(outRGB, outA);
+            }
+            ENDCG
+        }
+    }
+
+    Fallback "Sprites/Default"
+}

--- a/project1/Assets/Art/Shaders/DirectionOutlineGlow.shader.meta
+++ b/project1/Assets/Art/Shaders/DirectionOutlineGlow.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: a9076a00fced08b449ca56c7d33116f0
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/project1/Assets/Prefabs/Enemies/Boss_Dureoksini.prefab
+++ b/project1/Assets/Prefabs/Enemies/Boss_Dureoksini.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 1831119107564088829}
   - component: {fileID: 110446678007002424}
   - component: {fileID: 6676783505557286248}
+  - component: {fileID: 8970587817756802101}
   m_Layer: 0
   m_Name: Boss_Dureoksini
   m_TagString: Untagged
@@ -63,7 +64,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: d1800a8365fe0a64a8e1ba8ad3f072af, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -192,6 +193,7 @@ MonoBehaviour:
   _movePattern: 0
   _playerTarget: {fileID: 0}
   _riseHeight: 10
+  _keepDistance: 5
 --- !u!114 &6676783505557286248
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -205,3 +207,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyAttackSequence
   _sequence: 
+--- !u!114 &8970587817756802101
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5516339678559892061}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 430d9217983d07c42b488f40585b62e9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionColorView
+  _enemyHealth: {fileID: 1475677598667535634}
+  _spriteRenderer: {fileID: 5588491822506949314}
+  _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
+  _glowColorProperty: _GlowColor

--- a/project1/Assets/Prefabs/Enemies/Boss_Dureoksini.prefab
+++ b/project1/Assets/Prefabs/Enemies/Boss_Dureoksini.prefab
@@ -193,7 +193,6 @@ MonoBehaviour:
   _movePattern: 0
   _playerTarget: {fileID: 0}
   _riseHeight: 10
-  _keepDistance: 5
 --- !u!114 &6676783505557286248
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/project1/Assets/Prefabs/Enemies/Dokkaebibul.prefab
+++ b/project1/Assets/Prefabs/Enemies/Dokkaebibul.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 2996619713416633372}
   - component: {fileID: 905724965566422729}
   - component: {fileID: 3191558659866761560}
+  - component: {fileID: 286823776668359395}
   m_Layer: 0
   m_Name: Dokkaebibul
   m_TagString: Untagged
@@ -62,7 +63,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: d1800a8365fe0a64a8e1ba8ad3f072af, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -193,3 +194,19 @@ MonoBehaviour:
   _experiencePerOrb: 1
   _dropRadius: 0.3
   _monsterData: {fileID: 0}
+--- !u!114 &286823776668359395
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5147906851200314034}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 430d9217983d07c42b488f40585b62e9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionColorView
+  _enemyHealth: {fileID: 2996619713416633372}
+  _spriteRenderer: {fileID: 2857221759240280049}
+  _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
+  _glowColorProperty: _GlowColor

--- a/project1/Assets/Prefabs/Enemies/Dummy_Down.prefab
+++ b/project1/Assets/Prefabs/Enemies/Dummy_Down.prefab
@@ -193,7 +193,6 @@ MonoBehaviour:
   _movePattern: 0
   _playerTarget: {fileID: 0}
   _riseHeight: 10
-  _keepDistance: 5
 --- !u!114 &902457377154407016
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/project1/Assets/Prefabs/Enemies/Dummy_Down.prefab
+++ b/project1/Assets/Prefabs/Enemies/Dummy_Down.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 2488382620803013241}
   - component: {fileID: 707632565690213840}
   - component: {fileID: 902457377154407016}
+  - component: {fileID: 2164090938067278628}
   m_Layer: 0
   m_Name: Dummy_Down
   m_TagString: Untagged
@@ -63,7 +64,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: d1800a8365fe0a64a8e1ba8ad3f072af, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -192,6 +193,7 @@ MonoBehaviour:
   _movePattern: 0
   _playerTarget: {fileID: 0}
   _riseHeight: 10
+  _keepDistance: 5
 --- !u!114 &902457377154407016
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -205,3 +207,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyAttackSequence
   _sequence: 020000000300000004000000
+--- !u!114 &2164090938067278628
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6892844264584007441}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 430d9217983d07c42b488f40585b62e9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionColorView
+  _enemyHealth: {fileID: 4234627494100266546}
+  _spriteRenderer: {fileID: 5073888473262603188}
+  _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
+  _glowColorProperty: _GlowColor

--- a/project1/Assets/Prefabs/Enemies/Dummy_Left.prefab
+++ b/project1/Assets/Prefabs/Enemies/Dummy_Left.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 4829204163632401306}
   - component: {fileID: 2394660698194004625}
   - component: {fileID: 2776196048433973373}
+  - component: {fileID: 7387759474708353289}
   m_Layer: 0
   m_Name: Dummy_Left
   m_TagString: Untagged
@@ -63,7 +64,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: d1800a8365fe0a64a8e1ba8ad3f072af, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -192,6 +193,7 @@ MonoBehaviour:
   _movePattern: 0
   _playerTarget: {fileID: 0}
   _riseHeight: 10
+  _keepDistance: 5
 --- !u!114 &2776196048433973373
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -205,3 +207,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyAttackSequence
   _sequence: 030000000200000001000000
+--- !u!114 &7387759474708353289
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6848363840087502861}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 430d9217983d07c42b488f40585b62e9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionColorView
+  _enemyHealth: {fileID: 4368540737326870438}
+  _spriteRenderer: {fileID: 2472191227068787534}
+  _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
+  _glowColorProperty: _GlowColor

--- a/project1/Assets/Prefabs/Enemies/Dummy_Left.prefab
+++ b/project1/Assets/Prefabs/Enemies/Dummy_Left.prefab
@@ -193,7 +193,6 @@ MonoBehaviour:
   _movePattern: 0
   _playerTarget: {fileID: 0}
   _riseHeight: 10
-  _keepDistance: 5
 --- !u!114 &2776196048433973373
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/project1/Assets/Prefabs/Enemies/Dummy_Right.prefab
+++ b/project1/Assets/Prefabs/Enemies/Dummy_Right.prefab
@@ -193,7 +193,6 @@ MonoBehaviour:
   _movePattern: 0
   _playerTarget: {fileID: 0}
   _riseHeight: 10
-  _keepDistance: 5
 --- !u!114 &8797208339621773822
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/project1/Assets/Prefabs/Enemies/Dummy_Right.prefab
+++ b/project1/Assets/Prefabs/Enemies/Dummy_Right.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 1831119107564088829}
   - component: {fileID: 110446678007002424}
   - component: {fileID: 8797208339621773822}
+  - component: {fileID: 3917159128010735540}
   m_Layer: 0
   m_Name: Dummy_Right
   m_TagString: Untagged
@@ -63,7 +64,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: d1800a8365fe0a64a8e1ba8ad3f072af, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -192,6 +193,7 @@ MonoBehaviour:
   _movePattern: 0
   _playerTarget: {fileID: 0}
   _riseHeight: 10
+  _keepDistance: 5
 --- !u!114 &8797208339621773822
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -205,3 +207,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyAttackSequence
   _sequence: 040000000100000002000000
+--- !u!114 &3917159128010735540
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5516339678559892061}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 430d9217983d07c42b488f40585b62e9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionColorView
+  _enemyHealth: {fileID: 1475677598667535634}
+  _spriteRenderer: {fileID: 5588491822506949314}
+  _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
+  _glowColorProperty: _GlowColor

--- a/project1/Assets/Prefabs/Enemies/Dummy_Up.prefab
+++ b/project1/Assets/Prefabs/Enemies/Dummy_Up.prefab
@@ -193,7 +193,6 @@ MonoBehaviour:
   _movePattern: 0
   _playerTarget: {fileID: 0}
   _riseHeight: 10
-  _keepDistance: 5
 --- !u!114 &8489735811375365995
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/project1/Assets/Prefabs/Enemies/Dummy_Up.prefab
+++ b/project1/Assets/Prefabs/Enemies/Dummy_Up.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 8930110949059020394}
   - component: {fileID: 753179079726369400}
   - component: {fileID: 8489735811375365995}
+  - component: {fileID: 2372149767770650528}
   m_Layer: 0
   m_Name: Dummy_Up
   m_TagString: Untagged
@@ -63,7 +64,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: d1800a8365fe0a64a8e1ba8ad3f072af, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -192,6 +193,7 @@ MonoBehaviour:
   _movePattern: 0
   _playerTarget: {fileID: 0}
   _riseHeight: 10
+  _keepDistance: 5
 --- !u!114 &8489735811375365995
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -205,3 +207,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyAttackSequence
   _sequence: 010000000400000003000000
+--- !u!114 &2372149767770650528
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7248748341038818817}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 430d9217983d07c42b488f40585b62e9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionColorView
+  _enemyHealth: {fileID: 3535088139439741544}
+  _spriteRenderer: {fileID: 5162172495293148243}
+  _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
+  _glowColorProperty: _GlowColor

--- a/project1/Assets/Prefabs/Enemies/Eodukshini.prefab
+++ b/project1/Assets/Prefabs/Enemies/Eodukshini.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 8264697197640977571}
   - component: {fileID: 38237289102441794}
   - component: {fileID: 4619870557861803263}
+  - component: {fileID: 2701141439845745873}
   m_Layer: 0
   m_Name: Eodukshini
   m_TagString: Untagged
@@ -62,7 +63,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: d1800a8365fe0a64a8e1ba8ad3f072af, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -195,3 +196,19 @@ MonoBehaviour:
   _experiencePerOrb: 1
   _dropRadius: 0.3
   _monsterData: {fileID: 0}
+--- !u!114 &2701141439845745873
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1629169777572763157}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 430d9217983d07c42b488f40585b62e9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionColorView
+  _enemyHealth: {fileID: 8264697197640977571}
+  _spriteRenderer: {fileID: 89702068495939522}
+  _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
+  _glowColorProperty: _GlowColor

--- a/project1/Assets/Prefabs/Enemies/Maegu.prefab
+++ b/project1/Assets/Prefabs/Enemies/Maegu.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 3582893766163220544}
   - component: {fileID: 2003974151819554565}
   - component: {fileID: 6088130567171206265}
+  - component: {fileID: 4226264732907119970}
   m_Layer: 0
   m_Name: Maegu
   m_TagString: Untagged
@@ -63,7 +64,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: d1800a8365fe0a64a8e1ba8ad3f072af, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -209,3 +210,19 @@ MonoBehaviour:
   _experiencePerOrb: 1
   _dropRadius: 0.3
   _monsterData: {fileID: 0}
+--- !u!114 &4226264732907119970
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7950429823264773093}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 430d9217983d07c42b488f40585b62e9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionColorView
+  _enemyHealth: {fileID: 2073897433596552694}
+  _spriteRenderer: {fileID: 1924894169639563460}
+  _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
+  _glowColorProperty: _GlowColor

--- a/project1/Assets/Prefabs/Enemies/MaeguProjectile.prefab
+++ b/project1/Assets/Prefabs/Enemies/MaeguProjectile.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 9208102700381465589}
   - component: {fileID: 4969748495108068196}
   - component: {fileID: 6345066049086962115}
+  - component: {fileID: 1744564233771736578}
   m_Layer: 0
   m_Name: MaeguProjectile
   m_TagString: Untagged
@@ -61,7 +62,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: d1800a8365fe0a64a8e1ba8ad3f072af, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -171,3 +172,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.MaeguProjectile
   _lifetime: 6
+--- !u!114 &1744564233771736578
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6052417191953375108}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 430d9217983d07c42b488f40585b62e9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionColorView
+  _enemyHealth: {fileID: 4969748495108068196}
+  _spriteRenderer: {fileID: 6297030343194614764}
+  _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
+  _glowColorProperty: _GlowColor

--- a/project1/Assets/Prefabs/Enemies/MokgwiEnemy.prefab
+++ b/project1/Assets/Prefabs/Enemies/MokgwiEnemy.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 287392638280517337}
   - component: {fileID: 8322485774661296830}
   - component: {fileID: 6758741756703222207}
+  - component: {fileID: 6381372049556447655}
   m_Layer: 0
   m_Name: MokgwiEnemy
   m_TagString: Untagged
@@ -61,7 +62,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: d1800a8365fe0a64a8e1ba8ad3f072af, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -176,3 +177,19 @@ MonoBehaviour:
   _rootPrefab: {fileID: 386968887035504875, guid: 54e93149305e511448590bfb9763acaf, type: 3}
   _rootSpawnInterval: 3
   _maxRootsOnMap: 20
+--- !u!114 &6381372049556447655
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7157714492135509594}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 430d9217983d07c42b488f40585b62e9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionColorView
+  _enemyHealth: {fileID: 8322485774661296830}
+  _spriteRenderer: {fileID: 6335133232443173733}
+  _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
+  _glowColorProperty: _GlowColor

--- a/project1/Assets/Prefabs/Enemies/MokgwiRoot.prefab
+++ b/project1/Assets/Prefabs/Enemies/MokgwiRoot.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 665222801325094029}
   - component: {fileID: 2152396636063808086}
   - component: {fileID: 9185215621374291727}
+  - component: {fileID: 792862037092224575}
   m_Layer: 0
   m_Name: MokgwiRoot
   m_TagString: Untagged
@@ -61,7 +62,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: d1800a8365fe0a64a8e1ba8ad3f072af, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -170,3 +171,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 77e5393b47c84da4491911c9c98b12d9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.MokgwiRoot
+--- !u!114 &792862037092224575
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 386968887035504875}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 430d9217983d07c42b488f40585b62e9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionColorView
+  _enemyHealth: {fileID: 2152396636063808086}
+  _spriteRenderer: {fileID: 1207403830801882080}
+  _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
+  _glowColorProperty: _GlowColor

--- a/project1/Assets/Scripts/Combat/DirectionColorPalette.cs
+++ b/project1/Assets/Scripts/Combat/DirectionColorPalette.cs
@@ -1,0 +1,82 @@
+using Mukseon.Core.Input;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 방향 속성(Up/Down/Left/Right)을 색상으로 매핑한다(#82, `combat_system.md` §3).
+    /// 한국 전통 오방색에서 흑·백을 제외하고 재구성한 디폴트 값을 가지며,
+    /// 에셋이 지정되지 않아도 동작하도록 정적 기본값 폴백을 제공한다.
+    /// 유저 커스텀 매핑/저장은 후행 이슈(#83)에서 다룬다.
+    /// </summary>
+    [CreateAssetMenu(fileName = "DirectionColorPalette", menuName = "Mukseon/Data/Direction Color Palette")]
+    public class DirectionColorPalette : ScriptableObject
+    {
+        // 디폴트 색상 — 오방색 재구성 (청록 / 황금 / 적 / 녹)
+        private static readonly Color DefaultUp = new Color(0.16f, 0.70f, 0.74f);    // 청(靑) — 청록색
+        private static readonly Color DefaultDown = new Color(0.95f, 0.78f, 0.22f);  // 황(黃) — 황금색
+        private static readonly Color DefaultLeft = new Color(0.85f, 0.27f, 0.27f);  // 적(赤) — 붉은색
+        private static readonly Color DefaultRight = new Color(0.32f, 0.72f, 0.36f); // 녹(綠) — 초록색
+        private static readonly Color DefaultNone = new Color(0.6f, 0.6f, 0.6f);     // 방향 없음 — 회색
+
+        [SerializeField]
+        private Color _up = DefaultUp;
+
+        [SerializeField]
+        private Color _down = DefaultDown;
+
+        [SerializeField]
+        private Color _left = DefaultLeft;
+
+        [SerializeField]
+        private Color _right = DefaultRight;
+
+        [SerializeField]
+        private Color _none = DefaultNone;
+
+        /// <summary>지정된 방향의 색상을 반환한다.</summary>
+        public Color GetColor(SwipeDirection direction)
+        {
+            switch (direction)
+            {
+                case SwipeDirection.Up:
+                    return _up;
+                case SwipeDirection.Down:
+                    return _down;
+                case SwipeDirection.Left:
+                    return _left;
+                case SwipeDirection.Right:
+                    return _right;
+                default:
+                    return _none;
+            }
+        }
+
+        /// <summary>
+        /// 팔레트 에셋이 없을 때 사용하는 정적 디폴트 색상.
+        /// 컴포넌트가 팔레트 참조 없이도 동작하도록 보장한다.
+        /// </summary>
+        public static Color DefaultColor(SwipeDirection direction)
+        {
+            switch (direction)
+            {
+                case SwipeDirection.Up:
+                    return DefaultUp;
+                case SwipeDirection.Down:
+                    return DefaultDown;
+                case SwipeDirection.Left:
+                    return DefaultLeft;
+                case SwipeDirection.Right:
+                    return DefaultRight;
+                default:
+                    return DefaultNone;
+            }
+        }
+
+        /// <summary>팔레트가 null이어도 안전하게 색을 조회하는 헬퍼.</summary>
+        public static Color Resolve(DirectionColorPalette palette, SwipeDirection direction)
+        {
+            return palette != null ? palette.GetColor(direction) : DefaultColor(direction);
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/DirectionColorPalette.cs.meta
+++ b/project1/Assets/Scripts/Combat/DirectionColorPalette.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 97bd93ae15c780a4985c198c12d246b4

--- a/project1/Assets/Scripts/Combat/EnemyDirectionColorView.cs
+++ b/project1/Assets/Scripts/Combat/EnemyDirectionColorView.cs
@@ -25,9 +25,15 @@ namespace Mukseon.Gameplay.Combat
         [Tooltip("글로우 색상을 적용할 셰이더 프로퍼티명. 외곽선 글로우 머티리얼과 일치해야 한다.")]
         private string _glowColorProperty = "_GlowColor";
 
+        // 외곽선 글로우 셰이더(DirectionOutlineGlow)가 아틀라스 블리딩 방지를 위해 읽는 스프라이트 UV 바운드.
+        private const string SpriteRectProperty = "_SpriteRect";
+
         private MaterialPropertyBlock _propertyBlock;
         private EnemyAttackSequence _attackSequence;
         private int _glowColorId;
+        private int _spriteRectId;
+        private Sprite _boundsSprite;
+        private Vector4 _spriteBounds = new Vector4(0f, 0f, 1f, 1f);
 
         private void Awake()
         {
@@ -43,6 +49,7 @@ namespace Mukseon.Gameplay.Combat
 
             _attackSequence = GetComponent<EnemyAttackSequence>();
             _glowColorId = Shader.PropertyToID(_glowColorProperty);
+            _spriteRectId = Shader.PropertyToID(SpriteRectProperty);
             _propertyBlock = new MaterialPropertyBlock();
         }
 
@@ -95,10 +102,63 @@ namespace Mukseon.Gameplay.Combat
                 return;
             }
 
-            Color color = DirectionColorPalette.Resolve(_palette, _enemyHealth.SwipeDirection);
+            Color color = ResolveColor(_enemyHealth.SwipeDirection);
             _spriteRenderer.GetPropertyBlock(_propertyBlock);
             _propertyBlock.SetColor(_glowColorId, color);
+            _propertyBlock.SetVector(_spriteRectId, ResolveSpriteUvBounds());
             _spriteRenderer.SetPropertyBlock(_propertyBlock);
+        }
+
+        /// <summary>
+        /// 이 적의 외곽선 글로우와 동일한 팔레트 인스턴스로 지정 방향의 색을 조회한다(#82).
+        /// HUD 색 오브가 글로우와 같은 색을 쓰도록 외부(<c>GameplayHudBootstrapper</c>)에서 사용한다.
+        /// </summary>
+        public Color ResolveColor(SwipeDirection direction)
+        {
+            return DirectionColorPalette.Resolve(_palette, direction);
+        }
+
+        /// <summary>
+        /// 현재 스프라이트의 아틀라스 내 UV 바운드(min.xy, max.xy)를 반환한다(#82).
+        /// 글로우 셰이더가 8방향 샘플을 이 바운드로 클램핑해, 아틀라스 패킹 시
+        /// 이웃 스프라이트의 알파를 침범(bleeding)하는 것을 막는다. 스프라이트가 바뀔 때만 재계산한다.
+        /// </summary>
+        private Vector4 ResolveSpriteUvBounds()
+        {
+            Sprite sprite = _spriteRenderer.sprite;
+            if (ReferenceEquals(sprite, _boundsSprite))
+            {
+                return _spriteBounds;
+            }
+
+            _boundsSprite = sprite;
+            _spriteBounds = ComputeSpriteUvBounds(sprite);
+            return _spriteBounds;
+        }
+
+        private static Vector4 ComputeSpriteUvBounds(Sprite sprite)
+        {
+            // 바운드를 모르면 전체 텍스처(0..1)로 폴백 — 셰이더 클램핑이 사실상 비활성화된다.
+            if (sprite == null)
+            {
+                return new Vector4(0f, 0f, 1f, 1f);
+            }
+
+            Vector2[] uv = sprite.uv;
+            if (uv == null || uv.Length == 0)
+            {
+                return new Vector4(0f, 0f, 1f, 1f);
+            }
+
+            Vector2 min = uv[0];
+            Vector2 max = uv[0];
+            for (int i = 1; i < uv.Length; i++)
+            {
+                min = Vector2.Min(min, uv[i]);
+                max = Vector2.Max(max, uv[i]);
+            }
+
+            return new Vector4(min.x, min.y, max.x, max.y);
         }
     }
 }

--- a/project1/Assets/Scripts/Combat/EnemyDirectionColorView.cs
+++ b/project1/Assets/Scripts/Combat/EnemyDirectionColorView.cs
@@ -1,0 +1,104 @@
+using Mukseon.Core.Input;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 적의 현재 방향 속성을 색상으로 시각화한다(#82, `combat_system.md` §3 — 외곽선 글로우).
+    /// SpriteRenderer의 MaterialPropertyBlock에 방향 색상을 글로우 프로퍼티로 적용한다.
+    /// 글로우 셰이더/머티리얼이 아직 연결되지 않아도 안전하게 동작한다(프로퍼티 미존재 시 no-op).
+    /// </summary>
+    [RequireComponent(typeof(EnemyHealth))]
+    [DisallowMultipleComponent]
+    public class EnemyDirectionColorView : MonoBehaviour
+    {
+        [SerializeField]
+        private EnemyHealth _enemyHealth;
+
+        [SerializeField]
+        private SpriteRenderer _spriteRenderer;
+
+        [SerializeField]
+        private DirectionColorPalette _palette;
+
+        [SerializeField]
+        [Tooltip("글로우 색상을 적용할 셰이더 프로퍼티명. 외곽선 글로우 머티리얼과 일치해야 한다.")]
+        private string _glowColorProperty = "_GlowColor";
+
+        private MaterialPropertyBlock _propertyBlock;
+        private EnemyAttackSequence _attackSequence;
+        private int _glowColorId;
+
+        private void Awake()
+        {
+            if (_enemyHealth == null)
+            {
+                _enemyHealth = GetComponent<EnemyHealth>();
+            }
+
+            if (_spriteRenderer == null)
+            {
+                _spriteRenderer = GetComponentInChildren<SpriteRenderer>();
+            }
+
+            _attackSequence = GetComponent<EnemyAttackSequence>();
+            _glowColorId = Shader.PropertyToID(_glowColorProperty);
+            _propertyBlock = new MaterialPropertyBlock();
+        }
+
+        private void OnEnable()
+        {
+            if (_enemyHealth != null)
+            {
+                _enemyHealth.OnDirectionChanged += HandleDirectionChanged;
+            }
+
+            if (_attackSequence != null)
+            {
+                _attackSequence.OnAdvanced += HandleSequenceAdvanced;
+                _attackSequence.OnSequenceSet += ApplyCurrentColor;
+            }
+
+            // 스폰/재사용 직후 현재 방향 색을 즉시 반영한다.
+            ApplyCurrentColor();
+        }
+
+        private void OnDisable()
+        {
+            if (_enemyHealth != null)
+            {
+                _enemyHealth.OnDirectionChanged -= HandleDirectionChanged;
+            }
+
+            if (_attackSequence != null)
+            {
+                _attackSequence.OnAdvanced -= HandleSequenceAdvanced;
+                _attackSequence.OnSequenceSet -= ApplyCurrentColor;
+            }
+        }
+
+        private void HandleDirectionChanged(SwipeDirection direction)
+        {
+            ApplyCurrentColor();
+        }
+
+        private void HandleSequenceAdvanced(int currentIndex)
+        {
+            ApplyCurrentColor();
+        }
+
+        /// <summary>현재 방향(시퀀스 적은 현재 타격 대상 방향) 색을 글로우로 적용한다.</summary>
+        public void ApplyCurrentColor()
+        {
+            if (_spriteRenderer == null || _enemyHealth == null)
+            {
+                return;
+            }
+
+            Color color = DirectionColorPalette.Resolve(_palette, _enemyHealth.SwipeDirection);
+            _spriteRenderer.GetPropertyBlock(_propertyBlock);
+            _propertyBlock.SetColor(_glowColorId, color);
+            _spriteRenderer.SetPropertyBlock(_propertyBlock);
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/EnemyDirectionColorView.cs
+++ b/project1/Assets/Scripts/Combat/EnemyDirectionColorView.cs
@@ -84,14 +84,26 @@ namespace Mukseon.Gameplay.Combat
             }
         }
 
-        private void HandleDirectionChanged(SwipeDirection direction)
+        // 이벤트 시그니처상 인자를 받지만 현재 방향은 ApplyCurrentColor가 직접 조회하므로 사용하지 않는다.
+        private void HandleDirectionChanged(SwipeDirection _)
         {
             ApplyCurrentColor();
         }
 
-        private void HandleSequenceAdvanced(int currentIndex)
+        private void HandleSequenceAdvanced(int _)
         {
             ApplyCurrentColor();
+        }
+
+        private void Update()
+        {
+            // 애니메이션 등으로 SpriteRenderer의 스프라이트가 방향 이벤트와 무관하게 교체되면
+            // 셰이더에 주입된 UV 바운드가 낡게 된다(아틀라스 적의 프레임 간 바운드 차이).
+            // 스프라이트 변경을 감지해 다시 적용한다(#82). 변경이 없으면 캐시 비교만 수행한다.
+            if (_spriteRenderer != null && !ReferenceEquals(_spriteRenderer.sprite, _boundsSprite))
+            {
+                ApplyCurrentColor();
+            }
         }
 
         /// <summary>현재 방향(시퀀스 적은 현재 타격 대상 방향) 색을 글로우로 적용한다.</summary>

--- a/project1/Assets/Scripts/Combat/EnemyDirectionColorView.cs.meta
+++ b/project1/Assets/Scripts/Combat/EnemyDirectionColorView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 430d9217983d07c42b488f40585b62e9

--- a/project1/Assets/Scripts/Combat/EnemyHealth.cs
+++ b/project1/Assets/Scripts/Combat/EnemyHealth.cs
@@ -95,6 +95,9 @@ namespace Mukseon.Gameplay.Combat
         public event Action OnDied;
         public event Action<EnemyHealth> OnDeath;
 
+        /// <summary>현재 방향 속성이 (재)배정될 때 발생(#82). 색상 시각화 갱신에 사용된다.</summary>
+        public event Action<SwipeDirection> OnDirectionChanged;
+
         private void Awake()
         {
             _attackSequence = GetComponent<EnemyAttackSequence>();
@@ -201,6 +204,7 @@ namespace Mukseon.Gameplay.Combat
         public void SetSwipeDirection(SwipeDirection swipeDirection)
         {
             _swipeDirection = swipeDirection;
+            OnDirectionChanged?.Invoke(swipeDirection);
         }
 
         public void SetMoveSpeed(float moveSpeed)
@@ -296,6 +300,7 @@ namespace Mukseon.Gameplay.Combat
             if (_monsterData != null)
             {
                 _swipeDirection = DirectionPool[UnityEngine.Random.Range(0, DirectionPool.Length)];
+                OnDirectionChanged?.Invoke(_swipeDirection);
             }
         }
 

--- a/project1/Assets/Scripts/Combat/EnemyHealth.cs
+++ b/project1/Assets/Scripts/Combat/EnemyHealth.cs
@@ -299,8 +299,9 @@ namespace Mukseon.Gameplay.Combat
 
             if (_monsterData != null)
             {
-                _swipeDirection = DirectionPool[UnityEngine.Random.Range(0, DirectionPool.Length)];
-                OnDirectionChanged?.Invoke(_swipeDirection);
+                // 방향 변경의 단일 진입점을 유지한다: _swipeDirection 직접 할당 + 이벤트 수동 발행 대신
+                // SetSwipeDirection을 경유해, 이후 메서드에 로직이 추가돼도 이 경로가 누락되지 않게 한다.
+                SetSwipeDirection(DirectionPool[UnityEngine.Random.Range(0, DirectionPool.Length)]);
             }
         }
 

--- a/project1/Assets/Scripts/UI/GameplayHudBootstrapper.cs
+++ b/project1/Assets/Scripts/UI/GameplayHudBootstrapper.cs
@@ -765,11 +765,8 @@ namespace Mukseon.Gameplay.UI
 
             if (!enemy.UsesAttackSequence)
             {
-                hud.ArrowLabels[0].text = Arrow(enemy.SwipeDirection);
-                hud.ArrowLabels[0].style.display = DisplayStyle.Flex;
-                hud.ArrowLabels[0].style.color = new Color(1f, 0.94f, 0.5f);
-                hud.ArrowLabels[0].style.fontSize = 24f;
-                hud.ArrowLabels[0].style.unityFontStyleAndWeight = FontStyle.Bold;
+                // 색상 1차 표시(#82): 단일 방향 적은 현재 방향 색 오브 하나만 표시한다.
+                ApplyOrb(hud.ArrowLabels[0], enemy.SwipeDirection, true);
                 for (int i = 1; i < 3; i++)
                 {
                     hud.ArrowLabels[i].style.display = DisplayStyle.None;
@@ -790,21 +787,8 @@ namespace Mukseon.Gameplay.UI
 
                 if (seqIdx < total)
                 {
-                    label.style.display = DisplayStyle.Flex;
-                    label.text = Arrow(seq.Sequence[seqIdx]);
-
-                    if (i == 0)
-                    {
-                        label.style.color = new Color(1f, 0.94f, 0.2f);
-                        label.style.fontSize = 28f;
-                        label.style.unityFontStyleAndWeight = FontStyle.Bold;
-                    }
-                    else
-                    {
-                        label.style.color = new Color(1f, 1f, 1f, 0.45f);
-                        label.style.fontSize = 20f;
-                        label.style.unityFontStyleAndWeight = FontStyle.Normal;
-                    }
+                    // 시퀀스 적(보스): 현재 타격 대상(i==0)만 강조 색 오브, 이후는 흐린 색 오브.
+                    ApplyOrb(label, seq.Sequence[seqIdx], i == 0);
                 }
                 else
                 {
@@ -989,6 +973,7 @@ namespace Mukseon.Gameplay.UI
             container.style.translate = new Translate(Length.Percent(-50f), 0f);
         }
 
+        // 접근성 화살표 표시(#83)에서 재사용 예정. 현재 기본 표시는 색 오브.
         private static string Arrow(SwipeDirection direction)
         {
             switch (direction)
@@ -1004,6 +989,45 @@ namespace Mukseon.Gameplay.UI
                 default:
                     return "•";
             }
+        }
+
+        /// <summary>
+        /// 방향 표시 슬롯을 색 오브(둥근 색 구슬)로 스타일링한다(#82, `combat_system.md` §3).
+        /// current=true면 현재 타격 대상으로 크게·불투명·밝은 외곽선 강조, false면 작게·반투명.
+        /// 색상은 팔레트 정적 디폴트(글로우와 동일 매핑)를 사용한다.
+        /// </summary>
+        private static void ApplyOrb(Label slot, SwipeDirection direction, bool current)
+        {
+            slot.style.display = DisplayStyle.Flex;
+            slot.text = string.Empty;
+
+            float size = current ? 20f : 14f;
+            slot.style.width = size;
+            slot.style.height = size;
+            slot.style.marginLeft = 3f;
+            slot.style.marginRight = 3f;
+
+            float radius = size * 0.5f;
+            slot.style.borderTopLeftRadius = radius;
+            slot.style.borderTopRightRadius = radius;
+            slot.style.borderBottomLeftRadius = radius;
+            slot.style.borderBottomRightRadius = radius;
+
+            Color color = DirectionColorPalette.DefaultColor(direction);
+            color.a = current ? 1f : 0.5f;
+            slot.style.backgroundColor = color;
+
+            float border = current ? 2f : 0f;
+            slot.style.borderTopWidth = border;
+            slot.style.borderBottomWidth = border;
+            slot.style.borderLeftWidth = border;
+            slot.style.borderRightWidth = border;
+
+            Color borderColor = new Color(1f, 1f, 1f, current ? 0.9f : 0f);
+            slot.style.borderTopColor = borderColor;
+            slot.style.borderBottomColor = borderColor;
+            slot.style.borderLeftColor = borderColor;
+            slot.style.borderRightColor = borderColor;
         }
 
         private static VisualElement Panel(VisualElement parent, float left, float top, float width, float height)

--- a/project1/Assets/Scripts/UI/GameplayHudBootstrapper.cs
+++ b/project1/Assets/Scripts/UI/GameplayHudBootstrapper.cs
@@ -78,6 +78,8 @@ namespace Mukseon.Gameplay.UI
             public Label EllipsisLabel;
             public Action<int> AdvancedHandler;
             public Action SequenceSetHandler;
+            public Action<SwipeDirection> DirectionChangedHandler;
+            public EnemyDirectionColorView ColorView;
         }
 
         private readonly HashSet<EnemyHealth> _trackedEnemies = new HashSet<EnemyHealth>();
@@ -658,6 +660,11 @@ namespace Mukseon.Gameplay.UI
 
             if (enemy != null && _sequenceHuds.TryGetValue(enemy, out SequenceHud hud))
             {
+                if (hud.DirectionChangedHandler != null)
+                {
+                    enemy.OnDirectionChanged -= hud.DirectionChangedHandler;
+                }
+
                 EnemyAttackSequence seq = enemy.AttackSequence;
                 if (seq != null)
                 {
@@ -739,7 +746,14 @@ namespace Mukseon.Gameplay.UI
             container.Add(ellipsis);
             hud.EllipsisLabel = ellipsis;
 
+            // 색 오브 색상을 적의 외곽선 글로우와 동일한 팔레트 인스턴스에서 가져오기 위해 캐싱한다(#82).
+            hud.ColorView = enemy.GetComponent<EnemyDirectionColorView>();
             _sequenceHuds[enemy] = hud;
+
+            // 단일 방향 적(예: MokgwiRoot, MaeguProjectile)은 스폰 이후 SetSwipeDirection으로
+            // 방향이 동적으로 바뀔 수 있으므로, 방향 변경 시 색 오브가 갱신되도록 구독한다(#82).
+            hud.DirectionChangedHandler = _ => RefreshSequenceHud(enemy);
+            enemy.OnDirectionChanged += hud.DirectionChangedHandler;
 
             EnemyAttackSequence seq = enemy.AttackSequence;
             if (seq != null && enemy.UsesAttackSequence)
@@ -766,7 +780,7 @@ namespace Mukseon.Gameplay.UI
             if (!enemy.UsesAttackSequence)
             {
                 // 색상 1차 표시(#82): 단일 방향 적은 현재 방향 색 오브 하나만 표시한다.
-                ApplyOrb(hud.ArrowLabels[0], enemy.SwipeDirection, true);
+                ApplyOrb(hud.ArrowLabels[0], ResolveDirectionColor(hud, enemy.SwipeDirection), true);
                 for (int i = 1; i < 3; i++)
                 {
                     hud.ArrowLabels[i].style.display = DisplayStyle.None;
@@ -788,7 +802,7 @@ namespace Mukseon.Gameplay.UI
                 if (seqIdx < total)
                 {
                     // 시퀀스 적(보스): 현재 타격 대상(i==0)만 강조 색 오브, 이후는 흐린 색 오브.
-                    ApplyOrb(label, seq.Sequence[seqIdx], i == 0);
+                    ApplyOrb(label, ResolveDirectionColor(hud, seq.Sequence[seqIdx]), i == 0);
                 }
                 else
                 {
@@ -992,11 +1006,23 @@ namespace Mukseon.Gameplay.UI
         }
 
         /// <summary>
+        /// 색 오브 색상을 적의 <see cref="EnemyDirectionColorView"/>(외곽선 글로우와 동일한 팔레트
+        /// 인스턴스)에서 조회한다(#82). 뷰가 없으면 정적 디폴트로 폴백해, HUD 색 오브와 월드의
+        /// 외곽선 글로우 색이 팔레트 에셋을 수정하더라도 항상 일치하도록 보장한다.
+        /// </summary>
+        private static Color ResolveDirectionColor(SequenceHud hud, SwipeDirection direction)
+        {
+            return hud.ColorView != null
+                ? hud.ColorView.ResolveColor(direction)
+                : DirectionColorPalette.DefaultColor(direction);
+        }
+
+        /// <summary>
         /// 방향 표시 슬롯을 색 오브(둥근 색 구슬)로 스타일링한다(#82, `combat_system.md` §3).
         /// current=true면 현재 타격 대상으로 크게·불투명·밝은 외곽선 강조, false면 작게·반투명.
-        /// 색상은 팔레트 정적 디폴트(글로우와 동일 매핑)를 사용한다.
+        /// 색상은 <see cref="ResolveDirectionColor"/>가 적 팔레트에서 해석한 값을 받는다.
         /// </summary>
-        private static void ApplyOrb(Label slot, SwipeDirection direction, bool current)
+        private static void ApplyOrb(Label slot, Color color, bool current)
         {
             slot.style.display = DisplayStyle.Flex;
             slot.text = string.Empty;
@@ -1013,7 +1039,6 @@ namespace Mukseon.Gameplay.UI
             slot.style.borderBottomLeftRadius = radius;
             slot.style.borderBottomRightRadius = radius;
 
-            Color color = DirectionColorPalette.DefaultColor(direction);
             color.a = current ? 1f : 0.5f;
             slot.style.backgroundColor = color;
 

--- a/project1/Assets/Settings/Data/Visual.meta
+++ b/project1/Assets/Settings/Data/Visual.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0018682c82a987c419e7644601a014be
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/project1/Assets/Settings/Data/Visual/DirectionColorPalette.asset
+++ b/project1/Assets/Settings/Data/Visual/DirectionColorPalette.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 97bd93ae15c780a4985c198c12d246b4, type: 3}
+  m_Name: DirectionColorPalette
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.DirectionColorPalette
+  _up: {r: 0.16, g: 0.7, b: 0.74, a: 1}
+  _down: {r: 0.95, g: 0.78, b: 0.22, a: 1}
+  _left: {r: 0.85, g: 0.27, b: 0.27, a: 1}
+  _right: {r: 0.32, g: 0.72, b: 0.36, a: 1}
+  _none: {r: 0.6, g: 0.6, b: 0.6, a: 1}

--- a/project1/Assets/Settings/Data/Visual/DirectionColorPalette.asset.meta
+++ b/project1/Assets/Settings/Data/Visual/DirectionColorPalette.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: da07367ae5ae2a340ac99c70977e6437
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 개요

전투 시스템 재점검 2단계. 방향 속성 시각화를 화살표 1차 → **색상 1차**로 전환합니다(`combat_system.md` §3). 외곽선 글로우 + HUD 색 오브 두 표시를 구현합니다. (표시 방식 선택 / 색맹 화살표 병행 / 커스텀 매핑 저장은 후행 #83)

## 변경 내용

### C# 토대 (ee02538)
- **DirectionColorPalette** (ScriptableObject): 방향→색상 매핑 + 조회 API. 오방색 재구성 디폴트 + 정적 폴백(`Resolve`)으로 에셋 미연결 시에도 동작.
- **EnemyHealth.OnDirectionChanged**: 방향 (재)배정 시 이벤트 발행. 색상 갱신 트리거. 방향 배정은 `SetSwipeDirection` 단일 진입점 경유.
- **EnemyDirectionColorView**: SpriteRenderer MaterialPropertyBlock에 방향 색을 `_GlowColor`로 적용. 방향 변경·시퀀스 진행 이벤트에 반응. 글로우 머티리얼 미연결 시 안전 no-op.
- **GameplayHudBootstrapper**: 방향 표시를 색 오브(둥근 색 구슬)로 렌더링. 시퀀스 적은 현재 타격 대상만 강조. 화살표는 #83 접근성용으로 메서드 유지.

### 셰이더·에셋·프리팹 (e316529)
- **DirectionOutlineGlow.shader**: 파이프라인 비의존 언릿 스프라이트 외곽선 글로우. 주변 알파 8방향 샘플링. URP 2D 렌더 확인.
- **DirectionGlow.mat** + **DirectionColorPalette.asset** 생성.
- 적 프리팹 11종에 색상 뷰 + 글로우 머티리얼 연결 (Dummy 4종 / Maegu / MaeguProjectile / Mokgwi / MokgwiRoot / Dokkaebibul / Eodukshini / Boss_Dureoksini). DarknessOverlay 제외.
  - 프리팹 변경은 **색상 뷰 컴포넌트 추가 + 글로우 머티리얼 연결**로 한정. 재직렬화로 딸려왔던 `EnemyMover._keepDistance` 기본값 라인은 정리해 diff에서 제외(동작 영향 없음).

## 코드리뷰 반영

### 1차 리뷰 (gemini-code-assist)
- HUD가 단일 방향 적의 `OnDirectionChanged`를 구독/해제하도록 추가 → `SetSwipeDirection`으로 방향이 바뀌는 적(MokgwiRoot/MaeguProjectile 등)도 색 오브 실시간 갱신.
- HUD 색 오브를 적 `EnemyDirectionColorView`(글로우와 동일 팔레트 인스턴스)에서 해석 → 팔레트 에셋 수정 시에도 글로우/HUD 색 일치 보장.
- 셰이더에 `_SpriteRect` 추가, 8방향 샘플 UV를 스프라이트 바운드로 클램핑 → 아틀라스 패킹 시 이웃 스프라이트 알파 침범(bleeding) 방지.

### 2차 리뷰
- **`ConfigureDirectionForSpawn` 우회 제거**: `_swipeDirection` 직접 할당 + 이벤트 수동 발행 대신 `SetSwipeDirection` 경유로 방향 변경의 단일 진입점 유지.
- **애니메이션 스프라이트 대응**: `EnemyDirectionColorView.Update`에서 SpriteRenderer 스프라이트 교체를 감지해 UV 바운드를 재주입(아틀라스 적의 프레임 간 바운드 차이 방어).
- **미사용 인자 명시**: 이벤트 핸들러(`HandleDirectionChanged`/`HandleSequenceAdvanced`)의 미사용 인자를 `_`로 표기해 의도를 명확화.
- `Arrow()`는 #83(색맹 접근성 화살표 병행) 재사용 예정으로 의도적 유지.

### 3차 리뷰
- **`_keepDistance` 직렬화 라인 제거**: 색상 뷰 컴포넌트 추가로 재직렬화되며 딸려온 `EnemyMover._keepDistance` 기본값(5) 라인을 5개 프리팹(Boss_Dureoksini / Dummy 4종)에서 제거해, 프리팹 diff를 의도된 변경으로 한정.

## 검증

- ✅ C# 컴파일 오류 없음 / 셰이더 컴파일 메시지 0 / 신규 콘솔 에러 없음
- ✅ 프리팹 연동 확인 (글로우 머티리얼 + 뷰 스크립트 참조)

## 남은 작업 (후속)

- ⏳ **글로우 시각 튜닝** — 두께/강도(`_GlowThickness`, `_GlowIntensity`)는 플레이 모드 확인 후 조정 예정. 현재 퀄리티는 1차 수준이며 별도 품질 향상 패스로 다룬다.
- 🔄 동적 변환(#68) 연동 — 이벤트 훅(`OnDirectionChanged`)은 준비됨, #68 구현 시 자동 연동.

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)
