### PR TITLE
feat: 방향 속성 동적 변환 시스템 — 누적 카운트 / 확률 변환 / 시각 피드백 (#68)

### DIFF
--- a/project1/Assets/Prefabs/Enemies/Dokkaebibul.prefab
+++ b/project1/Assets/Prefabs/Enemies/Dokkaebibul.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 905724965566422729}
   - component: {fileID: 3191558659866761560}
   - component: {fileID: 286823776668359395}
+  - component: {fileID: 986459759498208246}
   m_Layer: 0
   m_Name: Dokkaebibul
   m_TagString: Untagged
@@ -210,3 +211,17 @@ MonoBehaviour:
   _spriteRenderer: {fileID: 2857221759240280049}
   _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
   _glowColorProperty: _GlowColor
+--- !u!114 &986459759498208246
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5147906851200314034}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 14befdec210748342a13614bec6adcee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionConverter
+  _enemyHealth: {fileID: 2996619713416633372}
+  _config: {fileID: 11400000, guid: f1a9553ab329986408b9f0c2d2067df3, type: 2}

--- a/project1/Assets/Prefabs/Enemies/Dummy_Down.prefab
+++ b/project1/Assets/Prefabs/Enemies/Dummy_Down.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 707632565690213840}
   - component: {fileID: 902457377154407016}
   - component: {fileID: 2164090938067278628}
+  - component: {fileID: 1050207443342037178}
   m_Layer: 0
   m_Name: Dummy_Down
   m_TagString: Untagged
@@ -222,3 +223,17 @@ MonoBehaviour:
   _spriteRenderer: {fileID: 5073888473262603188}
   _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
   _glowColorProperty: _GlowColor
+--- !u!114 &1050207443342037178
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6892844264584007441}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 14befdec210748342a13614bec6adcee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionConverter
+  _enemyHealth: {fileID: 4234627494100266546}
+  _config: {fileID: 11400000, guid: f1a9553ab329986408b9f0c2d2067df3, type: 2}

--- a/project1/Assets/Prefabs/Enemies/Dummy_Left.prefab
+++ b/project1/Assets/Prefabs/Enemies/Dummy_Left.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 2394660698194004625}
   - component: {fileID: 2776196048433973373}
   - component: {fileID: 7387759474708353289}
+  - component: {fileID: 4611500699197383874}
   m_Layer: 0
   m_Name: Dummy_Left
   m_TagString: Untagged
@@ -222,3 +223,17 @@ MonoBehaviour:
   _spriteRenderer: {fileID: 2472191227068787534}
   _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
   _glowColorProperty: _GlowColor
+--- !u!114 &4611500699197383874
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6848363840087502861}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 14befdec210748342a13614bec6adcee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionConverter
+  _enemyHealth: {fileID: 4368540737326870438}
+  _config: {fileID: 11400000, guid: f1a9553ab329986408b9f0c2d2067df3, type: 2}

--- a/project1/Assets/Prefabs/Enemies/Dummy_Right.prefab
+++ b/project1/Assets/Prefabs/Enemies/Dummy_Right.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 110446678007002424}
   - component: {fileID: 8797208339621773822}
   - component: {fileID: 3917159128010735540}
+  - component: {fileID: 2685217770002757526}
   m_Layer: 0
   m_Name: Dummy_Right
   m_TagString: Untagged
@@ -222,3 +223,17 @@ MonoBehaviour:
   _spriteRenderer: {fileID: 5588491822506949314}
   _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
   _glowColorProperty: _GlowColor
+--- !u!114 &2685217770002757526
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5516339678559892061}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 14befdec210748342a13614bec6adcee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionConverter
+  _enemyHealth: {fileID: 1475677598667535634}
+  _config: {fileID: 11400000, guid: f1a9553ab329986408b9f0c2d2067df3, type: 2}

--- a/project1/Assets/Prefabs/Enemies/Dummy_Up.prefab
+++ b/project1/Assets/Prefabs/Enemies/Dummy_Up.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 753179079726369400}
   - component: {fileID: 8489735811375365995}
   - component: {fileID: 2372149767770650528}
+  - component: {fileID: 7355930812239250675}
   m_Layer: 0
   m_Name: Dummy_Up
   m_TagString: Untagged
@@ -222,3 +223,17 @@ MonoBehaviour:
   _spriteRenderer: {fileID: 5162172495293148243}
   _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
   _glowColorProperty: _GlowColor
+--- !u!114 &7355930812239250675
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7248748341038818817}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 14befdec210748342a13614bec6adcee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionConverter
+  _enemyHealth: {fileID: 3535088139439741544}
+  _config: {fileID: 11400000, guid: f1a9553ab329986408b9f0c2d2067df3, type: 2}

