### PR TITLE
feat: StatType 확장 및 PlayerStatSystem 보완 (#40)

### DIFF
--- a/project1/Assets/Scripts/Combat/GangshinController.cs
+++ b/project1/Assets/Scripts/Combat/GangshinController.cs
@@ -141,7 +141,14 @@ namespace Mukseon.Gameplay.Combat
 
         private void HandleAnyEnemyDied(EnemyHealth enemyHealth)
         {
-            AddGauge(_gaugePerKill);
+            // 강신 게이지 충전 배율(#40)을 적용한다. 스탯이 없으면 1배.
+            float chargeRate = _playerStatSystem != null ? _playerStatSystem.GetValue(StatType.GangshinGaugeChargeRate) : 0f;
+            if (chargeRate <= 0f)
+            {
+                chargeRate = 1f;
+            }
+
+            AddGauge(_gaugePerKill * chargeRate);
         }
 
         private void HandleActivationRequested()

--- a/project1/Assets/Scripts/Combat/GangshinController.cs
+++ b/project1/Assets/Scripts/Combat/GangshinController.cs
@@ -142,12 +142,7 @@ namespace Mukseon.Gameplay.Combat
         private void HandleAnyEnemyDied(EnemyHealth enemyHealth)
         {
             // 강신 게이지 충전 배율(#40)을 적용한다. 스탯이 없으면 1배.
-            float chargeRate = _playerStatSystem != null ? _playerStatSystem.GetValue(StatType.GangshinGaugeChargeRate) : 0f;
-            if (chargeRate <= 0f)
-            {
-                chargeRate = 1f;
-            }
-
+            float chargeRate = PlayerStatSystem.ResolveValueOrDefault(_playerStatSystem, StatType.GangshinGaugeChargeRate, 1f);
             AddGauge(_gaugePerKill * chargeRate);
         }
 

--- a/project1/Assets/Scripts/Combat/PlayerHealth.cs
+++ b/project1/Assets/Scripts/Combat/PlayerHealth.cs
@@ -18,6 +18,9 @@ namespace Mukseon.Gameplay.Combat
 
         private const float AbsoluteMinHealth = 1f;
 
+        // 방어력 데미지 감소율 상한(#40, stat_balance_mvp.md — 최대 70%).
+        private const float MaxDefenseReduction = 0.7f;
+
         [Header("Debug")]
         [SerializeField]
         private bool _showDebugLogs;
@@ -93,8 +96,10 @@ namespace Mukseon.Gameplay.Combat
                 return;
             }
 
+            float mitigatedAmount = ApplyDefense(amount);
+
             float previous = _currentHealth;
-            _currentHealth = Mathf.Max(0f, _currentHealth - amount);
+            _currentHealth = Mathf.Max(0f, _currentHealth - mitigatedAmount);
 
             float actualDamage = previous - _currentHealth;
 
@@ -185,6 +190,24 @@ namespace Mukseon.Gameplay.Combat
             }
 
             OnHealthChanged?.Invoke(_currentHealth, _resolvedMaxHealth);
+        }
+
+        /// <summary>방어력(StatType.Defense, 감소율 %)을 적용해 실제 피해량을 반환한다(#40). 상한 70%.</summary>
+        private float ApplyDefense(float amount)
+        {
+            if (_playerStatSystem == null)
+            {
+                return amount;
+            }
+
+            float defensePercent = _playerStatSystem.GetValue(StatType.Defense);
+            if (defensePercent <= 0f)
+            {
+                return amount;
+            }
+
+            float reduction = Mathf.Clamp(defensePercent / 100f, 0f, MaxDefenseReduction);
+            return amount * (1f - reduction);
         }
 
         private void ResolveMaxHealth()

--- a/project1/Assets/Scripts/Combat/PlayerSwipeAttackController.cs
+++ b/project1/Assets/Scripts/Combat/PlayerSwipeAttackController.cs
@@ -1,5 +1,6 @@
 using System;
 using Mukseon.Core.Input;
+using Mukseon.Gameplay.Stats;
 using UnityEngine;
 
 namespace Mukseon.Gameplay.Combat
@@ -11,6 +12,15 @@ namespace Mukseon.Gameplay.Combat
         [Header("Input")]
         [SerializeField]
         private SwipeInputDetector _swipeInputDetector;
