### PR TITLE
feat: 혼불 시스템 — 스와이프 끝점 당기기 / 소멸 타이머·깜빡임 / 상태 관리 (#67)

### DIFF
--- a/project1/Assets/SampleScene.unity
+++ b/project1/Assets/SampleScene.unity
@@ -137,6 +137,7 @@ GameObject:
   - component: {fileID: 187285035}
   - component: {fileID: 187285038}
   - component: {fileID: 187285039}
+  - component: {fileID: 187285040}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -159,6 +160,7 @@ MonoBehaviour:
   _playerSwipeAttackController: {fileID: 0}
   _playerStatSystem: {fileID: 0}
   _attackOrigin: {fileID: 0}
+  _camera: {fileID: 0}
   _baseDamage: 1
   _targetsPerAttack: 1
   _showDebugLogs: 1
@@ -356,6 +358,22 @@ MonoBehaviour:
   _inkExplosionPrefab: {fileID: 1521378134529826040, guid: ab7ed0e16a58dbf4baec6ec147295338, type: 3}
   _barrierRenderer: {fileID: 1279299310}
   _barrierRadius: 3
+--- !u!114 &187285040
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 187285028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 17d0d85837d6e3d42a86b5c46545a42a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Progression.SwipeSoulPuller
+  _swipeAttackController: {fileID: 0}
+  _camera: {fileID: 0}
+  _pullRadius: 2.5
+  _moveDistance: 3
 --- !u!1 &289712652
 GameObject:
   m_ObjectHideFlags: 0

--- a/project1/Assets/Scripts/Progression/SoulOrb.cs
+++ b/project1/Assets/Scripts/Progression/SoulOrb.cs
@@ -23,6 +23,14 @@ namespace Mukseon.Gameplay.Progression
 
         private static readonly List<SoulOrb> _activeSouls = new List<SoulOrb>(64);
 
+        // Enter Play Mode 설정에서 Domain Reload가 꺼져 있으면 static 필드가 세션 간 유지된다.
+        // 이전 세션의 파괴된 혼불 참조가 남아 누수/불필요한 순회를 일으키지 않도록 시작 시 비운다.
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void ResetActiveSouls()
+        {
+            _activeSouls.Clear();
+        }
+
         /// <summary>현재 씬에 활성화된 모든 혼불. 스와이프 끝점 당기기 탐색용(읽기 전용).</summary>
         public static IReadOnlyList<SoulOrb> ActiveSouls => _activeSouls;
 
@@ -167,7 +175,8 @@ namespace Mukseon.Gameplay.Progression
         {
             // 드랍 직후 산개 속도를 점차 감쇠시켜 제자리에 정착한다.
             transform.position += _scatterVelocity * Time.deltaTime;
-            _scatterVelocity = Vector3.Lerp(_scatterVelocity, Vector3.zero, Time.deltaTime * 4f);
+            // 프레임레이트 독립적 지수 감쇠. Lerp 방식은 프레임 드랍 시 deltaTime*4가 1을 넘으면 속도가 즉시 끊긴다.
+            _scatterVelocity *= Mathf.Exp(-4f * Time.deltaTime);
             TickDespawn();
         }
 
@@ -197,7 +206,9 @@ namespace Mukseon.Gameplay.Progression
 
             _currentAttractSpeed += _attractAcceleration * Time.deltaTime;
             Vector3 dir = distance > 0.001f ? toCenter / distance : Vector3.zero;
-            transform.position += dir * _currentAttractSpeed * Time.deltaTime;
+            // 가속된 속도가 남은 거리를 넘어 중앙을 지나치며 진동하는 것을 막는다(오버슈트 클램프).
+            float step = Mathf.Min(_currentAttractSpeed * Time.deltaTime, distance);
+            transform.position += dir * step;
         }
 
         private void EnterAttracting()