--- a/project1/Assets/Prefabs/Enemies/Eodukshini.prefab
+++ b/project1/Assets/Prefabs/Enemies/Eodukshini.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 38237289102441794}
   - component: {fileID: 4619870557861803263}
   - component: {fileID: 2701141439845745873}
+  - component: {fileID: 3788330022052152550}
   m_Layer: 0
   m_Name: Eodukshini
   m_TagString: Untagged
@@ -212,3 +213,17 @@ MonoBehaviour:
   _spriteRenderer: {fileID: 89702068495939522}
   _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
   _glowColorProperty: _GlowColor
+--- !u!114 &3788330022052152550
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1629169777572763157}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 14befdec210748342a13614bec6adcee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionConverter
+  _enemyHealth: {fileID: 8264697197640977571}
+  _config: {fileID: 11400000, guid: f1a9553ab329986408b9f0c2d2067df3, type: 2}

--- a/project1/Assets/Prefabs/Enemies/Maegu.prefab
+++ b/project1/Assets/Prefabs/Enemies/Maegu.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 2003974151819554565}
   - component: {fileID: 6088130567171206265}
   - component: {fileID: 4226264732907119970}
+  - component: {fileID: 4322963437025646320}
   m_Layer: 0
   m_Name: Maegu
   m_TagString: Untagged
@@ -226,3 +227,17 @@ MonoBehaviour:
   _spriteRenderer: {fileID: 1924894169639563460}
   _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
   _glowColorProperty: _GlowColor
+--- !u!114 &4322963437025646320
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7950429823264773093}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 14befdec210748342a13614bec6adcee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionConverter
+  _enemyHealth: {fileID: 2073897433596552694}
+  _config: {fileID: 11400000, guid: f1a9553ab329986408b9f0c2d2067df3, type: 2}

--- a/project1/Assets/Prefabs/Enemies/MaeguProjectile.prefab
+++ b/project1/Assets/Prefabs/Enemies/MaeguProjectile.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 4969748495108068196}
   - component: {fileID: 6345066049086962115}
   - component: {fileID: 1744564233771736578}
+  - component: {fileID: 8641598991015300937}
   m_Layer: 0
   m_Name: MaeguProjectile
   m_TagString: Untagged
@@ -188,3 +189,17 @@ MonoBehaviour:
   _spriteRenderer: {fileID: 6297030343194614764}
   _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
   _glowColorProperty: _GlowColor
+--- !u!114 &8641598991015300937
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6052417191953375108}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 14befdec210748342a13614bec6adcee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionConverter
+  _enemyHealth: {fileID: 4969748495108068196}
+  _config: {fileID: 11400000, guid: f1a9553ab329986408b9f0c2d2067df3, type: 2}

--- a/project1/Assets/Prefabs/Enemies/MokgwiEnemy.prefab
+++ b/project1/Assets/Prefabs/Enemies/MokgwiEnemy.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 8322485774661296830}
   - component: {fileID: 6758741756703222207}
   - component: {fileID: 6381372049556447655}
+  - component: {fileID: 5896460207554604860}
   m_Layer: 0
   m_Name: MokgwiEnemy
   m_TagString: Untagged
@@ -193,3 +194,17 @@ MonoBehaviour:
   _spriteRenderer: {fileID: 6335133232443173733}
   _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
   _glowColorProperty: _GlowColor
+--- !u!114 &5896460207554604860
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7157714492135509594}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 14befdec210748342a13614bec6adcee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionConverter
+  _enemyHealth: {fileID: 8322485774661296830}
+  _config: {fileID: 11400000, guid: f1a9553ab329986408b9f0c2d2067df3, type: 2}

--- a/project1/Assets/Prefabs/Enemies/MokgwiRoot.prefab
+++ b/project1/Assets/Prefabs/Enemies/MokgwiRoot.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 2152396636063808086}
   - component: {fileID: 9185215621374291727}
   - component: {fileID: 792862037092224575}
+  - component: {fileID: 6511171215557517011}
   m_Layer: 0
   m_Name: MokgwiRoot
   m_TagString: Untagged
@@ -187,3 +188,17 @@ MonoBehaviour:
   _spriteRenderer: {fileID: 1207403830801882080}
   _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
   _glowColorProperty: _GlowColor
+--- !u!114 &6511171215557517011
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 386968887035504875}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 14befdec210748342a13614bec6adcee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionConverter
+  _enemyHealth: {fileID: 2152396636063808086}
+  _config: {fileID: 11400000, guid: f1a9553ab329986408b9f0c2d2067df3, type: 2}