+
+        [SerializeField]
+        private PlayerStatSystem _playerStatSystem;
+
+        // 공격 쿨타임 하한(#40, stat_balance_mvp.md — 쿨타임이 지나치게 낮아지지 않도록).
+        private const float MinAttackCooldown = 0.1f;
+
+        // 마지막 공격 시각(unscaledTime). 강신 슬로모/일시정지에 영향받지 않도록 실시간 기준으로 둔다.
+        private float _lastAttackTime = -999f;
 
         [Header("Animator Parameters")]
         [SerializeField]
@@ -44,6 +54,11 @@ namespace Mukseon.Gameplay.Combat
                 _swipeInputDetector = FindSwipeDetectorInScene();
             }
 
+            if (_playerStatSystem == null)
+            {
+                _playerStatSystem = GetComponent<PlayerStatSystem>();
+            }
+
             BuildAnimatorTriggerHashes();
 
             if (_animator.runtimeAnimatorController == null)
@@ -74,8 +89,27 @@ namespace Mukseon.Gameplay.Combat
 
         private void HandleSwipeDetected(SwipeDirection direction, Vector2 endScreenPosition)
         {
+            // 공격 쿨타임(#40): 쿨타임 내 재입력은 공격·애니메이션·혼불 당기기 전부 무시한다.
+            if (!CanAttackNow())
+            {
+                return;
+            }
+
+            _lastAttackTime = Time.unscaledTime;
             ExecuteAttack(direction, endScreenPosition);
             TriggerAttackAnimation(direction);
+        }
+
+        private bool CanAttackNow()
+        {
+            float cooldown = _playerStatSystem != null ? _playerStatSystem.GetValue(StatType.AttackCooldown) : 0f;
+            if (cooldown <= 0f)
+            {
+                return true;
+            }
+
+            cooldown = Mathf.Max(MinAttackCooldown, cooldown);
+            return Time.unscaledTime - _lastAttackTime >= cooldown;
         }
 
         private void ExecuteAttack(SwipeDirection direction, Vector2 endScreenPosition)

--- a/project1/Assets/Scripts/Combat/SwipeAttackEventListener.cs
+++ b/project1/Assets/Scripts/Combat/SwipeAttackEventListener.cs
@@ -204,18 +204,24 @@ namespace Mukseon.Gameplay.Combat
 
         private int ResolveTargetsPerAttack()
         {
-            // 다중 히트 스탯(#40)이 정의되어 있으면 동시 타격 수의 기준값으로 사용한다.
+            int baseTargets = _targetsPerAttack;
+            CharacterData characterData = _playerStatSystem?.CharacterData;
+            if (characterData != null)
+            {
+                baseTargets = characterData.TargetsPerAttack;
+            }
+
+            // 다중 히트 스탯(#40)은 캐릭터 기본 타격 수보다 클 때만 끌어올린다(기본값을 낮추지 않음).
             if (_playerStatSystem != null)
             {
                 float multiHit = _playerStatSystem.GetValue(StatType.MultiHit);
                 if (multiHit > 0f)
                 {
-                    return Mathf.Max(1, Mathf.RoundToInt(multiHit));
+                    return Mathf.Max(baseTargets, Mathf.RoundToInt(multiHit));
                 }
             }
 
-            CharacterData characterData = _playerStatSystem?.CharacterData;
-            return characterData != null ? characterData.TargetsPerAttack : _targetsPerAttack;
+            return baseTargets;
         }
 
         private void ValidateCharacterData()

--- a/project1/Assets/Scripts/Combat/SwipeAttackEventListener.cs
+++ b/project1/Assets/Scripts/Combat/SwipeAttackEventListener.cs
@@ -204,6 +204,16 @@ namespace Mukseon.Gameplay.Combat
 
         private int ResolveTargetsPerAttack()
         {
+            // 다중 히트 스탯(#40)이 정의되어 있으면 동시 타격 수의 기준값으로 사용한다.
+            if (_playerStatSystem != null)
+            {
+                float multiHit = _playerStatSystem.GetValue(StatType.MultiHit);
+                if (multiHit > 0f)
+                {
+                    return Mathf.Max(1, Mathf.RoundToInt(multiHit));
+                }
+            }
+
             CharacterData characterData = _playerStatSystem?.CharacterData;
             return characterData != null ? characterData.TargetsPerAttack : _targetsPerAttack;
         }

