### PR TITLE
feat: 재생의 굿거리 스킬 구현 — 초당 HP 지속 회복 패시브 (#74)

### DIFF
--- a/project1/Assets/SampleScene.unity
+++ b/project1/Assets/SampleScene.unity
@@ -173,6 +173,7 @@ GameObject:
   - component: {fileID: 187285042}
   - component: {fileID: 187285043}
   - component: {fileID: 187285044}
+  - component: {fileID: 187285045}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -522,6 +523,25 @@ MonoBehaviour:
   - 1
   - 0.9
   - 0.8
+--- !u!114 &187285045
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 187285028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e5d65ccf6e44cb48832b63bbf0f67d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.HealthRegenSkill
+  _playerLevelSystem: {fileID: 0}
+  _playerHealth: {fileID: 0}
+  _skillId: health_regen
+  _regenPerSecondByLevel:
+  - 2
+  - 4
+  - 7
 --- !u!1 &275740323
 GameObject:
   m_ObjectHideFlags: 0

--- a/project1/Assets/Scripts/Combat/HealthRegenSkill.cs
+++ b/project1/Assets/Scripts/Combat/HealthRegenSkill.cs
@@ -1,0 +1,129 @@
+using Mukseon.Gameplay.Progression;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 재생의 굿거리(#74) — 발동 방식 ⑥ 상시 패시브(공용 스킬).
+    /// 스킬 획득 즉시 전투 중 초당 일정량의 HP를 지속 회복한다. 회복량은 고정 수치로,
+    /// 신당 체력(최대 HP) 업그레이드와 독립적으로 동작한다(skill_balance_mvp.md §3).
+    ///
+    /// 매 프레임 deltaTime에 비례해 회복하므로 회복이 매끄럽고, 최대 HP 초과 회복은
+    /// <see cref="PlayerHealth.Heal"/>의 클램프가, 사망 후 회복은 동일 메서드의 사망 가드가 막는다.
+    /// 레벨 추적은 <see cref="PlayerLevelSystem.OnSkillEffectPending"/> 구독 + OnEnable 동기화로
+    /// 처리한다(BarrierAuraSkill·InkTrailSlowSkill과 동일 패턴).
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class HealthRegenSkill : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField]
+        private PlayerLevelSystem _playerLevelSystem;
+
+        [SerializeField]
+        private PlayerHealth _playerHealth;
+
+        [SerializeField, Tooltip("연동 SkillData의 SkillId. OnEnable 레벨 동기화에 사용.")]
+        private string _skillId = "health_regen";
+
+        [Header("Per-Level (index 0 = Lv1) — skill_balance_mvp.md §3")]
+        [SerializeField, Tooltip("레벨별 초당 회복량(HP/초). 고정 수치 — 최대 HP 업그레이드와 독립적으로 동작.")]
+        private float[] _regenPerSecondByLevel = { 2f, 4f, 7f };
+
+        public const int MaxLevel = 3;
+
+        private int _level;
+
+        public int Level => _level;
+
+        /// <summary>현재 초당 회복량(HP/초). 미보유=0.</summary>
+        public float CurrentRegenPerSecond => _level < 1 ? 0f : GetPerLevel(_regenPerSecondByLevel, _level, 0f);
+
+        private void Awake()
+        {
+            if (_playerLevelSystem == null)
+            {
+                _playerLevelSystem = GetComponent<PlayerLevelSystem>();
+            }
+
+            if (_playerHealth == null)
+            {
+                _playerHealth = GetComponent<PlayerHealth>();
+            }
+        }
+
+        private void OnEnable()
+        {
+            if (_playerLevelSystem != null)
+            {
+                _playerLevelSystem.OnSkillEffectPending += HandleSkillEffectPending;
+                // 비활성 중 부여/레벨업 이벤트를 놓쳤을 수 있어 현재 레벨을 직접 동기화한다.
+                ApplyLevel(_playerLevelSystem.GetSkillLevel(_skillId));
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (_playerLevelSystem != null)
+            {
+                _playerLevelSystem.OnSkillEffectPending -= HandleSkillEffectPending;
+            }
+        }
+
+        private void HandleSkillEffectPending(SkillData skill, int nextLevel)
+        {
+            if (skill == null || skill.EffectType != LevelUpSkillEffectType.HealthRegen)
+            {
+                return;
+            }
+
+            ApplyLevel(nextLevel);
+        }
+
+        /// <summary>레벨을 직접 설정한다(이벤트 핸들러 및 테스트에서 사용). [0, MaxLevel]로 클램프.</summary>
+        public void ApplyLevel(int level)
+        {
+            _level = Mathf.Clamp(level, 0, MaxLevel);
+        }
+
+        private void Update()
+        {
+            if (_level < 1)
+            {
+                return;
+            }
+
+            ApplyRegen(Time.deltaTime);
+        }
+
+        /// <summary>
+        /// <paramref name="deltaTime"/> 동안의 회복(초당 회복량 × deltaTime)을 적용한다.
+        /// Update가 매 프레임 호출하며, 테스트에서는 임의의 deltaTime으로 직접 호출한다.
+        /// 미보유·사망·최대 HP 도달 시의 처리는 PlayerHealth.Heal에 위임한다.
+        /// </summary>
+        public void ApplyRegen(float deltaTime)
+        {
+            if (_level < 1 || _playerHealth == null || deltaTime <= 0f)
+            {
+                return;
+            }
+
+            float amount = CurrentRegenPerSecond * deltaTime;
+            if (amount > 0f)
+            {
+                _playerHealth.Heal(amount);
+            }
+        }
+
+        private static float GetPerLevel(float[] perLevel, int level, float fallback)
+        {
+            if (level < 1 || perLevel == null || perLevel.Length == 0)
+            {
+                return fallback;
+            }
+
+            int index = Mathf.Clamp(level - 1, 0, perLevel.Length - 1);
+            return perLevel[index];
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/HealthRegenSkill.cs
+++ b/project1/Assets/Scripts/Combat/HealthRegenSkill.cs
@@ -8,8 +8,8 @@ namespace Mukseon.Gameplay.Combat
     /// 스킬 획득 즉시 전투 중 초당 일정량의 HP를 지속 회복한다. 회복량은 고정 수치로,
     /// 신당 체력(최대 HP) 업그레이드와 독립적으로 동작한다(skill_balance_mvp.md §3).
     ///
-    /// 매 프레임 deltaTime에 비례해 회복하므로 회복이 매끄럽고, 최대 HP 초과 회복은
-    /// <see cref="PlayerHealth.Heal"/>의 클램프가, 사망 후 회복은 동일 메서드의 사망 가드가 막는다.
+    /// 매 프레임 deltaTime에 비례해 회복하므로 회복이 매끄럽다. 사망했거나 이미 최대 HP면 ApplyRegen이
+    /// 조기 반환해 불필요한 Heal 호출·이벤트를 피하고, 최종 안전장치로 <see cref="PlayerHealth.Heal"/>도 같은 조건을 막는다.
     /// 레벨 추적은 <see cref="PlayerLevelSystem.OnSkillEffectPending"/> 구독 + OnEnable 동기화로
     /// 처리한다(BarrierAuraSkill·InkTrailSlowSkill과 동일 패턴).
     /// </summary>
@@ -39,6 +39,13 @@ namespace Mukseon.Gameplay.Combat
         /// <summary>현재 초당 회복량(HP/초). 미보유=0.</summary>
         public float CurrentRegenPerSecond => _level < 1 ? 0f : GetPerLevel(_regenPerSecondByLevel, _level, 0f);
 
+        // 레벨 값 배열 길이를 실효 최대 레벨로 삼는다(배열이 비면 MaxLevel로 폴백).
+        // 인스펙터에서 배열을 늘리거나 줄여도 클램프가 정의된 데이터 범위를 벗어나지 않게 한다.
+        private int EffectiveMaxLevel =>
+            _regenPerSecondByLevel != null && _regenPerSecondByLevel.Length > 0
+                ? _regenPerSecondByLevel.Length
+                : MaxLevel;
+
         private void Awake()
         {
             if (_playerLevelSystem == null)
@@ -49,6 +56,14 @@ namespace Mukseon.Gameplay.Combat
             if (_playerHealth == null)
             {
                 _playerHealth = GetComponent<PlayerHealth>();
+            }
+
+            // 레벨 값 배열 길이가 설계상 최대 레벨과 다르면 GetPerLevel이 마지막 값을 반복 사용하게 되어
+            // 의도와 다른 수치가 적용될 수 있으므로 설정 드리프트를 경고로 알린다(클램프 자체는 실효 길이 기준이라 범위는 안전).
+            if (_regenPerSecondByLevel == null || _regenPerSecondByLevel.Length != MaxLevel)
+            {
+                int length = _regenPerSecondByLevel != null ? _regenPerSecondByLevel.Length : 0;
+                Debug.LogWarning($"[HealthRegenSkill] _regenPerSecondByLevel 길이({length})가 MaxLevel({MaxLevel})과 다릅니다. 레벨별 수치 설정을 확인하세요.");
             }
         }
 
@@ -80,10 +95,10 @@ namespace Mukseon.Gameplay.Combat
             ApplyLevel(nextLevel);
         }
 
-        /// <summary>레벨을 직접 설정한다(이벤트 핸들러 및 테스트에서 사용). [0, MaxLevel]로 클램프.</summary>
+        /// <summary>레벨을 직접 설정한다(이벤트 핸들러 및 테스트에서 사용). [0, 실효 최대 레벨]로 클램프.</summary>
         public void ApplyLevel(int level)
         {
-            _level = Mathf.Clamp(level, 0, MaxLevel);
+            _level = Mathf.Clamp(level, 0, EffectiveMaxLevel);
         }
 
         private void Update()
@@ -99,7 +114,7 @@ namespace Mukseon.Gameplay.Combat
         /// <summary>
         /// <paramref name="deltaTime"/> 동안의 회복(초당 회복량 × deltaTime)을 적용한다.
         /// Update가 매 프레임 호출하며, 테스트에서는 임의의 deltaTime으로 직접 호출한다.
-        /// 미보유·사망·최대 HP 도달 시의 처리는 PlayerHealth.Heal에 위임한다.
+        /// 미보유·사망·최대 HP 상태에서는 조기 반환해 불필요한 Heal 호출·이벤트를 피한다.
         /// </summary>
         public void ApplyRegen(float deltaTime)
         {
@@ -108,11 +123,15 @@ namespace Mukseon.Gameplay.Combat
                 return;
             }
 
-            float amount = CurrentRegenPerSecond * deltaTime;
-            if (amount > 0f)
+            // 사망/최대 HP면 Heal이 내부적으로 무효 처리하지만, 매 프레임 호출 자체를 피하려고 먼저 거른다.
+            if (!_playerHealth.IsAlive || _playerHealth.CurrentHealth >= _playerHealth.MaxHealth)
             {
-                _playerHealth.Heal(amount);
+                return;
             }
+
+            // 여기 도달 시 _level >= 1(회복량 > 0)이고 deltaTime > 0이므로 amount는 항상 양수다.
+            float amount = CurrentRegenPerSecond * deltaTime;
+            _playerHealth.Heal(amount);
         }
 
         private static float GetPerLevel(float[] perLevel, int level, float fallback)

--- a/project1/Assets/Scripts/Combat/HealthRegenSkill.cs.meta
+++ b/project1/Assets/Scripts/Combat/HealthRegenSkill.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1e5d65ccf6e44cb48832b63bbf0f67d3

--- a/project1/Assets/Settings/Data/Characters/Character_Baksu.asset
+++ b/project1/Assets/Settings/Data/Characters/Character_Baksu.asset
@@ -25,4 +25,5 @@ MonoBehaviour:
   - {fileID: 11400000, guid: b5f6b329496938f4780bf000813e8429, type: 2}
   - {fileID: 11400000, guid: 409eb7a6cfdb5704887435b77656ff18, type: 2}
   - {fileID: 11400000, guid: 4607d94a2a2945347a2e658b78885046, type: 2}
+  - {fileID: 11400000, guid: 7f23f3279b754c889acee2fc9ee0145c, type: 2}
   _startingSkills: []

--- a/project1/Assets/Settings/Data/Characters/Character_Mudang.asset
+++ b/project1/Assets/Settings/Data/Characters/Character_Mudang.asset
@@ -26,5 +26,6 @@ MonoBehaviour:
   - {fileID: 11400000, guid: be007eb0bf48ffd41bba6d449a38320f, type: 2}
   - {fileID: 11400000, guid: 409eb7a6cfdb5704887435b77656ff18, type: 2}
   - {fileID: 11400000, guid: 4607d94a2a2945347a2e658b78885046, type: 2}
+  - {fileID: 11400000, guid: 7f23f3279b754c889acee2fc9ee0145c, type: 2}
   _startingSkills:
   - {fileID: 11400000, guid: be007eb0bf48ffd41bba6d449a38320f, type: 2}

--- a/project1/Assets/Settings/Data/Skills/Skill_HealthRegen.asset
+++ b/project1/Assets/Settings/Data/Skills/Skill_HealthRegen.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9c108d14243300c4b992897d5c4b7f43, type: 3}
+  m_Name: Skill_HealthRegen
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Progression.SkillData
+  _skillId: health_regen
+  _displayName: "\uC7AC\uC0DD\uC758 \uAD7F\uAC70\uB9AC"
+  _description: "\uC804\uD22C \uC911 \uCD08\uB2F9 \uCCB4\uB825\uC744 \uC9C0\uC18D
+    \uD68C\uBCF5\uD55C\uB2E4. \uB808\uBCA8\uC5C5 \uC2DC
+    \uD68C\uBCF5\uB7C9 \uC99D\uAC00. \uD68C\uBCF5\uB7C9\uC740
+    \uACE0\uC815 \uC218\uCE58\uB85C \uC2E0\uB2F9 \uCCB4\uB825
+    \uC5C5\uADF8\uB808\uC774\uB4DC\uC640
+    \uB3C5\uB9BD\uC801\uC73C\uB85C \uB3D9\uC791\uD55C\uB2E4."
+  _effectType: 14
+  _statType: 1
+  _value: 1
+  _maxLevel: 3
+  _icon: {fileID: 0}