--- a/project1/Assets/Scripts/Combat/DirectionConversionConfig.cs
+++ b/project1/Assets/Scripts/Combat/DirectionConversionConfig.cs
@@ -1,0 +1,57 @@
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 방향 속성 동적 변환 시스템 설정(#68, `direction_dynamic_system.md`).
+    /// 누적 타격 카운트별 방향 변환 확률 테이블과 변환 임박 연출 시작 임계값을 정의한다.
+    /// 에셋이 지정되지 않아도 동작하도록 정적 디폴트 폴백을 제공한다.
+    /// 보스/미니 보스 전용 확률 테이블은 후속 작업(선택적)에서 다룬다.
+    /// </summary>
+    [CreateAssetMenu(fileName = "DirectionConversionConfig", menuName = "Mukseon/Data/Direction Conversion Config")]
+    public class DirectionConversionConfig : ScriptableObject
+    {
+        // 디폴트 확률 곡선(초안, direction_dynamic_system.md §확률 곡선).
+        // index 0 = 1회차 타격, 마지막 = "N회 이상". 플레이테스트 후 조정 예정.
+        private static readonly float[] DefaultProbabilities = { 0f, 0.10f, 0.25f, 0.50f, 0.75f };
+        private const int DefaultImminentThreshold = 2;
+
+        [SerializeField]
+        [Tooltip("누적 타격 수별 방향 변환 확률(0~1). index 0 = 1회차. 카운트가 길이를 넘으면 마지막 값을 사용한다.")]
+        private float[] _conversionProbabilities = { 0f, 0.10f, 0.25f, 0.50f, 0.75f };
+
+        [SerializeField, Min(1)]
+        [Tooltip("변환 임박 연출(흔들림/깜빡임)을 시작하는 누적 타격 카운트.")]
+        private int _imminentThresholdCount = DefaultImminentThreshold;
+
+        /// <summary>변환 임박 연출을 시작하는 누적 타격 카운트(1 이상).</summary>
+        public int ImminentThresholdCount => Mathf.Max(1, _imminentThresholdCount);
+
+        /// <summary>누적 타격 카운트(1 이상)에 대응하는 방향 변환 확률(0~1)을 반환한다.</summary>
+        public float GetConversionChance(int hitCount)
+        {
+            return Resolve(_conversionProbabilities, hitCount);
+        }
+
+        /// <summary>에셋이 없을 때 사용하는 정적 디폴트 변환 확률.</summary>
+        public static float DefaultConversionChance(int hitCount)
+        {
+            return Resolve(DefaultProbabilities, hitCount);
+        }
+
+        /// <summary>설정이 없을 때 사용하는 정적 디폴트 임박 임계값.</summary>
+        public static int DefaultImminentThresholdCount => DefaultImminentThreshold;
+
+        private static float Resolve(float[] table, int hitCount)
+        {
+            if (table == null || table.Length == 0 || hitCount <= 0)
+            {
+                return 0f;
+            }
+
+            // 카운트가 테이블 길이를 넘어서면 마지막 값("N회 이상")으로 클램핑한다.
+            int index = Mathf.Min(hitCount, table.Length) - 1;
+            return Mathf.Clamp01(table[index]);
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/DirectionConversionConfig.cs
+++ b/project1/Assets/Scripts/Combat/DirectionConversionConfig.cs
@@ -18,7 +18,9 @@ namespace Mukseon.Gameplay.Combat
 
         [SerializeField]
         [Tooltip("누적 타격 수별 방향 변환 확률(0~1). index 0 = 1회차. 카운트가 길이를 넘으면 마지막 값을 사용한다.")]
-        private float[] _conversionProbabilities = { 0f, 0.10f, 0.25f, 0.50f, 0.75f };
+        // 정적 폴백과 동일한 초안값을 공유한다(이중 관리 방지). Unity 직렬화 시 값이 복사되어 에셋은 독립 동작하고,
+        // 에셋 없이 실행할 때만 DefaultProbabilities가 폴백으로 사용된다. 어느 쪽도 배열 내용을 변경하지 않는다.
+        private float[] _conversionProbabilities = DefaultProbabilities;
 
         [SerializeField, Min(1)]
         [Tooltip("변환 임박 연출(흔들림/깜빡임)을 시작하는 누적 타격 카운트.")]

--- a/project1/Assets/Scripts/Combat/DirectionConversionConfig.cs.meta
+++ b/project1/Assets/Scripts/Combat/DirectionConversionConfig.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a43b212a125c09249a15bd9b788aaed7

--- a/project1/Assets/Scripts/Combat/EnemyDirectionColorView.cs
+++ b/project1/Assets/Scripts/Combat/EnemyDirectionColorView.cs
@@ -131,13 +131,14 @@ namespace Mukseon.Gameplay.Combat
             ApplyCurrentColor();
         }
 
-        // 변환 임박 강도 갱신(#68). 0이 되면 평상 색으로 복귀한다.
-        private void HandleHitCountChanged(int count, float intensity)
+        // 변환 임박 강도 갱신(#68). 0이 되면 평상 색으로 복귀한다. 카운트 값은 피드백에 쓰지 않으므로 무시한다.
+        private void HandleHitCountChanged(int _, float intensity)
         {
             _imminence = Mathf.Clamp01(intensity);
         }
 
         // 방향 변환 순간(#68): 흰색 플래시를 시작한다. 색 전환 자체는 OnDirectionChanged가 처리한다.
+        // from/to는 현재 미사용이나, 향후 변환 연출(먹물 번짐 파티클 등)을 방향별로 분기하기 위해 시그니처를 유지한다.
         private void HandleConverted(SwipeDirection from, SwipeDirection to)
         {
             _flashTimer = _convertFlashDuration;

--- a/project1/Assets/Scripts/Combat/EnemyDirectionColorView.cs
+++ b/project1/Assets/Scripts/Combat/EnemyDirectionColorView.cs
@@ -25,6 +25,19 @@ namespace Mukseon.Gameplay.Combat
         [Tooltip("글로우 색상을 적용할 셰이더 프로퍼티명. 외곽선 글로우 머티리얼과 일치해야 한다.")]
         private string _glowColorProperty = "_GlowColor";
 
+        [Header("동적 변환 피드백 (#68)")]
+        [SerializeField, Min(0f)]
+        [Tooltip("변환 임박 시 글로우 깜빡임 속도.")]
+        private float _imminentBlinkSpeed = 9f;
+
+        [SerializeField, Range(0f, 1f)]
+        [Tooltip("변환 임박 깜빡임이 흰색으로 섞이는 최대 비율.")]
+        private float _imminentBlinkAmount = 0.7f;
+
+        [SerializeField, Min(0.01f)]
+        [Tooltip("방향 변환 순간 흰색 플래시 지속 시간(초).")]
+        private float _convertFlashDuration = 0.25f;
+
         // 외곽선 글로우 셰이더(DirectionOutlineGlow)가 아틀라스 블리딩 방지를 위해 읽는 스프라이트 UV 바운드.
         private const string SpriteRectProperty = "_SpriteRect";
 
@@ -34,6 +47,11 @@ namespace Mukseon.Gameplay.Combat
         private int _spriteRectId;
         private Sprite _boundsSprite;
         private Vector4 _spriteBounds = new Vector4(0f, 0f, 1f, 1f);
+
+        private EnemyDirectionConverter _converter;
+        private float _imminence;   // 0~1, 변환 임박 강도
+        private float _flashTimer;  // 변환 순간 플래시 잔여 시간
+        private bool _pulseActive;  // 현재 펄스/플래시로 글로우 색을 덮어쓰는 중인지
 
         private void Awake()
         {
@@ -48,6 +66,7 @@ namespace Mukseon.Gameplay.Combat
             }
 
             _attackSequence = GetComponent<EnemyAttackSequence>();
+            _converter = GetComponent<EnemyDirectionConverter>();
             _glowColorId = Shader.PropertyToID(_glowColorProperty);
             _spriteRectId = Shader.PropertyToID(SpriteRectProperty);
             _propertyBlock = new MaterialPropertyBlock();
@@ -66,6 +85,17 @@ namespace Mukseon.Gameplay.Combat
                 _attackSequence.OnSequenceSet += ApplyCurrentColor;
             }
 
+            if (_converter != null)
+            {
+                _converter.OnHitCountChanged += HandleHitCountChanged;
+                _converter.OnConverted += HandleConverted;
+            }
+
+            // 풀 재사용 직후 변환 피드백 상태를 초기화한다.
+            _imminence = 0f;
+            _flashTimer = 0f;
+            _pulseActive = false;
+
             // 스폰/재사용 직후 현재 방향 색을 즉시 반영한다.
             ApplyCurrentColor();
         }
@@ -82,6 +112,12 @@ namespace Mukseon.Gameplay.Combat
                 _attackSequence.OnAdvanced -= HandleSequenceAdvanced;
                 _attackSequence.OnSequenceSet -= ApplyCurrentColor;
             }