--- a/project1/Assets/Scripts/Progression/SoulOrb.cs
+++ b/project1/Assets/Scripts/Progression/SoulOrb.cs
@@ -1,40 +1,108 @@
-﻿using Mukseon.Core.Pool;
+using System.Collections.Generic;
+using Mukseon.Core.Pool;
 using UnityEngine;
 
 namespace Mukseon.Gameplay.Progression
 {
+    /// <summary>
+    /// 경험치 구슬 '혼불'(#67, `honbul_system.md`). 적 처치 위치에 드랍되어
+    /// 세 가지 상태로 동작한다: 정적(Idle, 소멸 타이머 진행) → 스와이프 끝점 당기기(Pulled)
+    /// 또는 자력 흡수(Attracting). 당겨지거나 흡수되는 동안에는 소멸 타이머가 정지한다.
+    /// 모든 혼불은 오브젝트 풀로 관리되며, 활성 혼불은 <see cref="ActiveSouls"/>에 등록되어
+    /// 스와이프 끝점 탐색(<see cref="SwipeSoulPuller"/>)에 사용된다.
+    /// </summary>
     [DisallowMultipleComponent]
     public class SoulOrb : MonoBehaviour
     {
+        private enum SoulState
+        {
+            Idle,        // 정적: 드랍 직후 산개 후 정지. 소멸 타이머가 진행된다.
+            Pulled,      // 스와이프 끝점 당기기로 중앙을 향해 이동 중. 소멸 타이머 정지.
+            Attracting   // 자력 반경 진입 후 가속하며 흡수되는 중. 소멸 타이머 정지.
+        }
+
+        private static readonly List<SoulOrb> _activeSouls = new List<SoulOrb>(64);
+
+        /// <summary>현재 씬에 활성화된 모든 혼불. 스와이프 끝점 당기기 탐색용(읽기 전용).</summary>
+        public static IReadOnlyList<SoulOrb> ActiveSouls => _activeSouls;
+
         [SerializeField, Min(1)]
         private int _experienceAmount = 1;
 
+        [Header("드랍 산개")]
         [SerializeField, Min(0f)]
         private float _scatterSpeed = 1.2f;
 
+        [Header("자력 흡수")]
         [SerializeField, Min(0.1f)]
         private float _attractSpeed = 6f;
 
         [SerializeField, Min(0.1f)]
         private float _attractAcceleration = 12f;
 
+        [Header("스와이프 끝점 당기기")]
+        [SerializeField, Min(0.1f)]
+        [Tooltip("스와이프 끝점에 당겨질 때 중앙 방향으로 이동하는 속도.")]
+        private float _pullSpeed = 8f;
+
+        [Header("소멸")]
+        [SerializeField, Min(0.1f)]
+        [Tooltip("드랍 후 미획득 시 소멸까지 걸리는 시간(초). 이동 상태에서는 정지/리셋된다.")]
+        private float _lifetime = 15f;
+
+        [SerializeField, Min(0f)]
+        [Tooltip("소멸 N초 전부터 깜빡임 경고를 시작한다.")]
+        private float _warningDuration = 3f;
+
+        [SerializeField, Min(0.1f)]
+        [Tooltip("소멸 경고 깜빡임 속도.")]
+        private float _blinkSpeed = 12f;
+
+        [SerializeField, Range(0f, 1f)]
+        [Tooltip("깜빡임 시 내려가는 최소 알파 비율.")]
+        private float _blinkMinAlpha = 0.25f;
+
+        private SpriteRenderer _spriteRenderer;
+        private Color _baseColor = Color.white;
         private float _initialAttractSpeed;
+
+        private SoulState _state;
         private Vector3 _scatterVelocity;
-        private bool _isAttracting;
+        private float _despawnTimer;
+        private float _pullRemaining;
+        private float _currentAttractSpeed;
 
         private void Awake()
         {
+            _spriteRenderer = GetComponentInChildren<SpriteRenderer>();
+            if (_spriteRenderer != null)
+            {
+                _baseColor = _spriteRenderer.color;
+            }
+
             _initialAttractSpeed = _attractSpeed;
         }
 
         private void OnEnable()
         {
+            _activeSouls.Add(this);
+
+            // 풀 재사용 시 상태를 완전히 초기화한다.
             float randomX = Random.Range(-1f, 1f);
             float randomY = Random.Range(-1f, 1f);
             Vector3 direction = new Vector3(randomX, randomY, 0f).normalized;
             _scatterVelocity = direction * _scatterSpeed;
-            _attractSpeed = _initialAttractSpeed;
-            _isAttracting = false;
+
+            _state = SoulState.Idle;
+            _despawnTimer = 0f;
+            _pullRemaining = 0f;
+            _currentAttractSpeed = _initialAttractSpeed;
+            RestoreColor();
+        }
+
+        private void OnDisable()
+        {
+            _activeSouls.Remove(this);
         }
 
         private void Update()
@@ -42,53 +110,154 @@ namespace Mukseon.Gameplay.Progression
             SoulCollector collector = SoulCollector.ActiveCollector;
             if (collector == null)
             {
+                // 수거자가 없어도 소멸은 진행해 화면에 무한히 쌓이지 않도록 한다.
+                TickDespawn();
                 return;
             }
 
-            Vector3 targetPosition = collector.transform.position;
-            targetPosition.z = transform.position.z;
-            Vector3 toTarget = targetPosition - transform.position;
-            float distance = toTarget.magnitude;
+            Vector3 center = collector.transform.position;
+            center.z = transform.position.z;
+            Vector3 toCenter = center - transform.position;
+            float distance = toCenter.magnitude;
 
-            if (!_isAttracting)
+            // 자력 반경 진입 시 어떤 상태에서든 흡수로 전환한다.
+            if (_state != SoulState.Attracting && distance <= collector.AttractionRadius)
             {
-                if (distance <= collector.AttractionRadius)
-                {
-                    _isAttracting = true;
-                }
-                else
-                {
-                    transform.position += _scatterVelocity * Time.deltaTime;
-                    _scatterVelocity = Vector3.Lerp(_scatterVelocity, Vector3.zero, Time.deltaTime * 4f);
-                    return;
-                }
+                EnterAttracting();
             }
 
-            if (distance <= collector.CollectRadius)
+            switch (_state)
             {
-                collector.Collect(_experienceAmount);
+                case SoulState.Idle:
+                    UpdateIdle();
+                    break;
+                case SoulState.Pulled:
+                    UpdatePulled(toCenter, distance);
+                    break;
+                case SoulState.Attracting:
+                    UpdateAttracting(collector, toCenter, distance);
+                    break;
+            }
+        }
 
-                if (PoolManager.Instance != null)
-                {
-                    PoolManager.Instance.Release(gameObject);
-                }
-                else
-                {
-                    Destroy(gameObject);
-                }
-
+        /// <summary>
+        /// 스와이프 끝점 당기기로 이 혼불을 중앙 방향으로 <paramref name="moveDistance"/>만큼 이동시킨다.
+        /// 이미 당겨지거나 흡수 중이면 무시한다(연속 스와이프의 중복 당기기 방지).
+        /// </summary>
+        public void Pull(float moveDistance)
+        {
+            if (_state == SoulState.Pulled || _state == SoulState.Attracting)
+            {
                 return;
             }
 
-            float currentSpeed = Mathf.Max(0.1f, _attractSpeed);
-            _attractSpeed = currentSpeed + _attractAcceleration * Time.deltaTime;
-            Vector3 directionToTarget = distance > 0.001f ? toTarget / distance : Vector3.zero;
-            transform.position += directionToTarget * _attractSpeed * Time.deltaTime;
+            _state = SoulState.Pulled;
+            _scatterVelocity = Vector3.zero;
+            _pullRemaining = Mathf.Max(0f, moveDistance);
+            _despawnTimer = 0f;   // 이동 상태 전환 시 소멸 타이머 리셋.
+            RestoreColor();
         }
 
         public void SetExperienceAmount(int experienceAmount)
         {
             _experienceAmount = Mathf.Max(1, experienceAmount);
+        }
+
+        private void UpdateIdle()
+        {
+            // 드랍 직후 산개 속도를 점차 감쇠시켜 제자리에 정착한다.
+            transform.position += _scatterVelocity * Time.deltaTime;
+            _scatterVelocity = Vector3.Lerp(_scatterVelocity, Vector3.zero, Time.deltaTime * 4f);
+            TickDespawn();
+        }
+
+        private void UpdatePulled(Vector3 toCenter, float distance)
+        {
+            if (_pullRemaining <= 0f)
+            {
+                // 당기기 이동 거리를 모두 소진하면 다시 정적 상태로 복귀하며 소멸 타이머를 재개한다.
+                _state = SoulState.Idle;
+                return;
+            }
+
+            Vector3 dir = distance > 0.001f ? toCenter / distance : Vector3.zero;
+            float step = Mathf.Min(_pullSpeed * Time.deltaTime, _pullRemaining);
+            transform.position += dir * step;
+            _pullRemaining -= step;
+        }
+
+        private void UpdateAttracting(SoulCollector collector, Vector3 toCenter, float distance)
+        {
+            if (distance <= collector.CollectRadius)
+            {
+                collector.Collect(_experienceAmount);
+                Release();
+                return;
+            }
+
+            _currentAttractSpeed += _attractAcceleration * Time.deltaTime;
+            Vector3 dir = distance > 0.001f ? toCenter / distance : Vector3.zero;
+            transform.position += dir * _currentAttractSpeed * Time.deltaTime;
+        }
+
+        private void EnterAttracting()
+        {
+            _state = SoulState.Attracting;
+            _despawnTimer = 0f;
+            _currentAttractSpeed = _initialAttractSpeed;
+            RestoreColor();
+        }
+
+        private void TickDespawn()
+        {
+            _despawnTimer += Time.deltaTime;
+            if (_despawnTimer >= _lifetime)
+            {
+                Release();
+                return;
+            }
+
+            UpdateBlink();
+        }
+
+        /// <summary>소멸 경고 구간(_lifetime - _warningDuration ~ _lifetime)에서 알파를 점멸시킨다.</summary>
+        private void UpdateBlink()
+        {
+            if (_spriteRenderer == null)
+            {
+                return;
+            }
+
+            float remaining = _lifetime - _despawnTimer;
+            if (remaining > _warningDuration)
+            {
+                return;
+            }
+
+            float wave = Mathf.Abs(Mathf.Sin(_despawnTimer * _blinkSpeed));
+            Color color = _baseColor;
+            color.a = _baseColor.a * Mathf.Lerp(_blinkMinAlpha, 1f, wave);
+            _spriteRenderer.color = color;
+        }
+
+        private void RestoreColor()
+        {
+            if (_spriteRenderer != null)
+            {
+                _spriteRenderer.color = _baseColor;
+            }
+        }
+
+        private void Release()
+        {
+            if (PoolManager.Instance != null)
+            {
+                PoolManager.Instance.Release(gameObject);
+            }
+            else
+            {
+                Destroy(gameObject);
+            }
         }
     }
 }