--- a/project1/Assets/Scripts/Progression/PlayerLevelSystem.cs
+++ b/project1/Assets/Scripts/Progression/PlayerLevelSystem.cs
@@ -281,9 +281,10 @@ namespace Mukseon.Gameplay.Progression
                     }
                     break;
                 case LevelUpSkillEffectType.PickupRadius:
-                    if (_soulCollector != null)
+                    if (_playerStatSystem != null)
                     {
-                        _soulCollector.AddPickupRadius(definition.Value);
+                        // 혼불 자력 반경을 Flat StatModifier로 증가시킨다(#40). SoulCollector가 MagnetRadius 스탯을 읽는다.
+                        _playerStatSystem.AddModifier(StatType.MagnetRadius, new StatModifier(definition.Value, StatModifierType.Flat, this));
                     }
                     break;
                 default:

--- a/project1/Assets/Scripts/Progression/PlayerLevelSystem.cs
+++ b/project1/Assets/Scripts/Progression/PlayerLevelSystem.cs
@@ -39,9 +39,6 @@ namespace Mukseon.Gameplay.Progression
         [SerializeField]
         private SwipeAttackEventListener _swipeAttackEventListener;
 
-        [SerializeField]
-        private SoulCollector _soulCollector;
-
         [Header("Progression")]
         [SerializeField, Min(1f)]
         private float _baseExperienceThreshold = 5f;
@@ -91,11 +88,6 @@ namespace Mukseon.Gameplay.Progression
             if (_swipeAttackEventListener == null)
             {
                 _swipeAttackEventListener = GetComponent<SwipeAttackEventListener>();
-            }
-
-            if (_soulCollector == null)
-            {
-                _soulCollector = GetComponent<SoulCollector>();
             }
 
             ResolveSkillDefinitions();

--- a/project1/Assets/Scripts/Progression/SoulCollector.cs
+++ b/project1/Assets/Scripts/Progression/SoulCollector.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using Mukseon.Gameplay.Stats;
 using UnityEngine;
 
 namespace Mukseon.Gameplay.Progression
@@ -9,7 +10,11 @@ namespace Mukseon.Gameplay.Progression
         [SerializeField]
         private PlayerLevelSystem _playerLevelSystem;
 
+        [SerializeField]
+        private PlayerStatSystem _playerStatSystem;
+
         [SerializeField, Min(0.1f)]
+        [Tooltip("StatType.MagnetRadius가 정의되지 않았을 때 사용하는 자력 반경 폴백값.")]
         private float _attractionRadius = 2.5f;
 
         [SerializeField, Min(0.05f)]
@@ -17,7 +22,8 @@ namespace Mukseon.Gameplay.Progression
 
         public static SoulCollector ActiveCollector { get; private set; }
 
-        public float AttractionRadius => Mathf.Max(0.1f, _attractionRadius);
+        /// <summary>자력 반경. StatType.MagnetRadius가 있으면 그 값을, 없으면 직렬화 폴백값을 사용한다(#40).</summary>
+        public float AttractionRadius => Mathf.Max(0.1f, ResolveStat(StatType.MagnetRadius, _attractionRadius));
         public float CollectRadius => Mathf.Max(0.05f, _collectRadius);
 
         public event Action<int> OnSoulCollected;
@@ -27,6 +33,11 @@ namespace Mukseon.Gameplay.Progression
             if (_playerLevelSystem == null)
             {
                 _playerLevelSystem = GetComponent<PlayerLevelSystem>();
+            }
+
+            if (_playerStatSystem == null)
+            {
+                _playerStatSystem = GetComponent<PlayerStatSystem>();
             }
         }
 
@@ -45,19 +56,30 @@ namespace Mukseon.Gameplay.Progression
 
         public void Collect(int experienceAmount)
         {
-            int amount = Mathf.Max(0, experienceAmount);
-            if (amount <= 0)
+            int baseAmount = Mathf.Max(0, experienceAmount);
+            if (baseAmount <= 0)
             {
                 return;
             }
+
+            // 혼불 획득 배율 × 경험치 획득 배율을 적용한다(#40). 두 스탯이 없으면 1배.
+            float multiplier = ResolveStat(StatType.HonbulAcquireMultiplier, 1f) * ResolveStat(StatType.ExperienceGain, 1f);
+            int amount = Mathf.Max(1, Mathf.RoundToInt(baseAmount * multiplier));
 
             _playerLevelSystem?.AddExperience(amount);
             OnSoulCollected?.Invoke(amount);
         }
 