+
+            if (_converter != null)
+            {
+                _converter.OnHitCountChanged -= HandleHitCountChanged;
+                _converter.OnConverted -= HandleConverted;
+            }
         }
 
         // 이벤트 시그니처상 인자를 받지만 현재 방향은 ApplyCurrentColor가 직접 조회하므로 사용하지 않는다.
@@ -95,6 +131,18 @@ namespace Mukseon.Gameplay.Combat
             ApplyCurrentColor();
         }
 
+        // 변환 임박 강도 갱신(#68). 0이 되면 평상 색으로 복귀한다.
+        private void HandleHitCountChanged(int count, float intensity)
+        {
+            _imminence = Mathf.Clamp01(intensity);
+        }
+
+        // 방향 변환 순간(#68): 흰색 플래시를 시작한다. 색 전환 자체는 OnDirectionChanged가 처리한다.
+        private void HandleConverted(SwipeDirection from, SwipeDirection to)
+        {
+            _flashTimer = _convertFlashDuration;
+        }
+
         private void Update()
         {
             // 애니메이션 등으로 SpriteRenderer의 스프라이트가 방향 이벤트와 무관하게 교체되면
@@ -104,6 +152,58 @@ namespace Mukseon.Gameplay.Combat
             {
                 ApplyCurrentColor();
             }
+
+            UpdateConversionFeedback();
+        }
+
+        /// <summary>
+        /// 변환 임박 깜빡임 + 변환 순간 플래시를 글로우 색에 반영한다(#68).
+        /// 임박/플래시가 없으면 평상 색으로 1회 복귀 후 매 프레임 쓰기를 멈춘다.
+        /// </summary>
+        private void UpdateConversionFeedback()
+        {
+            if (_spriteRenderer == null || _enemyHealth == null)
+            {
+                return;
+            }
+
+            bool flashing = _flashTimer > 0f;
+            if (flashing)
+            {
+                _flashTimer -= Time.deltaTime;
+            }
+
+            bool imminent = _imminence > 0f;
+            if (!imminent && !flashing)
+            {
+                if (_pulseActive)
+                {
+                    // 펄스 종료 → 평상 색으로 복귀(이후 이벤트 발생 전까지 매 프레임 쓰기 없음).
+                    _pulseActive = false;
+                    ApplyCurrentColor();
+                }
+
+                return;
+            }
+
+            _pulseActive = true;
+
+            float blink = 0f;
+            if (imminent)
+            {
+                // 임박 깜빡임: 강도가 높을수록 빠르고 강하게 흰색으로 점멸한다.
+                float wave = Mathf.Sin(Time.time * _imminentBlinkSpeed * (0.5f + _imminence)) * 0.5f + 0.5f;
+                blink = wave * _imminentBlinkAmount * _imminence;
+            }
+
+            if (flashing)
+            {
+                // 변환 순간 강한 흰색 플래시(시간에 따라 감쇠).
+                blink = Mathf.Max(blink, Mathf.Clamp01(_flashTimer / Mathf.Max(0.01f, _convertFlashDuration)));
+            }
+
+            Color glow = Color.Lerp(ResolveColor(_enemyHealth.SwipeDirection), Color.white, blink);
+            WriteGlow(glow);
         }
 
         /// <summary>현재 방향(시퀀스 적은 현재 타격 대상 방향) 색을 글로우로 적용한다.</summary>