--- a/project1/Assets/Scripts/Progression/SwipeSoulPuller.cs
+++ b/project1/Assets/Scripts/Progression/SwipeSoulPuller.cs
@@ -1,0 +1,132 @@
+using System.Collections.Generic;
+using Mukseon.Core.Input;
+using Mukseon.Gameplay.Combat;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Progression
+{
+    /// <summary>
+    /// 스와이프 끝점 당기기(#67, `honbul_system.md`). 스와이프 입력 종료(Touch Up) 시
+    /// 끝점 좌표 기준 일정 반경 내 혼불을 중앙(플레이어) 방향으로 당긴다.
+    /// 당겨진 혼불은 자력 반경에 진입하면 <see cref="SoulOrb"/>가 자동으로 흡수한다.
+    /// 당기기 반경/이동 거리는 혼불 획득 스탯으로 강화 예정이나(#40), 현재는 직렬화 설정값을 사용한다.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class SwipeSoulPuller : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField]
+        private PlayerSwipeAttackController _swipeAttackController;
+
+        [SerializeField]
+        private Camera _camera;
+
+        [Header("당기기 설정 (#40에서 스탯 연동 예정)")]
+        [SerializeField, Min(0f)]
+        [Tooltip("스와이프 끝점 기준 혼불을 탐색·당기는 반경.")]
+        private float _pullRadius = 2.5f;
+
+        [SerializeField, Min(0f)]
+        [Tooltip("한 번 당겨질 때 혼불이 중앙 방향으로 이동하는 거리.")]
+        private float _moveDistance = 3f;
+
+        public float PullRadius => Mathf.Max(0f, _pullRadius);
+        public float MoveDistance => Mathf.Max(0f, _moveDistance);
+
+        private void Awake()
+        {
+            if (_swipeAttackController == null)
+            {
+                _swipeAttackController = GetComponent<PlayerSwipeAttackController>();
+            }
+
+            if (_swipeAttackController == null)
+            {
+                _swipeAttackController = FindSwipeAttackController();
+            }
+        }
+
+        private void OnEnable()
+        {
+            if (_swipeAttackController != null)
+            {
+                _swipeAttackController.OnAttackExecuted += HandleAttackExecuted;
+            }
+            else
+            {
+                Debug.LogWarning("[SwipeSoulPuller] PlayerSwipeAttackController 참조가 없어 스와이프 끝점 당기기가 동작하지 않습니다.");
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (_swipeAttackController != null)
+            {
+                _swipeAttackController.OnAttackExecuted -= HandleAttackExecuted;
+            }
+        }
+
+        private void HandleAttackExecuted(SwipeDirection direction, Vector2 endScreenPosition)
+        {
+            // 수거자가 없으면 당겨도 흡수 목적지가 없으므로 건너뛴다.
+            if (SoulCollector.ActiveCollector == null)
+            {
+                return;
+            }
+
+            Vector2 endWorld = ResolveWorldPoint(endScreenPosition);
+            float radiusSquared = PullRadius * PullRadius;
+            float moveDistance = MoveDistance;
+
+            // SoulOrb.Pull은 ActiveSouls를 변경하지 않으므로(흡수/소멸은 Update에서 처리) 순회 중 호출이 안전하다.
+            IReadOnlyList<SoulOrb> souls = SoulOrb.ActiveSouls;
+            for (int i = 0; i < souls.Count; i++)
+            {
+                SoulOrb soul = souls[i];
+                if (soul == null)
+                {
+                    continue;
+                }
+
+                Vector2 soulPosition = soul.transform.position;
+                if ((soulPosition - endWorld).sqrMagnitude <= radiusSquared)
+                {
+                    soul.Pull(moveDistance);
+                }
+            }
+        }
+
+        /// <summary>스와이프 끝점(스크린 좌표)을 월드 좌표로 변환한다. 카메라가 없으면 스크린 좌표를 폴백으로 사용한다.</summary>
+        private Vector2 ResolveWorldPoint(Vector2 screenPosition)
+        {
+            // Camera.main은 Awake 시점에 아직 null일 수 있으므로 사용 시점에 지연 해석한다.
+            if (_camera == null)
+            {
+                _camera = Camera.main;
+            }
+
+            if (_camera != null)
+            {
+                Vector3 world = _camera.ScreenToWorldPoint(screenPosition);
+                return new Vector2(world.x, world.y);
+            }
+
+            return screenPosition;
+        }
+
+        private static PlayerSwipeAttackController FindSwipeAttackController()
+        {
+#if UNITY_2023_1_OR_NEWER
+            return FindFirstObjectByType<PlayerSwipeAttackController>();
+#else
+            return FindObjectOfType<PlayerSwipeAttackController>();
+#endif
+        }
+
+        private void OnDrawGizmosSelected()
+        {
+            Gizmos.color = new Color(0.4f, 1f, 1f, 0.5f);
+            Gizmos.DrawWireSphere(transform.position, PullRadius);
+        }
+    }
+}