-        public void AddPickupRadius(float amount)
+        /// <summary>스탯값을 조회하되, 스탯이 정의되지 않아 0이면 폴백값을 반환한다.</summary>
+        private float ResolveStat(StatType statType, float fallback)
         {
-            _attractionRadius = Mathf.Max(0.1f, _attractionRadius + amount);
+            if (_playerStatSystem == null)
+            {
+                return fallback;
+            }
+
+            float value = _playerStatSystem.GetValue(statType);
+            return value > 0f ? value : fallback;
         }
 
         private void OnDrawGizmosSelected()

--- a/project1/Assets/Scripts/Progression/SoulCollector.cs
+++ b/project1/Assets/Scripts/Progression/SoulCollector.cs
@@ -23,7 +23,7 @@ namespace Mukseon.Gameplay.Progression
         public static SoulCollector ActiveCollector { get; private set; }
 
         /// <summary>자력 반경. StatType.MagnetRadius가 있으면 그 값을, 없으면 직렬화 폴백값을 사용한다(#40).</summary>
-        public float AttractionRadius => Mathf.Max(0.1f, ResolveStat(StatType.MagnetRadius, _attractionRadius));
+        public float AttractionRadius => Mathf.Max(0.1f, PlayerStatSystem.ResolveValueOrDefault(_playerStatSystem, StatType.MagnetRadius, _attractionRadius));
         public float CollectRadius => Mathf.Max(0.05f, _collectRadius);
 
         public event Action<int> OnSoulCollected;
@@ -63,23 +63,12 @@ namespace Mukseon.Gameplay.Progression
             }
 
             // 혼불 획득 배율 × 경험치 획득 배율을 적용한다(#40). 두 스탯이 없으면 1배.
-            float multiplier = ResolveStat(StatType.HonbulAcquireMultiplier, 1f) * ResolveStat(StatType.ExperienceGain, 1f);
+            float multiplier = PlayerStatSystem.ResolveValueOrDefault(_playerStatSystem, StatType.HonbulAcquireMultiplier, 1f)
+                * PlayerStatSystem.ResolveValueOrDefault(_playerStatSystem, StatType.ExperienceGain, 1f);
             int amount = Mathf.Max(1, Mathf.RoundToInt(baseAmount * multiplier));
 
             _playerLevelSystem?.AddExperience(amount);
             OnSoulCollected?.Invoke(amount);
-        }
-
-        /// <summary>스탯값을 조회하되, 스탯이 정의되지 않아 0이면 폴백값을 반환한다.</summary>
-        private float ResolveStat(StatType statType, float fallback)
-        {
-            if (_playerStatSystem == null)
-            {
-                return fallback;
-            }
-
-            float value = _playerStatSystem.GetValue(statType);
-            return value > 0f ? value : fallback;
         }
 
         private void OnDrawGizmosSelected()

--- a/project1/Assets/Scripts/Progression/SwipeSoulPuller.cs
+++ b/project1/Assets/Scripts/Progression/SwipeSoulPuller.cs
@@ -35,10 +35,10 @@ namespace Mukseon.Gameplay.Progression
         private float _moveDistance = 3f;
 
         /// <summary>스와이프 끝점 당기기 반경. StatType.SwipeEndpointPullRadius가 있으면 그 값을 사용한다(#40).</summary>
-        public float PullRadius => Mathf.Max(0f, ResolveStat(StatType.SwipeEndpointPullRadius, _pullRadius));
+        public float PullRadius => Mathf.Max(0f, PlayerStatSystem.ResolveValueOrDefault(_playerStatSystem, StatType.SwipeEndpointPullRadius, _pullRadius));
 
         /// <summary>한 번 당겨질 때 이동 거리. StatType.HonbulMoveDistance가 있으면 그 값을 사용한다(#40).</summary>