@@ -114,9 +214,14 @@ namespace Mukseon.Gameplay.Combat
                 return;
             }
 
-            Color color = ResolveColor(_enemyHealth.SwipeDirection);
+            WriteGlow(ResolveColor(_enemyHealth.SwipeDirection));
+        }
+
+        /// <summary>주어진 글로우 색과 현재 스프라이트 UV 바운드를 MaterialPropertyBlock으로 적용한다.</summary>
+        private void WriteGlow(Color glow)
+        {
             _spriteRenderer.GetPropertyBlock(_propertyBlock);
-            _propertyBlock.SetColor(_glowColorId, color);
+            _propertyBlock.SetColor(_glowColorId, glow);
             _propertyBlock.SetVector(_spriteRectId, ResolveSpriteUvBounds());
             _spriteRenderer.SetPropertyBlock(_propertyBlock);
         }

--- a/project1/Assets/Scripts/Combat/EnemyDirectionConverter.cs
+++ b/project1/Assets/Scripts/Combat/EnemyDirectionConverter.cs
@@ -29,7 +29,9 @@ namespace Mukseon.Gameplay.Combat
         private DirectionConversionConfig _config;
 
         private int _hitCount;
-        private int _lastSwipeId = int.MinValue;
+        // 센티넬은 -1: _swipeId는 0에서 시작해 증가하므로(SwipeAttackEventListener) 절대 충돌하지 않는다.
+        // int.MinValue를 쓰면 _swipeId가 오버플로우해 int.MinValue로 반전될 때 첫 유효 타격이 잘못 차단될 수 있다.
+        private int _lastSwipeId = -1;
 
         /// <summary>누적 타격 카운트가 변할 때 발생. (현재 카운트, 변환 임박 강도 0~1). 흔들림/깜빡임 연출용.</summary>
         public event Action<int, float> OnHitCountChanged;