--- a/project1/Assets/Scripts/Progression/SwipeSoulPuller.cs
+++ b/project1/Assets/Scripts/Progression/SwipeSoulPuller.cs
@@ -125,6 +125,8 @@ namespace Mukseon.Gameplay.Progression
 
         private void OnDrawGizmosSelected()
         {
+            // 실제 당기기 판정은 런타임 스와이프 끝점(endWorld) 기준이다(HandleAttackExecuted 참고).
+            // 끝점은 런타임에만 알 수 있으므로, 여기서는 당기기 반경의 '크기'만 플레이어 위치에 참고용으로 표시한다.
             Gizmos.color = new Color(0.4f, 1f, 1f, 0.5f);
             Gizmos.DrawWireSphere(transform.position, PullRadius);
         }

--- a/project1/Assets/Scripts/Progression/SwipeSoulPuller.cs.meta
+++ b/project1/Assets/Scripts/Progression/SwipeSoulPuller.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 17d0d85837d6e3d42a86b5c46545a42a


### PR DESCRIPTION
## 개요

이슈 #67(혼불 시스템) 중 **빠진 게임플레이**를 구현합니다. 기존 `Soul` 시스템(혼불의 영어 네이밍)이 드랍·자력 흡수·경험치·풀링을 이미 갖추고 있어, **리네이밍 없이 확장**했습니다.