--- a/project1/Assets/Settings/Data/Skills/Skill_HealthRegen.asset.meta
+++ b/project1/Assets/Settings/Data/Skills/Skill_HealthRegen.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7f23f3279b754c889acee2fc9ee0145c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/project1/Assets/Tests/EditMode/HealthRegenTests.cs
+++ b/project1/Assets/Tests/EditMode/HealthRegenTests.cs
@@ -1,0 +1,171 @@
+using System.Reflection;
+using Mukseon.Gameplay.Combat;
+using Mukseon.Gameplay.Stats;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Mukseon.Tests.EditMode
+{
+    /// <summary>레벨별 초당 회복량 수치(skill_balance_mvp.md §3)와 클램프를 검증한다(PlayerHealth 불필요).</summary>
+    public class HealthRegenSkillLevelTests
+    {
+        private GameObject _go;
+        private HealthRegenSkill _skill;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _go = new GameObject("HealthRegenSkill");
+            _skill = _go.AddComponent<HealthRegenSkill>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_go != null)
+            {
+                Object.DestroyImmediate(_go);
+            }
+        }
+
+        [Test]
+        public void NotOwned_HasZeroRegen()
+        {
+            Assert.That(_skill.Level, Is.EqualTo(0));
+            Assert.That(_skill.CurrentRegenPerSecond, Is.EqualTo(0f));
+        }
+
+        [Test]
+        public void Level1To3_UseBalanceTableValues()
+        {
+            _skill.ApplyLevel(1);
+            Assert.That(_skill.CurrentRegenPerSecond, Is.EqualTo(2f).Within(1e-4f));
+
+            _skill.ApplyLevel(2);
+            Assert.That(_skill.CurrentRegenPerSecond, Is.EqualTo(4f).Within(1e-4f));
+
+            _skill.ApplyLevel(3);
+            Assert.That(_skill.CurrentRegenPerSecond, Is.EqualTo(7f).Within(1e-4f));
+        }
+
+        [Test]
+        public void ApplyLevel_ClampsToRange()
+        {
+            _skill.ApplyLevel(99);
+            Assert.That(_skill.Level, Is.EqualTo(HealthRegenSkill.MaxLevel));
+
+            _skill.ApplyLevel(-3);
+            Assert.That(_skill.Level, Is.EqualTo(0));
+        }
+    }
+
+    /// <summary>PlayerHealth와 결합한 회복 동작(누적·최대치 클램프·사망/미보유 가드)을 검증한다.</summary>
+    public class HealthRegenSkillRegenTests
+    {
+        private GameObject _go;
+        private PlayerHealth _playerHealth;
+        private HealthRegenSkill _skill;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _go = new GameObject("HealthRegenSkillRegen");
+            _go.AddComponent<PlayerStatSystem>();
+            _playerHealth = _go.AddComponent<PlayerHealth>();
+
+            // EditMode에서는 Awake가 호출되지 않아 직렬화 기본값/참조가 적용되지 않으므로 직접 세팅한다.
+            SetPrivateField(_playerHealth, "_fallbackMaxHealth", 100f);
+            _playerHealth.ResetHealth();
+
+            _skill = _go.AddComponent<HealthRegenSkill>();
+            // Awake 미호출 → GetComponent 자동 결선이 일어나지 않으므로 참조를 주입한다.
+            SetPrivateField(_skill, "_playerHealth", _playerHealth);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_go != null)
+            {
+                Object.DestroyImmediate(_go);
+            }
+        }
+
+        [Test]
+        public void ApplyRegen_HealsRateTimesDeltaTime()
+        {
+            _playerHealth.TakeDamage(50f); // 100 → 50
+            _skill.ApplyLevel(1);          // 2 HP/s
+
+            _skill.ApplyRegen(1f);         // +2
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(52f).Within(1e-3f));
+
+            _skill.ApplyRegen(0.5f);       // +1
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(53f).Within(1e-3f));
+        }
+
+        [Test]
+        public void ApplyRegen_ScalesWithLevel()
+        {
+            _playerHealth.TakeDamage(60f); // 100 → 40
+            _skill.ApplyLevel(3);          // 7 HP/s
+
+            _skill.ApplyRegen(2f);         // +14
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(54f).Within(1e-3f));
+        }
+
+        [Test]
+        public void ApplyRegen_DoesNotExceedMaxHealth()
+        {
+            _playerHealth.TakeDamage(1f);  // 100 → 99
+            _skill.ApplyLevel(3);          // 7 HP/s
+
+            _skill.ApplyRegen(10f);        // +70 → 최대치(100)에서 클램프
+
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(_playerHealth.MaxHealth).Within(1e-3f));
+        }
+
+        [Test]
+        public void ApplyRegen_NotOwned_DoesNothing()
+        {
+            _playerHealth.TakeDamage(30f);
+            float before = _playerHealth.CurrentHealth;
+
+            _skill.ApplyRegen(5f);         // 레벨 0
+
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(before));
+        }
+
+        [Test]
+        public void ApplyRegen_DeadPlayer_DoesNotRevive()
+        {
+            _playerHealth.TakeDamage(_playerHealth.MaxHealth + 1f); // 사망(0 HP)
+            Assert.That(_playerHealth.IsAlive, Is.False);
+
+            _skill.ApplyLevel(3);
+            _skill.ApplyRegen(5f);
+
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(0f));
+        }
+
+        [Test]
+        public void ApplyRegen_IgnoresZeroAndNegativeDeltaTime()
+        {
+            _playerHealth.TakeDamage(20f);
+            float before = _playerHealth.CurrentHealth;
+            _skill.ApplyLevel(2);
+
+            _skill.ApplyRegen(0f);
+            _skill.ApplyRegen(-1f);
+
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(before));
+        }
+
+        private static void SetPrivateField(object target, string fieldName, object value)
+        {
+            FieldInfo field = target.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.That(field, Is.Not.Null, $"Field '{fieldName}' not found on {target.GetType().Name}");
+            field.SetValue(target, value);
+        }
+    }
+}