@@ -99,7 +101,7 @@ namespace Mukseon.Gameplay.Combat
         private void ResetCount()
         {
             _hitCount = 0;
-            _lastSwipeId = int.MinValue;
+            _lastSwipeId = -1;
             OnHitCountChanged?.Invoke(0, 0f);
         }
 

--- a/project1/Assets/Scripts/Combat/EnemyDirectionConverter.cs
+++ b/project1/Assets/Scripts/Combat/EnemyDirectionConverter.cs
@@ -1,0 +1,135 @@
+using System;
+using Mukseon.Core.Input;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 방향 속성 동적 변환(#68, `direction_dynamic_system.md`).
+    /// 같은 적을 동일 방향으로 반복 타격할수록 방향이 변환될 확률이 누적되고,
+    /// 확률 발동 시 현재 방향을 제외한 3방향 중 하나로 즉시 전환된다(카운트 리셋).
+    /// 색상 전환은 <see cref="EnemyHealth.OnDirectionChanged"/>를 통해 색상 시스템(#82)이 자동 반영한다.
+    /// </summary>
+    [RequireComponent(typeof(EnemyHealth))]
+    [DisallowMultipleComponent]
+    public class EnemyDirectionConverter : MonoBehaviour
+    {
+        private static readonly SwipeDirection[] Directions =
+        {
+            SwipeDirection.Up,
+            SwipeDirection.Down,
+            SwipeDirection.Left,
+            SwipeDirection.Right
+        };
+
+        [SerializeField]
+        private EnemyHealth _enemyHealth;
+
+        [SerializeField]
+        private DirectionConversionConfig _config;
+
+        private int _hitCount;
+        private int _lastSwipeId = int.MinValue;
+
+        /// <summary>누적 타격 카운트가 변할 때 발생. (현재 카운트, 변환 임박 강도 0~1). 흔들림/깜빡임 연출용.</summary>
+        public event Action<int, float> OnHitCountChanged;
+
+        /// <summary>방향 변환이 발동된 순간 발생. (이전 방향, 새 방향). 먹물 번짐 등 변환 연출 트리거용.</summary>
+        public event Action<SwipeDirection, SwipeDirection> OnConverted;
+
+        /// <summary>현재 누적 타격 카운트.</summary>
+        public int HitCount => _hitCount;
+
+        private void Awake()
+        {
+            if (_enemyHealth == null)
+            {
+                _enemyHealth = GetComponent<EnemyHealth>();
+            }
+        }
+
+        private void OnEnable()
+        {
+            // 오브젝트 풀에서 재사용될 때마다 카운트를 초기화한다(direction_dynamic_system.md §엣지 케이스).
+            ResetCount();
+        }
+
+        /// <summary>
+        /// 스와이프 타격 1회를 등록한다. 타겟팅(<see cref="SwipeAttackTargeting"/>)이 이미 방향이 일치하는
+        /// 적만 선택하므로, 이 호출 자체가 "동일 방향 타격"을 의미한다.
+        /// 동일 스와이프(<paramref name="swipeId"/>)로 같은 적이 여러 번(n-hit) 들어와도 카운트는 1회만 증가한다.
+        /// </summary>
+        public void RegisterDirectionalHit(int swipeId)
+        {
+            // 시퀀스 적(보스 패턴, #84)은 방향이 시퀀스에서 결정되므로 동적 변환 대상에서 제외한다.
+            if (_enemyHealth == null || !_enemyHealth.IsAlive || _enemyHealth.UsesAttackSequence)
+            {
+                return;
+            }
+
+            // n-hit 가드: 같은 스와이프의 중복 타격은 1회만 카운트한다.
+            if (swipeId == _lastSwipeId)
+            {
+                return;
+            }
+
+            _lastSwipeId = swipeId;
+            _hitCount++;
+
+            if (UnityEngine.Random.value < ConversionChance(_hitCount))
+            {
+                Convert();
+                return;
+            }
+
+            OnHitCountChanged?.Invoke(_hitCount, ImminenceIntensity());
+        }
+
+        private void Convert()
+        {
+            SwipeDirection from = _enemyHealth.SwipeDirection;
+            SwipeDirection to = PickDifferentDirection(from);
+
+            // 즉시 적용: SetSwipeDirection이 OnDirectionChanged를 발행 → 색상 시스템(#82)이 새 색으로 전환.
+            _enemyHealth.SetSwipeDirection(to);
+            ResetCount();
+            OnConverted?.Invoke(from, to);
+        }
+
+        private void ResetCount()
+        {
+            _hitCount = 0;
+            _lastSwipeId = int.MinValue;
+            OnHitCountChanged?.Invoke(0, 0f);
+        }
+
+        private float ConversionChance(int hitCount)
+        {
+            return _config != null
+                ? _config.GetConversionChance(hitCount)
+                : DirectionConversionConfig.DefaultConversionChance(hitCount);
+        }
+
+        /// <summary>임박 임계값 이상에서만 0이 아닌 강도를 반환한다. 다음 변환 확률을 강도로 사용해 카운트가 높을수록 강해진다.</summary>
+        private float ImminenceIntensity()
+        {
+            int threshold = _config != null ? _config.ImminentThresholdCount : DirectionConversionConfig.DefaultImminentThresholdCount;
+            return _hitCount >= threshold ? ConversionChance(_hitCount) : 0f;
+        }
+
+        /// <summary>현재 방향을 제외한 나머지 3방향 중 하나를 균등 확률로 고른다.</summary>
+        private static SwipeDirection PickDifferentDirection(SwipeDirection current)
+        {
+            int currentIndex = Array.IndexOf(Directions, current);
+            if (currentIndex < 0)
+            {
+                // 현재 방향이 None 등으로 미정이면 4방향 전체에서 고른다.
+                return Directions[UnityEngine.Random.Range(0, Directions.Length)];
+            }
+
+            // offset 1~3을 더해 현재 인덱스를 반드시 벗어난 방향을 균등하게 선택한다.
+            int offset = UnityEngine.Random.Range(1, Directions.Length);
+            return Directions[(currentIndex + offset) % Directions.Length];
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/EnemyDirectionConverter.cs.meta
+++ b/project1/Assets/Scripts/Combat/EnemyDirectionConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 14befdec210748342a13614bec6adcee

--- a/project1/Assets/Scripts/Combat/EnemyHealth.cs
+++ b/project1/Assets/Scripts/Combat/EnemyHealth.cs
@@ -42,6 +42,8 @@ namespace Mukseon.Gameplay.Combat
         private Collider2D[] _colliders;
         private EnemyAttackSequence _attackSequence;
         private bool _attackSequenceCached;
+        private EnemyDirectionConverter _directionConverter;
+        private bool _directionConverterCached;
 
         public float MaxHealth => _maxHealth;
         public float CurrentHealth { get; private set; }
@@ -63,6 +65,21 @@ namespace Mukseon.Gameplay.Combat
                 }
 
                 return _attackSequence;
+            }
+        }
+
+        /// <summary>방향 동적 변환(#68) 컴포넌트. 없으면 null(변환 미적용 적).</summary>
+        public EnemyDirectionConverter DirectionConverter
+        {
+            get
+            {
+                if (!_directionConverterCached)
+                {
+                    _directionConverter = GetComponent<EnemyDirectionConverter>();
+                    _directionConverterCached = true;
+                }
+
+                return _directionConverter;
             }
         }
 