-        public float MoveDistance => Mathf.Max(0f, ResolveStat(StatType.HonbulMoveDistance, _moveDistance));
+        public float MoveDistance => Mathf.Max(0f, PlayerStatSystem.ResolveValueOrDefault(_playerStatSystem, StatType.HonbulMoveDistance, _moveDistance));
 
         private void Awake()
         {
@@ -56,18 +56,6 @@ namespace Mukseon.Gameplay.Progression
             {
                 _playerStatSystem = GetComponent<PlayerStatSystem>();
             }
-        }
-
-        /// <summary>스탯값을 조회하되, 스탯이 정의되지 않아 0이면 폴백값을 반환한다.</summary>
-        private float ResolveStat(StatType statType, float fallback)
-        {
-            if (_playerStatSystem == null)
-            {
-                return fallback;
-            }
-
-            float value = _playerStatSystem.GetValue(statType);
-            return value > 0f ? value : fallback;
         }
 
         private void OnEnable()

--- a/project1/Assets/Scripts/Progression/SwipeSoulPuller.cs
+++ b/project1/Assets/Scripts/Progression/SwipeSoulPuller.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Mukseon.Core.Input;
 using Mukseon.Gameplay.Combat;
+using Mukseon.Gameplay.Stats;
 using UnityEngine;
 
 namespace Mukseon.Gameplay.Progression
@@ -19,19 +20,25 @@ namespace Mukseon.Gameplay.Progression
         private PlayerSwipeAttackController _swipeAttackController;
 
         [SerializeField]
+        private PlayerStatSystem _playerStatSystem;
+
+        [SerializeField]
         private Camera _camera;
 
-        [Header("당기기 설정 (#40에서 스탯 연동 예정)")]
+        [Header("당기기 폴백 설정")]
         [SerializeField, Min(0f)]
-        [Tooltip("스와이프 끝점 기준 혼불을 탐색·당기는 반경.")]
+        [Tooltip("StatType.SwipeEndpointPullRadius가 없을 때 사용하는 당기기 반경 폴백값.")]
         private float _pullRadius = 2.5f;
 
         [SerializeField, Min(0f)]
-        [Tooltip("한 번 당겨질 때 혼불이 중앙 방향으로 이동하는 거리.")]
+        [Tooltip("StatType.HonbulMoveDistance가 없을 때 사용하는 이동 거리 폴백값.")]
         private float _moveDistance = 3f;
 
-        public float PullRadius => Mathf.Max(0f, _pullRadius);
-        public float MoveDistance => Mathf.Max(0f, _moveDistance);
+        /// <summary>스와이프 끝점 당기기 반경. StatType.SwipeEndpointPullRadius가 있으면 그 값을 사용한다(#40).</summary>
+        public float PullRadius => Mathf.Max(0f, ResolveStat(StatType.SwipeEndpointPullRadius, _pullRadius));
+
+        /// <summary>한 번 당겨질 때 이동 거리. StatType.HonbulMoveDistance가 있으면 그 값을 사용한다(#40).</summary>
+        public float MoveDistance => Mathf.Max(0f, ResolveStat(StatType.HonbulMoveDistance, _moveDistance));
 
         private void Awake()
         {
@@ -44,6 +51,23 @@ namespace Mukseon.Gameplay.Progression
             {
                 _swipeAttackController = FindSwipeAttackController();
             }
+
+            if (_playerStatSystem == null)
+            {
+                _playerStatSystem = GetComponent<PlayerStatSystem>();
+            }
+        }
+
+        /// <summary>스탯값을 조회하되, 스탯이 정의되지 않아 0이면 폴백값을 반환한다.</summary>
+        private float ResolveStat(StatType statType, float fallback)
+        {
+            if (_playerStatSystem == null)
+            {
+                return fallback;
+            }
+
+            float value = _playerStatSystem.GetValue(statType);
+            return value > 0f ? value : fallback;
         }
 
         private void OnEnable()

--- a/project1/Assets/Scripts/Stats/PlayerStatSystem.cs
+++ b/project1/Assets/Scripts/Stats/PlayerStatSystem.cs
@@ -68,6 +68,21 @@ namespace Mukseon.Gameplay.Stats
             return _runtimeStats.TryGetValue(statType, out RuntimeStat runtimeStat) ? runtimeStat.Value : 0f;
         }
 