--- a/project1/Assets/Tests/EditMode/HealthRegenTests.cs
+++ b/project1/Assets/Tests/EditMode/HealthRegenTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Mukseon.Gameplay.Combat;
+using Mukseon.Gameplay.Progression;
 using Mukseon.Gameplay.Stats;
 using NUnit.Framework;
 using UnityEngine;
@@ -56,6 +57,59 @@ namespace Mukseon.Tests.EditMode
 
             _skill.ApplyLevel(-3);
             Assert.That(_skill.Level, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void HandleSkillEffectPending_HealthRegenType_UpdatesLevel()
+        {
+            SkillData skill = MakeSkill(LevelUpSkillEffectType.HealthRegen);
+            try
+            {
+                InvokeHandleSkillEffectPending(_skill, skill, 2);
+                Assert.That(_skill.Level, Is.EqualTo(2));
+            }
+            finally
+            {
+                Object.DestroyImmediate(skill);
+            }
+        }
+
+        [Test]
+        public void HandleSkillEffectPending_OtherType_IsIgnored()
+        {
+            SkillData skill = MakeSkill(LevelUpSkillEffectType.BarrierRadiusExpand);
+            try
+            {
+                InvokeHandleSkillEffectPending(_skill, skill, 2);
+                Assert.That(_skill.Level, Is.EqualTo(0));
+            }
+            finally
+            {
+                Object.DestroyImmediate(skill);
+            }
+        }
+
+        [Test]
+        public void HandleSkillEffectPending_NullSkill_IsIgnored()
+        {
+            InvokeHandleSkillEffectPending(_skill, null, 2);
+            Assert.That(_skill.Level, Is.EqualTo(0));
+        }
+
+        private static SkillData MakeSkill(LevelUpSkillEffectType effectType)
+        {
+            SkillData skill = ScriptableObject.CreateInstance<SkillData>();
+            FieldInfo field = typeof(SkillData).GetField("_effectType", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.That(field, Is.Not.Null, "SkillData._effectType field not found");
+            field.SetValue(skill, effectType);
+            return skill;
+        }
+
+        private static void InvokeHandleSkillEffectPending(HealthRegenSkill skill, SkillData data, int nextLevel)
+        {
+            MethodInfo method = typeof(HealthRegenSkill).GetMethod("HandleSkillEffectPending", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.That(method, Is.Not.Null, "HealthRegenSkill.HandleSkillEffectPending method not found");
+            method.Invoke(skill, new object[] { data, nextLevel });
         }
     }
 

--- a/project1/Assets/Tests/EditMode/HealthRegenTests.cs.meta
+++ b/project1/Assets/Tests/EditMode/HealthRegenTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0ffcfddafa4c4667991c8a8c41d42ed0


### PR DESCRIPTION
## 개요
이슈 #74 — **재생의 굿거리**(초당 HP 지속 회복) 구현. 발동 방식 ⑥ 상시 패시브(공용 스킬). 스킬 획득 즉시 전투 중 초당 일정량의 HP를 지속 회복하며, 회복량은 **고정 수치**라 신당 체력(최대 HP) 업그레이드와 독립적으로 동작한다.

## 레벨별 수치 (skill_balance_mvp.md §3)
| 레벨 | 초당 회복량 |
|------|-----------|
| 1 | 2 HP/s |
| 2 | 4 HP/s |
| 3 | 7 HP/s |

최대 레벨 3.

## 변경 사항
- **HealthRegenSkill.cs**: `OnSkillEffectPending` 구독 + `OnEnable` 레벨 동기화(BarrierAuraSkill·InkTrailSlowSkill과 동일 패턴). `Update`에서 매 프레임 `Heal(rate × deltaTime)`로 매끄럽게 지속 회복. 최대 HP 초과/사망 시 회복 차단은 `PlayerHealth.Heal`의 가드에 위임.
- **Skill_HealthRegen.asset**: `SkillData`(EffectType=HealthRegen, maxLevel=3). 공용 스킬이라 무당/박수 양쪽 레벨업 풀에 연결.
- **SampleScene**: Player에 `HealthRegenSkill` 컴포넌트 추가.

## 완료 기준 (DoD)
- [x] 스킬 획득 즉시 초당 정의된 HP 회복
- [x] 레벨업 시 회복량 갱신 (`OnSkillEffectPending` → `ApplyLevel`)
- [x] 최대 HP 초과 회복 방지 (`PlayerHealth.Heal` 클램프)
- [x] `SkillData` ScriptableObject로 수치 관리

## 테스트/검증
- **HealthRegenTests (EditMode)**: 레벨별 수치(2/4/7)·클램프 + PlayerHealth 결합 회복(누적·최대치 클램프·사망/미보유/0 deltaTime 가드).
- **런타임 스모크**: 50→52→54 회복, 대량 회복 시 최대치(100) 클램프, 사망 후 무회복(무부활) 확인. 인게임에서 시작 HP 50%로 회복이 HUD·실측값 모두 정상 반영됨을 확인.

관련 이슈: #66 (강화 카드 시스템 — 스킬 획득/레벨업 트리거)

🤖 Generated with [Claude Code](https://claude.com/claude-code)