--- a/project1/Assets/Scripts/Combat/SwipeAttackEventListener.cs
+++ b/project1/Assets/Scripts/Combat/SwipeAttackEventListener.cs
@@ -30,6 +30,9 @@ namespace Mukseon.Gameplay.Combat
 
         private int _bonusTargets;
 
+        // 동적 방향 변환(#68) n-hit 가드용 스와이프 식별자. 스와이프 1회마다 증가한다.
+        private int _swipeId;
+
         [Header("Debug")]
         [SerializeField]
         private bool _showDebugLogs = true;
@@ -78,6 +81,9 @@ namespace Mukseon.Gameplay.Combat
             {
                 return;
             }
+
+            // 동적 변환(#68): 이 스와이프를 식별해 동일 스와이프의 n-hit 중복 카운트를 막는다.
+            _swipeId++;
 
             // combat_system.md §2: 스와이프 끝점(Touch Up 좌표)에 가장 가까운 적을 우선 타격한다.
             Vector2 attackOrigin = ResolveAttackOrigin(endScreenPosition);
@@ -148,9 +154,19 @@ namespace Mukseon.Gameplay.Combat
                 float actualDamage = usesSequence ? 1f : damage;
                 enemyHealth.ApplyDamage(actualDamage, this);
 
-                if (enemyHealth.IsAlive && usesSequence)
+                if (!enemyHealth.IsAlive)
+                {
+                    continue;
+                }
+
+                if (usesSequence)
                 {
                     enemyHealth.AttackSequence.Advance();
+                }
+                else
+                {
+                    // 동적 방향 변환(#68): 타겟팅이 방향 일치 적만 선택하므로 이 호출 == 동일 방향 타격.
+                    enemyHealth.DirectionConverter?.RegisterDirectionalHit(_swipeId);
                 }
             }
 