> 스코프: `StatType` 연동(자력 반경·당기기 반경·이동 거리·획득 배율)은 별도 이슈 #40으로 이월. 현재는 직렬화 설정값을 사용합니다.

## 변경 사항

### `SoulOrb.cs` (수정)
- 명시적 상태머신 도입: `Idle`(정적) / `Pulled`(끝점 당기기 이동) / `Attracting`(자력 흡수)
- **소멸 타이머**: 정적 상태에서 진행, 소멸 N초 전부터 알파 깜빡임 경고 후 풀 반환 (초안 15초 / 경고 3초)
- **`Pull(moveDistance)`**: 스와이프 끝점 당기기로 중앙 방향 이동. 이미 이동/흡수 중이면 무시 → **연속 스와이프 중복 당기기 방지**
- 이동/흡수 전환 시 **소멸 타이머 정지·리셋** (당겨지는 중엔 소멸하지 않음)
- 활성 혼불을 정적 `ActiveSouls` 레지스트리에 등록 (끝점 탐색용)

### `SwipeSoulPuller.cs` (신규)
- `PlayerSwipeAttackController.OnAttackExecuted` 구독 → 스와이프 끝점(스크린→월드) 반경 내 혼불을 중앙으로 당김
- 참조는 코드베이스 관례대로 런타임 자동 해석 (`GetComponent` / `Camera.main`)

### `SampleScene.unity`
- `Player`에 `SwipeSoulPuller` 부착 (`_pullRadius:2.5`, `_moveDistance:3`)

## 완료 기준 (DoD)

- ✅ 적 처치 시 혼불 드랍 *(기존 `EnemySoulDropper`)*
- ✅ 자력 반경 내 자동 흡수
- ✅ 스와이프 종료 시 끝점 반경 내 혼불을 중앙으로 당김
- ✅ 일정 시간 미획득 시 깜빡임 후 소멸
- ✅ 이동 중 혼불은 소멸 타이머 정지
- ✅ 연속 스와이프 중복 당기기 방지
- ✅ 오브젝트 풀링으로 관리

## 이월 (#40)

- `StatType.MagnetRadius` / `SwipeEndpointPullRadius` / `HonbulMoveDistance` / `HonbulAcquireMultiplier` enum 추가 및 스탯 배선
- 경험치 획득 배율은 현재 미적용 (`SoulCollector.Collect`는 원본 경험치 그대로 지급)

## 테스트

- ✅ 컴파일 오류 없음
- ⬜ 플레이 모드 실측(드랍→당기기→흡수→소멸)은 미진행

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)