+        /// <summary>
+        /// 지정 시스템에서 스탯값을 조회하되, 시스템이 없거나 스탯이 미정의(값 0)면 폴백값을 반환한다(#40).
+        /// 여러 컴포넌트(SoulCollector/SwipeSoulPuller/GangshinController 등)의 폴백 조회 패턴을 한 곳으로 모은다.
+        /// </summary>
+        public static float ResolveValueOrDefault(PlayerStatSystem system, StatType statType, float fallback)
+        {
+            if (system == null)
+            {
+                return fallback;
+            }
+
+            float value = system.GetValue(statType);
+            return value > 0f ? value : fallback;
+        }
+
         public bool AddModifier(StatType statType, StatModifier modifier)
         {
             if (!_runtimeStats.TryGetValue(statType, out RuntimeStat runtimeStat))

--- a/project1/Assets/Scripts/Stats/StatType.cs
+++ b/project1/Assets/Scripts/Stats/StatType.cs
@@ -1,9 +1,24 @@
 namespace Mukseon.Gameplay.Stats
 {
+    /// <summary>
+    /// 플레이어 스탯 종류(#40, `player_stats.md`). 직렬화 데이터(PlayerStatsDefinition 에셋)에
+    /// 정수로 저장되므로, 기존 값의 번호를 바꾸지 말고 새 항목은 끝에 추가한다.
+    /// </summary>
     public enum StatType
     {
         MaxHealth = 0,
         AttackPower = 1,
-        AttackSpeed = 2
+        AttackSpeed = 2,                 // 레거시(미사용). 쿨타임 기반 공격 속도는 AttackCooldown 사용.
+
+        Defense = 3,                     // 방어력: 피격 데미지 감소율(%). 상한 70%.
+        AttackCooldown = 4,              // 공격 속도: 스와이프 공격 후 다음 공격까지의 쿨타임(초). 낮을수록 빠름.
+        MultiHit = 5,                    // 다중 히트: 스와이프 1회 동시 타격 가능한 적의 수.
+        GangshinGaugeChargeRate = 6,     // 강신 게이지 충전 배율: 적 처치 시 충전량 배율.
+        MagnetRadius = 7,                // 자력 반경: 플레이어 주변 혼불 자동 흡수 범위.
+        SwipeEndpointPullRadius = 8,     // 스와이프 끝점 당기기 반경.
+        HonbulMoveDistance = 9,          // 당겨지는 혼불이 한 번에 중앙으로 이동하는 거리.
+        HonbulAcquireMultiplier = 10,    // 혼불 1개당 획득 경험치 배율.
+        GoldGain = 11,                   // 골드 획득 배율(골드 시스템 도입 시 연동).
+        ExperienceGain = 12,             // 혼불 배율과 별개로 적용되는 경험치 보너스 배율.
     }
 }

--- a/project1/Assets/Settings/Data/Stats/PlayerStats_Baksu.asset
+++ b/project1/Assets/Settings/Data/Stats/PlayerStats_Baksu.asset
@@ -19,3 +19,23 @@ MonoBehaviour:
     _baseValue: 2.5
   - _statType: 2
     _baseValue: 0.8
+  - _statType: 3
+    _baseValue: 0
+  - _statType: 4
+    _baseValue: 0.25
+  - _statType: 5
+    _baseValue: 1
+  - _statType: 6
+    _baseValue: 1
+  - _statType: 7
+    _baseValue: 2.5
+  - _statType: 8
+    _baseValue: 2.5
+  - _statType: 9
+    _baseValue: 3
+  - _statType: 10
+    _baseValue: 1
+  - _statType: 11
+    _baseValue: 1
+  - _statType: 12
+    _baseValue: 1

--- a/project1/Assets/Settings/Data/Stats/PlayerStats_Mudang.asset
+++ b/project1/Assets/Settings/Data/Stats/PlayerStats_Mudang.asset
@@ -19,3 +19,23 @@ MonoBehaviour:
     _baseValue: 1.5
   - _statType: 2
     _baseValue: 0.95
+  - _statType: 3
+    _baseValue: 0
+  - _statType: 4
+    _baseValue: 0.25
+  - _statType: 5
+    _baseValue: 1
+  - _statType: 6
+    _baseValue: 1
+  - _statType: 7
+    _baseValue: 2.5
+  - _statType: 8
+    _baseValue: 2.5
+  - _statType: 9
+    _baseValue: 3
+  - _statType: 10
+    _baseValue: 1
+  - _statType: 11
+    _baseValue: 1
+  - _statType: 12
+    _baseValue: 1

--- a/project1/Assets/Settings/PlayerStats_Default.asset
+++ b/project1/Assets/Settings/PlayerStats_Default.asset
@@ -19,3 +19,23 @@ MonoBehaviour:
     _baseValue: 1
   - _statType: 2
     _baseValue: 1
+  - _statType: 3
+    _baseValue: 0
+  - _statType: 4
+    _baseValue: 0.25
+  - _statType: 5
+    _baseValue: 1
+  - _statType: 6
+    _baseValue: 1
+  - _statType: 7
+    _baseValue: 2.5
+  - _statType: 8
+    _baseValue: 2.5
+  - _statType: 9
+    _baseValue: 3
+  - _statType: 10
+    _baseValue: 1
+  - _statType: 11
+    _baseValue: 1
+  - _statType: 12
+    _baseValue: 1


### PR DESCRIPTION
## 개요

`StatType` enum을 13종으로 확장하고, 각 신규 스탯을 해당 게임 시스템에 연동합니다. base/런타임 스탯 분리(`PlayerStatsDefinition` 에셋 → `RuntimeStat`)를 유지하며, 모든 증가는 `StatModifier`(Flat/Percent)를 통해 이루어집니다.

## 변경 사항

### 기반
- **`StatType`**: `Defense`, `AttackCooldown`, `MultiHit`, `GangshinGaugeChargeRate`, `MagnetRadius`, `SwipeEndpointPullRadius`, `HonbulMoveDistance`, `HonbulAcquireMultiplier`, `GoldGain`, `ExperienceGain` 추가. 기존 `MaxHealth=0/AttackPower=1/AttackSpeed=2` 번호 유지(직렬화 호환), 신규는 3~12로 append.
- **`PlayerStats` 정의 에셋 3종**(Default/Mudang/Baksu)에 신규 스탯 base값 추가 — 미정의 시 `GetValue`가 0을 반환하므로 필수.

### 시스템 연동
| 스탯 | 위치 | 동작 |
|------|------|------|
| `Defense` | `PlayerHealth.ApplyDefense` | 피격 데미지 감소율(%), 상한 70% |
| `AttackCooldown` | `PlayerSwipeAttackController.CanAttackNow` | 스와이프 쿨타임 게이팅(신규), `unscaledTime`·하한 0.1s |
| `MultiHit` | `SwipeAttackEventListener.ResolveTargetsPerAttack` | 동시 타격 수 기준값 |
| `GangshinGaugeChargeRate` | `GangshinController.HandleAnyEnemyDied` | 처치 시 게이지 충전량 배율 |
| `MagnetRadius` | `SoulCollector.AttractionRadius` | 자력 반경 (폴백: 직렬화값) |
| `SwipeEndpointPullRadius`/`HonbulMoveDistance` | `SwipeSoulPuller` | 당기기 반경/이동 거리 |
| `HonbulAcquireMultiplier`·`ExperienceGain` | `SoulCollector.Collect` | 경험치 배율 합성 |

- `Skill_Magnet`(PickupRadius)을 `SoulCollector.AddPickupRadius` 직접 변경 → **`MagnetRadius` StatModifier 주입**으로 리팩터링(`AddPickupRadius` 제거). 자력 반경 성장이 base/런타임 분리 모델 안으로 편입됨.

## 완료 기준 (DoD)

- ✅ 신규 StatType 전부 enum + PlayerStatsDefinition에 정의
- ✅ 자력/끝점/이동 거리가 StatModifier에 따라 변동
- ✅ 강신 게이지 충전이 GangshinGaugeChargeRate 반영
- ✅ 공격 쿨타임이 AttackCooldown에 따라 동작 (플레이 검증 완료)
- ✅ 스와이프 1회 다중 타격이 MultiHit에 따라 동작

## 보류 / 참고

- **`GoldGain`**: 골드 시스템 부재로 enum/기본값만 추가, 연동 보류.
- **씬 변경 없음**: 신규 `_playerStatSystem` 참조는 런타임 `GetComponent`로 자동 해석.
- **기존 체력/공격력 base값 유지**: 이슈 표(무당 100/0.8 등)와 자산값(110/1.5 등)이 달라 회귀 방지로 자산값 보존 — 밸런스 재조정은 후속.

## 테스트

- ✅ 컴파일 오류 없음
- ✅ AttackCooldown 동작 플레이 검증(임시 2초로 게이팅 확인 후 0.25s 복구)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)