--- a/project1/Assets/Settings/Data/Combat.meta
+++ b/project1/Assets/Settings/Data/Combat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7c1d02742fa67104085fc832dac7734a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/project1/Assets/Settings/Data/Combat/DirectionConversionConfig.asset
+++ b/project1/Assets/Settings/Data/Combat/DirectionConversionConfig.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a43b212a125c09249a15bd9b788aaed7, type: 3}
+  m_Name: DirectionConversionConfig
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.DirectionConversionConfig
+  _conversionProbabilities:
+  - 0
+  - 0.1
+  - 0.25
+  - 0.5
+  - 0.75
+  _imminentThresholdCount: 2

--- a/project1/Assets/Settings/Data/Combat/DirectionConversionConfig.asset.meta
+++ b/project1/Assets/Settings/Data/Combat/DirectionConversionConfig.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f1a9553ab329986408b9f0c2d2067df3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 개요

전투 시스템 재점검 3단계. **방향 속성 동적 변환 시스템**을 구현합니다(`direction_dynamic_system.md`, `combat_system.md` §4).
같은 적을 동일 방향으로 반복 타격하면 방향이 변환될 확률이 누적되고, 발동 시 현재 방향을 제외한 3방향 중 하나로 즉시 전환됩니다. 색상 표시 기반은 #82.

## 변경 내용

### 코어 로직 (0479e10)
- **DirectionConversionConfig** (ScriptableObject): 누적 타격 카운트별 변환 확률 테이블 + 변환 임박 임계값. 정적 폴백으로 에셋 미연결 시에도 동작.
- **EnemyDirectionConverter**: 누적 카운트 → 확률 판정 → 현재 제외 3방향 랜덤 전환 + 즉시 리셋. 변환은 `SetSwipeDirection`을 경유해 `OnDirectionChanged`(#82) 발행 → 색상 자동 전환.
- **EnemyHealth**: `DirectionConverter` 캐시 접근자 추가.
- **SwipeAttackEventListener**: 스와이프마다 ID 부여, 생존한 비시퀀스 피격 적에 `RegisterDirectionalHit(swipeId)` 호출.
- **EnemyDirectionColorView**: 변환 임박 시 글로우 흰색 깜빡임(카운트↑일수록 강하게) + 변환 순간 흰색 플래시.

### 설정·프리팹 연동 (d3970c4)
- **DirectionConversionConfig.asset** 생성 (확률 `[0, 0.1, 0.25, 0.5, 0.75]`, 임박 임계값 2).
- 비보스 적 11종 → **10종** 프리팹에 `EnemyDirectionConverter` 추가 + 참조 연결 (Dummy 4종 / Maegu / MaeguProjectile / MokgwiEnemy / MokgwiRoot / Dokkaebibul / Eodukshini). 보스(Dureoksini)는 방향 시퀀스 기반이라 제외.

## 설계 노트

- **카운트 누적 조건**: 타겟팅(`SwipeAttackTargeting`)이 방향이 일치하는 적만 선택하므로, 피격 등록 = "동일 방향 타격". "다른 방향 스와이프 후 복귀 시 카운트 유지"가 자연스럽게 성립.
- **n-hit 가드**: 동일 `swipeId`의 중복 타격은 1회만 카운트(향후 관통/다단 히트 대비).
- **시퀀스(보스) 제외**: 방향이 시퀀스에서 결정되므로 동적 변환 대상 아님.
- **풀 재사용**: `OnEnable`에서 카운트 초기화.
- **`_keepDistance`**: 컴포넌트 추가로 4개 Dummy에 재출현했던 `EnemyMover._keepDistance` 기본값 라인을 정리해, 프리팹 diff를 컴포넌트 추가로 한정(동작 영향 없음).

## 완료 기준 (DoD)

- [x] 동일 적을 같은 방향으로 반복 타격 시 카운트 누적
- [x] 확률 테이블에 따라 방향 변환 발동
- [x] 변환 후 카운트 즉시 0 리셋
- [x] n-hit 스와이프 시 카운트 1만 증가
- [x] 임계값 도달 시 색상 흔들림/깜빡임 연출
- [x] 변환 시 새 방향 색상 전환 (+ 흰색 플래시)
- [x] 풀 반환 시 카운트 초기화

## 검증

- ✅ C# 컴파일 오류 없음 / 신규 콘솔 에러 없음
- ✅ 플레이 테스트: 반복 타격 → 임박 깜빡임 → 변환(색 전환) → 변환 후 새 방향으로 타격 동작 확인

## 미채택 / 후속

- **먹물 번짐 파티클**: 색 변경 순간의 먹물 연출이 테마상 어색해 미채택. 변환 임박 깜빡임 + 색 전환 + 흰색 플래시로 피드백을 마무리. (`OnConverted` 훅은 유지되어 추후 연출 교체 가능)
- 확률 곡선/임박 임계값은 초안값이며 플레이테스트 후 튜닝 예정.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)
