### PR TITLE
feat: 도깨비불 소환 스킬 구현 — 궤도 드론/탐지/자폭/일괄 재소환 (#72)

### DIFF
--- a/project1/Assets/Prefabs/Skills.meta
+++ b/project1/Assets/Prefabs/Skills.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 97179cde1eb5a704ba0e053b44b44a14
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/project1/Assets/Prefabs/Skills/DokkaebiOrbDrone.prefab
+++ b/project1/Assets/Prefabs/Skills/DokkaebiOrbDrone.prefab
@@ -1,0 +1,107 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8224889374593239114
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1604411849867940375}
+  - component: {fileID: 7482695136541514428}
+  - component: {fileID: 6830693106595643412}
+  m_Layer: 0
+  m_Name: DokkaebiOrbDrone
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1604411849867940375
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8224889374593239114}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.35, y: 0.35, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &7482695136541514428
+SpriteRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8224889374593239114}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 10
+  m_MaskInteraction: 0
+  m_Sprite: {fileID: -755589722, guid: f9c5ac197d26d8f4ca51380a395fde85, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 2.56, y: 2.56}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_SpriteSortPoint: 0
+--- !u!114 &6830693106595643412
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8224889374593239114}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ca941cdd4ea04dc8b677220a5ce67345, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.DokkaebiOrbDrone
+  _explosionVfxPrefab: {fileID: 0}

--- a/project1/Assets/Prefabs/Skills/DokkaebiOrbDrone.prefab.meta
+++ b/project1/Assets/Prefabs/Skills/DokkaebiOrbDrone.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e54e545fd240e4646a7ce27f3dc8fde5
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/project1/Assets/SampleScene.unity
+++ b/project1/Assets/SampleScene.unity
@@ -174,6 +174,7 @@ GameObject:
   - component: {fileID: 187285043}
   - component: {fileID: 187285044}
   - component: {fileID: 187285045}
+  - component: {fileID: 187285046}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -542,6 +543,47 @@ MonoBehaviour:
   - 2
   - 4
   - 7
+--- !u!114 &187285046
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 187285028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 22c7d46f74ce4cac8065fad939b74293, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.DokkaebiOrbSkill
+  _playerLevelSystem: {fileID: 187285035}
+  _orbitCenter: {fileID: 187285032}
+  _skillId: dokkaebi_orb
+  _dronePrefab: {fileID: 8224889374593239114, guid: e54e545fd240e4646a7ce27f3dc8fde5, type: 3}
+  _orbitRadius: 1.8
+  _orbitAngularSpeedDeg: 120
+  _baseDetectRange: 4
+  _explosionRadius: 1.5
+  _chargeSpeed: 9
+  _detonateDistance: 0.35
+  _droneCountPerLevel: 0100000001000000020000000200000003000000
+  _detectRangeMultiplierPerLevel:
+  - 1
+  - 1.2
+  - 1.2
+  - 1.3
+  - 1.3
+  _explosionDamagePerLevel:
+  - 50
+  - 65
+  - 65
+  - 80
+  - 100
+  _resummonCooldownPerLevel:
+  - 5
+  - 4.5
+  - 4.5
+  - 4
+  - 3.5
 --- !u!1 &275740323
 GameObject:
   m_ObjectHideFlags: 0
@@ -1967,7 +2009,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 844f18395eff4a4458380264f791323c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Core.Pool.PoolManager
-  _presets: []
+  _presets:
+  - Prefab: {fileID: 8224889374593239114, guid: e54e545fd240e4646a7ce27f3dc8fde5, type: 3}
+    InitialSize: 3
+    MaxSize: 8
 --- !u!4 &2014046898
 Transform:
   m_ObjectHideFlags: 0

--- a/project1/Assets/Scripts/Combat/BarrierTickDamage.cs
+++ b/project1/Assets/Scripts/Combat/BarrierTickDamage.cs
@@ -4,9 +4,8 @@ using UnityEngine;
 namespace Mukseon.Gameplay.Combat
 {
     /// <summary>
-    /// 항마의 결계(#73)의 틱 데미지 적용 — 순수 로직.
-    /// 원점 기준 반경 내의 살아있고 타격 가능한 적 전체에 데미지를 적용한다(범위 밖 적은 영향 없음).
-    /// 물리 충돌 대신 거리 비교(sqrMagnitude)를 사용해 기존 타겟팅(SwipeAttackTargeting 등)과 일관성을 맞춘다.
+    /// 항마의 결계(#73)의 틱 데미지 적용 — 결계 전용 진입점.
+    /// 실제 반경 데미지 로직은 공용 <see cref="RadialDamage.ApplyInRadius"/>에 위임한다.
     /// </summary>
     public static class BarrierTickDamage
     {
@@ -20,35 +19,7 @@ namespace Mukseon.Gameplay.Combat
             IReadOnlyList<EnemyHealth> enemies,
             object source)
         {
-            if (enemies == null || radius <= 0f || damage <= 0f || enemies.Count == 0)
-            {
-                return 0;
-            }
-
-            // ApplyDamage로 적이 사망하면 EnemyHealth.ActiveEnemies에서 즉시 제거되어
-            // 순회 중 컬렉션이 변경(인덱스 밀림 → 다음 적 스킵)될 수 있다. 스냅샷을 떠서 순회한다.
-            var targets = new List<EnemyHealth>(enemies);
-            float sqrRadius = radius * radius;
-            int hitCount = 0;
-
-            for (int i = 0; i < targets.Count; i++)
-            {
-                EnemyHealth enemy = targets[i];
-                if (enemy == null || !enemy.IsAlive || !enemy.IsTargetable)
-                {
-                    continue;
-                }
-
-                if (((Vector2)enemy.transform.position - origin).sqrMagnitude > sqrRadius)
-                {
-                    continue;
-                }
-
-                enemy.ApplyDamage(damage, source);
-                hitCount++;
-            }
-
-            return hitCount;
+            return RadialDamage.ApplyInRadius(origin, radius, damage, enemies, source);
         }
     }
 }

--- a/project1/Assets/Scripts/Combat/DokkaebiOrbDrone.cs
+++ b/project1/Assets/Scripts/Combat/DokkaebiOrbDrone.cs
@@ -1,0 +1,240 @@
+using Mukseon.Core.Pool;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 도깨비불 소환(#72)의 드론 — 풀링되는 궤도 비행 오브젝트.
+    /// 소유 스킬(<see cref="DokkaebiOrbSkill"/>)이 풀에서 꺼내 <see cref="Initialize"/>로 설정한 뒤 활성화한다.
+    ///
+    /// 상태:
+    /// - <b>Orbit</b>: 플레이어(궤도 중심) 주변을 원형으로 비행하며 탐지 범위 내 가장 가까운 적을 탐색한다.
+    /// - <b>Charging</b>: 타깃을 향해 돌진한다. 근접 도달 시 자폭.
+    ///   돌진 중 타깃이 사라지면 <b>드론 위치 기준</b>으로 다른 적을 재탐색하고, 없으면 마지막 타깃 위치까지
+    ///   계속 날아가 그 자리에서 자폭한다(궤도로 되돌아가지 않는다 — 여러 드론이 한 적을 노릴 때의 순간이동 방지).
+    /// - <b>Consumed</b>: 자폭 후 모습을 감춘 채 스킬의 일괄 재소환(<see cref="Resummon"/>)을 기다린다.
+    ///
+    /// 재소환 쿨타임은 개별 드론이 아니라 스킬이 공유 클럭으로 관리한다(돌진 시작 시 시작, 경과 시 소비된 드론 일괄 재소환).
+    /// 반경·데미지 등 수치는 매 프레임 소유 스킬에서 실시간 조회하므로 스킬 레벨업이 즉시 반영된다.
+    /// 폭발 데미지는 공용 <see cref="RadialDamage.ApplyInRadius"/>로 적용한다.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class DokkaebiOrbDrone : MonoBehaviour
+    {
+        public enum DroneState
+        {
+            Orbit,
+            Charging,
+            Consumed,
+        }
+
+        [SerializeField, Tooltip("자폭 시 생성할 폭발 VFX 프리팹(선택). 풀링 대상.")]
+        private GameObject _explosionVfxPrefab;
+
+        private DokkaebiOrbSkill _skill;
+        private DroneState _state;
+        private float _phaseDeg;
+        private EnemyHealth _target;
+        private Vector2 _chargeTargetPos;
+
+        private SpriteRenderer[] _renderers;
+        private bool _renderersCached;
+
+        /// <summary>현재 드론 상태. 스킬이 공유 쿨타임/일괄 재소환 판정에 사용한다.</summary>
+        public DroneState State => _state;
+
+        /// <summary>
+        /// 풀에서 비활성으로 꺼낸 직후(활성화 전)에 호출해 드론을 설정한다.
+        /// </summary>
+        public void Initialize(DokkaebiOrbSkill skill, float phaseDeg)
+        {
+            _skill = skill;
+            _phaseDeg = phaseDeg;
+            _state = DroneState.Orbit;
+            _target = null;
+
+            SetVisible(true);
+            SnapToOrbit();
+        }
+
+        /// <summary>소유 스킬이 드론 수 변동 시 궤도 위상을 균등 분배하기 위해 호출한다.</summary>
+        public void SetOrbitPhase(float phaseDeg)
+        {
+            _phaseDeg = phaseDeg;
+        }
+
+        /// <summary>스킬이 공유 쿨타임 경과로 일괄 재소환할 때 호출 — 소비된 드론을 궤도로 되돌린다.</summary>
+        public void Resummon()
+        {
+            _target = null;
+            _state = DroneState.Orbit;
+            SetVisible(true);
+            SnapToOrbit();
+        }
+
+        private void OnDisable()
+        {
+            // 풀 반환·파괴 시 상태를 깨끗이 리셋해 재사용 시 오염을 막는다.
+            _state = DroneState.Orbit;
+            _target = null;
+        }
+
+        private void Update()
+        {
+            if (_skill == null)
+            {
+                return;
+            }
+
+            float dt = Time.deltaTime;
+
+            // 궤도 각도는 항상 진행시켜, 재소환 위치가 자연스럽게 분산되도록 한다.
+            _phaseDeg = Mathf.Repeat(_phaseDeg + _skill.OrbitAngularSpeedDeg * dt, 360f);
+
+            switch (_state)
+            {
+                case DroneState.Orbit:
+                    TickOrbit();
+                    break;
+                case DroneState.Charging:
+                    TickCharging(dt);
+                    break;
+                case DroneState.Consumed:
+                    // 스킬의 일괄 재소환을 기다린다(자체 쿨타임 없음).
+                    break;
+            }
+        }
+
+        private void TickOrbit()
+        {
+            SnapToOrbit();
+
+            // 탐지는 드론(도깨비불) 자신의 현재 위치를 기준으로 한다(돌진 중 재탐색과 동일 기준).
+            EnemyHealth target = DokkaebiOrbTargeting.FindNearestTarget(
+                transform.position, _skill.CurrentDetectRange, EnemyHealth.ActiveEnemies);
+
+            if (target != null)
+            {
+                _target = target;
+                _chargeTargetPos = target.transform.position;
+                _state = DroneState.Charging;
+            }
+        }
+
+        private void TickCharging(float dt)
+        {
+            Vector2 dronePos = transform.position;
+
+            if (_target != null && _target.IsAlive && _target.IsTargetable)
+            {
+                // 타깃 추적 — 현재 위치를 갱신한다.
+                _chargeTargetPos = _target.transform.position;
+            }
+            else
+            {
+                // 타깃 소실 — 드론 위치 기준으로 다른 적을 재탐색한다.
+                // 없으면 _target=null로 두고 마지막 위치(_chargeTargetPos)까지 날아가 그 자리에서 자폭한다.
+                EnemyHealth reacquired = DokkaebiOrbTargeting.FindNearestTarget(
+                    dronePos, _skill.CurrentDetectRange, EnemyHealth.ActiveEnemies);
+
+                if (reacquired != null)
+                {
+                    _target = reacquired;
+                    _chargeTargetPos = reacquired.transform.position;
+                }
+                else
+                {
+                    _target = null;
+                }
+            }
+
+            Vector2 toTarget = _chargeTargetPos - dronePos;
+            float detonate = _skill.DetonateDistance;
+            if (toTarget.sqrMagnitude <= detonate * detonate)
+            {
+                Detonate();
+                return;
+            }
+
+            Vector2 step = toTarget.normalized * (_skill.ChargeSpeed * dt);
+            transform.position = new Vector3(dronePos.x + step.x, dronePos.y + step.y, transform.position.z);
+        }
+
+        private void Detonate()
+        {
+            Vector2 explosionCenter = transform.position;
+            RadialDamage.ApplyInRadius(
+                explosionCenter,
+                _skill.ExplosionRadius,
+                _skill.CurrentExplosionDamage,
+                EnemyHealth.ActiveEnemies,
+                _skill);
+
+            SpawnExplosionVfx(explosionCenter);
+
+            _target = null;
+            _state = DroneState.Consumed;
+            SetVisible(false);
+        }
+
+        private void SpawnExplosionVfx(Vector2 position)
+        {
+            if (_explosionVfxPrefab == null)
+            {
+                return;
+            }
+
+            var pos = new Vector3(position.x, position.y, 0f);
+            if (PoolManager.Instance != null)
+            {
+                PoolManager.Instance.Get(_explosionVfxPrefab, pos, Quaternion.identity);
+            }
+            else
+            {
+                Instantiate(_explosionVfxPrefab, pos, Quaternion.identity);
+            }
+        }
+
+        private void SnapToOrbit()
+        {
+            Vector2 center = OrbitCenterPosition;
+            float rad = _phaseDeg * Mathf.Deg2Rad;
+            float radius = _skill.OrbitRadius;
+            transform.position = new Vector3(
+                center.x + Mathf.Cos(rad) * radius,
+                center.y + Mathf.Sin(rad) * radius,
+                transform.position.z);
+        }
+
+        private Vector2 OrbitCenterPosition
+        {
+            get
+            {
+                Transform center = _skill.OrbitCenter;
+                return center != null ? (Vector2)center.position : (Vector2)transform.position;
+            }
+        }
+
+        private void SetVisible(bool visible)
+        {
+            if (!_renderersCached)
+            {
+                _renderers = GetComponentsInChildren<SpriteRenderer>(true);
+                _renderersCached = true;
+            }
+
+            if (_renderers == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < _renderers.Length; i++)
+            {
+                if (_renderers[i] != null)
+                {
+                    _renderers[i].enabled = visible;
+                }
+            }
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/DokkaebiOrbDrone.cs
+++ b/project1/Assets/Scripts/Combat/DokkaebiOrbDrone.cs
@@ -156,8 +156,9 @@ namespace Mukseon.Gameplay.Combat
                 return;
             }
 
-            Vector2 step = toTarget.normalized * (_skill.ChargeSpeed * dt);
-            transform.position = new Vector3(dronePos.x + step.x, dronePos.y + step.y, transform.position.z);
+            // MoveTowards로 목표 위치를 초과하지 않게 이동을 제한한다(저프레임/고속 돌진 시 오버슈트·진동 방지).
+            Vector2 newPos = Vector2.MoveTowards(dronePos, _chargeTargetPos, _skill.ChargeSpeed * dt);
+            transform.position = new Vector3(newPos.x, newPos.y, transform.position.z);
         }
 
         private void Detonate()
@@ -206,14 +207,8 @@ namespace Mukseon.Gameplay.Combat
                 transform.position.z);
         }
 
-        private Vector2 OrbitCenterPosition
-        {
-            get
-            {
-                Transform center = _skill.OrbitCenter;
-                return center != null ? (Vector2)center.position : (Vector2)transform.position;
-            }
-        }
+        // _skill.OrbitCenter는 항상 non-null이다(스킬이 미지정 시 자기 transform으로 폴백).
+        private Vector2 OrbitCenterPosition => _skill.OrbitCenter.position;
 
         private void SetVisible(bool visible)
         {

--- a/project1/Assets/Scripts/Combat/DokkaebiOrbDrone.cs
+++ b/project1/Assets/Scripts/Combat/DokkaebiOrbDrone.cs
@@ -8,13 +8,13 @@ namespace Mukseon.Gameplay.Combat
     /// 소유 스킬(<see cref="DokkaebiOrbSkill"/>)이 풀에서 꺼내 <see cref="Initialize"/>로 설정한 뒤 활성화한다.
     ///
     /// 상태:
-    /// - <b>Orbit</b>: 플레이어(궤도 중심) 주변을 원형으로 비행하며 탐지 범위 내 가장 가까운 적을 탐색한다.
-    /// - <b>Charging</b>: 타깃을 향해 돌진한다. 근접 도달 시 자폭.
+    /// - <b>Orbit</b>: 플레이어(궤도 중심) 주변을 원형으로 비행하며 탐지 범위 내 가장 가까운 적을 탐색한다(= squad 구성원).
+    /// - <b>Charging</b>: 타깃을 향해 돌진한다(= squad에서 분리되어 날아가는 일회성 발사체). 근접 도달 시 자폭.
     ///   돌진 중 타깃이 사라지면 <b>드론 위치 기준</b>으로 다른 적을 재탐색하고, 없으면 마지막 타깃 위치까지
     ///   계속 날아가 그 자리에서 자폭한다(궤도로 되돌아가지 않는다 — 여러 드론이 한 적을 노릴 때의 순간이동 방지).
-    /// - <b>Consumed</b>: 자폭 후 모습을 감춘 채 스킬의 일괄 재소환(<see cref="Resummon"/>)을 기다린다.
     ///
-    /// 재소환 쿨타임은 개별 드론이 아니라 스킬이 공유 클럭으로 관리한다(돌진 시작 시 시작, 경과 시 소비된 드론 일괄 재소환).
+    /// 한번 돌진을 시작한 드론은 squad에서 빠진 것으로 간주된다. 자폭하면 스킬에 알려 풀로 회수되며,
+    /// 궤도 정원은 스킬이 공유 쿨타임으로 한 번에 보충한다(비행 중인 드론은 정원 계산에서 제외).
     /// 반경·데미지 등 수치는 매 프레임 소유 스킬에서 실시간 조회하므로 스킬 레벨업이 즉시 반영된다.
     /// 폭발 데미지는 공용 <see cref="RadialDamage.ApplyInRadius"/>로 적용한다.
     /// </summary>
@@ -25,7 +25,6 @@ namespace Mukseon.Gameplay.Combat
         {
             Orbit,
             Charging,
-            Consumed,
         }
 
         [SerializeField, Tooltip("자폭 시 생성할 폭발 VFX 프리팹(선택). 풀링 대상.")]
@@ -37,10 +36,7 @@ namespace Mukseon.Gameplay.Combat
         private EnemyHealth _target;
         private Vector2 _chargeTargetPos;
 
-        private SpriteRenderer[] _renderers;
-        private bool _renderersCached;
-
-        /// <summary>현재 드론 상태. 스킬이 공유 쿨타임/일괄 재소환 판정에 사용한다.</summary>
+        /// <summary>현재 드론 상태. 스킬이 궤도 정원(보충 대상) 판정에 사용한다.</summary>
         public DroneState State => _state;
 
         /// <summary>
@@ -53,22 +49,6 @@ namespace Mukseon.Gameplay.Combat
             _state = DroneState.Orbit;
             _target = null;
 
-            SetVisible(true);
-            SnapToOrbit();
-        }
-
-        /// <summary>소유 스킬이 드론 수 변동 시 궤도 위상을 균등 분배하기 위해 호출한다.</summary>
-        public void SetOrbitPhase(float phaseDeg)
-        {
-            _phaseDeg = phaseDeg;
-        }
-
-        /// <summary>스킬이 공유 쿨타임 경과로 일괄 재소환할 때 호출 — 소비된 드론을 궤도로 되돌린다.</summary>
-        public void Resummon()
-        {
-            _target = null;
-            _state = DroneState.Orbit;
-            SetVisible(true);
             SnapToOrbit();
         }
 
@@ -88,7 +68,7 @@ namespace Mukseon.Gameplay.Combat
 
             float dt = Time.deltaTime;
 
-            // 궤도 각도는 항상 진행시켜, 재소환 위치가 자연스럽게 분산되도록 한다.
+            // 궤도 각도는 항상 진행시킨다.
             _phaseDeg = Mathf.Repeat(_phaseDeg + _skill.OrbitAngularSpeedDeg * dt, 360f);
 
             switch (_state)
@@ -98,9 +78,6 @@ namespace Mukseon.Gameplay.Combat
                     break;
                 case DroneState.Charging:
                     TickCharging(dt);
-                    break;
-                case DroneState.Consumed:
-                    // 스킬의 일괄 재소환을 기다린다(자체 쿨타임 없음).
                     break;
             }
         }
@@ -174,8 +151,9 @@ namespace Mukseon.Gameplay.Combat
             SpawnExplosionVfx(explosionCenter);
 
             _target = null;
-            _state = DroneState.Consumed;
-            SetVisible(false);
+            // 비행 중 드론은 일회성이다 — 자폭 후 스킬에 알려 풀로 회수한다.
+            // (궤도 정원 보충은 스킬이 공유 쿨타임으로 한 번에 처리한다.)
+            _skill.NotifyDroneDetonated(this);
         }
 
         private void SpawnExplosionVfx(Vector2 position)
@@ -209,27 +187,5 @@ namespace Mukseon.Gameplay.Combat
 
         // _skill.OrbitCenter는 항상 non-null이다(스킬이 미지정 시 자기 transform으로 폴백).
         private Vector2 OrbitCenterPosition => _skill.OrbitCenter.position;
-
-        private void SetVisible(bool visible)
-        {
-            if (!_renderersCached)
-            {
-                _renderers = GetComponentsInChildren<SpriteRenderer>(true);
-                _renderersCached = true;
-            }
-
-            if (_renderers == null)
-            {
-                return;
-            }
-
-            for (int i = 0; i < _renderers.Length; i++)
-            {
-                if (_renderers[i] != null)
-                {
-                    _renderers[i].enabled = visible;
-                }
-            }
-        }
     }
 }

--- a/project1/Assets/Scripts/Combat/DokkaebiOrbDrone.cs.meta
+++ b/project1/Assets/Scripts/Combat/DokkaebiOrbDrone.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ca941cdd4ea04dc8b677220a5ce67345

--- a/project1/Assets/Scripts/Combat/DokkaebiOrbResummonClock.cs
+++ b/project1/Assets/Scripts/Combat/DokkaebiOrbResummonClock.cs
@@ -1,0 +1,68 @@
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 도깨비불 소환(#72)의 공유 재소환 쿨타임 클럭 — 순수 로직(테스트 가능).
+    ///
+    /// 규칙:
+    /// - 드론이 처음 돌진을 시작(타깃 락온)하면 쿨타임이 시작된다.
+    /// - 쿨타임이 경과하면 "소비된(자폭 후 숨김)" 드론을 한 번에 재소환해야 함을 알린다(<see cref="Tick"/> 반환 true).
+    /// - 경과 시점에 아직 돌진 중인 드론이 있으면 다음 주기를 이어가, 그 드론들이 자폭한 뒤에도 재소환되게 한다.
+    /// - 돌진 중인 드론이 없으면 클럭을 멈춘다(주변에 적이 없어 전체가 궤도만 돌면 재소환하지 않음).
+    ///
+    /// 실제 어떤 드론을 재소환할지(소비된 드론만)는 호출자가 결정한다. 이 클럭은 "언제 일괄 재소환할지"만 판정한다.
+    /// </summary>
+    public sealed class DokkaebiOrbResummonClock
+    {
+        private bool _running;
+        private float _timer;
+
+        public bool IsRunning => _running;
+        public float Remaining => _timer;
+
+        /// <summary>
+        /// 한 프레임 진행한다.
+        /// <paramref name="anyDroneCharging"/>: 현재 돌진(비행) 중인 드론이 하나라도 있는지.
+        /// <paramref name="cooldown"/>: 현재 레벨의 재소환 쿨타임(초).
+        /// 반환값이 true면 소비된 드론을 일괄 재소환해야 한다.
+        /// </summary>
+        public bool Tick(float deltaTime, bool anyDroneCharging, float cooldown)
+        {
+            if (!_running)
+            {
+                // 첫 교전(돌진 시작) 시 쿨타임을 시작한다. 시작 프레임에는 차감하지 않는다.
+                if (anyDroneCharging)
+                {
+                    _timer = cooldown;
+                    _running = true;
+                }
+
+                return false;
+            }
+
+            _timer -= deltaTime;
+            if (_timer > 0f)
+            {
+                return false;
+            }
+
+            // 쿨타임 경과 — 일괄 재소환 신호. 아직 비행 중인 드론이 있으면 다음 주기를 잇고, 없으면 멈춘다.
+            if (anyDroneCharging)
+            {
+                _timer = cooldown;
+            }
+            else
+            {
+                _running = false;
+            }
+
+            return true;
+        }
+
+        /// <summary>클럭을 초기 상태로 되돌린다(스킬 비활성화 등).</summary>
+        public void Reset()
+        {
+            _running = false;
+            _timer = 0f;
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/DokkaebiOrbResummonClock.cs
+++ b/project1/Assets/Scripts/Combat/DokkaebiOrbResummonClock.cs
@@ -48,7 +48,8 @@ namespace Mukseon.Gameplay.Combat
             // 쿨타임 경과 — 일괄 재소환 신호. 아직 비행 중인 드론이 있으면 다음 주기를 잇고, 없으면 멈춘다.
             if (anyDroneCharging)
             {
-                _timer = cooldown;
+                // 음수로 누적된 오버슈트(저프레임 등 deltaTime이 쿨타임을 초과)를 이월해 장기적으로 주기가 밀리지 않게 한다.
+                _timer += cooldown;
             }
             else
             {

--- a/project1/Assets/Scripts/Combat/DokkaebiOrbResummonClock.cs
+++ b/project1/Assets/Scripts/Combat/DokkaebiOrbResummonClock.cs
@@ -4,12 +4,13 @@ namespace Mukseon.Gameplay.Combat
     /// 도깨비불 소환(#72)의 공유 재소환 쿨타임 클럭 — 순수 로직(테스트 가능).
     ///
     /// 규칙:
-    /// - 드론이 처음 돌진을 시작(타깃 락온)하면 쿨타임이 시작된다.
-    /// - 쿨타임이 경과하면 "소비된(자폭 후 숨김)" 드론을 한 번에 재소환해야 함을 알린다(<see cref="Tick"/> 반환 true).
-    /// - 경과 시점에 아직 돌진 중인 드론이 있으면 다음 주기를 이어가, 그 드론들이 자폭한 뒤에도 재소환되게 한다.
-    /// - 돌진 중인 드론이 없으면 클럭을 멈춘다(주변에 적이 없어 전체가 궤도만 돌면 재소환하지 않음).
+    /// - 궤도 정원이 부족해지면(드론이 돌진해 나갔거나 자폭으로 소멸) 쿨타임이 시작된다.
+    /// - 쿨타임이 경과하면 궤도 정원까지 한 번에 보충해야 함을 알린다(<see cref="Tick"/> 반환 true).
+    /// - 보충으로 정원이 다시 채워지면(부족 상태 해제) 클럭은 멈춘다.
+    ///   주변에 적이 없어 전체가 궤도만 돌면(= 정원이 가득 차 보충이 필요 없으면) 시작하지 않는다.
     ///
-    /// 실제 어떤 드론을 재소환할지(소비된 드론만)는 호출자가 결정한다. 이 클럭은 "언제 일괄 재소환할지"만 판정한다.
+    /// 어떤 드론을/몇 개를 보충할지는 호출자가 결정한다(비행 중인 드론은 정원 계산에서 제외).
+    /// 이 클럭은 "언제 정원을 보충할지"만 판정한다.
     /// </summary>
     public sealed class DokkaebiOrbResummonClock
     {
@@ -21,21 +22,24 @@ namespace Mukseon.Gameplay.Combat
 
         /// <summary>
         /// 한 프레임 진행한다.
-        /// <paramref name="anyDroneCharging"/>: 현재 돌진(비행) 중인 드론이 하나라도 있는지.
+        /// <paramref name="replenishPending"/>: 궤도 정원이 부족해 보충이 필요한지(궤도 드론 수 &lt; 정원).
         /// <paramref name="cooldown"/>: 현재 레벨의 재소환 쿨타임(초).
-        /// 반환값이 true면 소비된 드론을 일괄 재소환해야 한다.
+        /// 반환값이 true면 궤도 정원까지 보충해야 한다.
         /// </summary>
-        public bool Tick(float deltaTime, bool anyDroneCharging, float cooldown)
+        public bool Tick(float deltaTime, bool replenishPending, float cooldown)
         {
+            // 보충할 필요가 없으면(정원이 가득) 클럭을 멈춘다. 부족해지는 순간 다시 시작한다.
+            if (!replenishPending)
+            {
+                _running = false;
+                return false;
+            }
+
             if (!_running)
             {
-                // 첫 교전(돌진 시작) 시 쿨타임을 시작한다. 시작 프레임에는 차감하지 않는다.
-                if (anyDroneCharging)
-                {
-                    _timer = cooldown;
-                    _running = true;
-                }
-
+                // 정원이 처음 부족해진 시점에 쿨타임을 시작한다(시작 프레임은 차감하지 않는다).
+                _timer = cooldown;
+                _running = true;
                 return false;
             }
 
@@ -45,17 +49,8 @@ namespace Mukseon.Gameplay.Combat
                 return false;
             }
 
-            // 쿨타임 경과 — 일괄 재소환 신호. 아직 비행 중인 드론이 있으면 다음 주기를 잇고, 없으면 멈춘다.
-            if (anyDroneCharging)
-            {
-                // 음수로 누적된 오버슈트(저프레임 등 deltaTime이 쿨타임을 초과)를 이월해 장기적으로 주기가 밀리지 않게 한다.
-                _timer += cooldown;
-            }
-            else
-            {
-                _running = false;
-            }
-
+            // 쿨타임 경과 — 보충 신호. 발화 후 정지하며, 보충 뒤에도 여전히 부족하면 다음 프레임에 재시작한다.
+            _running = false;
             return true;
         }
 

--- a/project1/Assets/Scripts/Combat/DokkaebiOrbResummonClock.cs.meta
+++ b/project1/Assets/Scripts/Combat/DokkaebiOrbResummonClock.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 852633d818f54414885241cbabdb866b

--- a/project1/Assets/Scripts/Combat/DokkaebiOrbSkill.cs
+++ b/project1/Assets/Scripts/Combat/DokkaebiOrbSkill.cs
@@ -1,0 +1,341 @@
+using System.Collections.Generic;
+using Mukseon.Core.Pool;
+using Mukseon.Gameplay.Progression;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 도깨비불 소환(#72) — 발동 방식 ② 쿨타임 자동 발동(공용 스킬).
+    /// 플레이어 주변을 궤도 비행하는 도깨비불 드론(<see cref="DokkaebiOrbDrone"/>)을 레벨별 개수만큼 소환한다.
+    /// 각 드론은 독립적으로 탐지·돌진·자폭하며, 자폭 후 해당 드론만 재소환 쿨타임을 거쳐 재소환된다.
+    ///
+    /// 이 컴포넌트는 레벨 추적과 드론 풀 관리를 담당하고, 개별 드론의 이동/탐지/폭발은
+    /// <see cref="DokkaebiOrbDrone"/>이 이 컴포넌트의 현재 수치(반경·데미지·쿨타임 등)를 실시간 조회해 처리한다.
+    /// 레벨 추적은 <see cref="PlayerLevelSystem.OnSkillEffectPending"/> 구독 + OnEnable 동기화로 처리한다.
+    /// 수치는 인스펙터에서 관리한다(skill_balance_mvp.md §1).
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class DokkaebiOrbSkill : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField]
+        private PlayerLevelSystem _playerLevelSystem;
+
+        [SerializeField, Tooltip("궤도 중심(미지정 시 이 컴포넌트의 Transform). 보통 플레이어.")]
+        private Transform _orbitCenter;
+
+        [SerializeField, Tooltip("연동 SkillData의 SkillId. OnEnable 레벨 동기화에 사용.")]
+        private string _skillId = "dokkaebi_orb";
+
+        [SerializeField, Tooltip("도깨비불 드론 프리팹(DokkaebiOrbDrone 보유). 오브젝트 풀링 대상.")]
+        private GameObject _dronePrefab;
+
+        [Header("Orbit")]
+        [SerializeField, Min(0.1f), Tooltip("플레이어 중심 궤도 반경(월드 유닛)")]
+        private float _orbitRadius = 1.8f;
+
+        [SerializeField, Tooltip("궤도 회전 각속도(도/초)")]
+        private float _orbitAngularSpeedDeg = 120f;
+
+        [Header("Drone Behavior")]
+        [SerializeField, Min(0.1f), Tooltip("탐지 기본 반경(월드 유닛). 레벨별 배수가 곱해진다.")]
+        private float _baseDetectRange = 4f;
+
+        [SerializeField, Min(0.1f), Tooltip("자폭 폭발 반경(월드 유닛)")]
+        private float _explosionRadius = 1.5f;
+
+        [SerializeField, Min(0.1f), Tooltip("적을 향해 돌진하는 속도(월드 유닛/초)")]
+        private float _chargeSpeed = 9f;
+
+        [SerializeField, Min(0.01f), Tooltip("타깃에 이 거리 이내로 도달하면 자폭한다.")]
+        private float _detonateDistance = 0.35f;
+
+        [Header("Per-Level (index 0 = Lv1) — skill_balance_mvp.md §1")]
+        [SerializeField, Tooltip("레벨별 도깨비불 수")]
+        private int[] _droneCountPerLevel = { 1, 1, 2, 2, 3 };
+
+        [SerializeField, Tooltip("레벨별 탐지 범위 배수(기본=1.0, +20%=1.2, +30%=1.3)")]
+        private float[] _detectRangeMultiplierPerLevel = { 1.0f, 1.2f, 1.2f, 1.3f, 1.3f };
+
+        [SerializeField, Tooltip("레벨별 폭발 데미지")]
+        private float[] _explosionDamagePerLevel = { 50f, 65f, 65f, 80f, 100f };
+
+        [SerializeField, Tooltip("레벨별 재소환 쿨타임(초)")]
+        private float[] _resummonCooldownPerLevel = { 5.0f, 4.5f, 4.5f, 4.0f, 3.5f };
+
+        public const int MaxLevel = 5;
+
+        private int _level;
+        private readonly List<DokkaebiOrbDrone> _drones = new List<DokkaebiOrbDrone>(MaxLevel);
+
+        // 공유 재소환 쿨타임 — 드론별 개별 쿨타임 대신, 돌진 시작 시 시작해 경과하면 소비된 드론을 일괄 재소환한다.
+        private readonly DokkaebiOrbResummonClock _resummonClock = new DokkaebiOrbResummonClock();
+
+        public int Level => _level;
+
+        /// <summary>현재 레벨의 도깨비불 수(미보유=0).</summary>
+        public int CurrentDroneCount => _level < 1 ? 0 : Mathf.Max(0, GetPerLevelInt(_droneCountPerLevel, _level, 0));
+
+        /// <summary>현재 탐지 반경(미보유=0).</summary>
+        public float CurrentDetectRange => _level < 1 ? 0f : _baseDetectRange * GetPerLevel(_detectRangeMultiplierPerLevel, _level, 1f);
+
+        /// <summary>현재 폭발 데미지(미보유=0).</summary>
+        public float CurrentExplosionDamage => _level < 1 ? 0f : GetPerLevel(_explosionDamagePerLevel, _level, 0f);
+
+        /// <summary>현재 재소환 쿨타임(초).</summary>
+        public float CurrentResummonCooldown => Mathf.Max(0f, GetPerLevel(_resummonCooldownPerLevel, _level, 5f));
+
+        // 드론이 실시간 조회하는 공유 수치.
+        public Transform OrbitCenter => _orbitCenter != null ? _orbitCenter : transform;
+        public float OrbitRadius => _orbitRadius;
+        public float OrbitAngularSpeedDeg => _orbitAngularSpeedDeg;
+        public float ExplosionRadius => _explosionRadius;
+        public float ChargeSpeed => _chargeSpeed;
+        public float DetonateDistance => _detonateDistance;
+
+        private void Awake()
+        {
+            if (_playerLevelSystem == null)
+            {
+                _playerLevelSystem = GetComponent<PlayerLevelSystem>();
+            }
+
+            if (_orbitCenter == null)
+            {
+                _orbitCenter = transform;
+            }
+        }
+
+        private void OnEnable()
+        {
+            if (_playerLevelSystem != null)
+            {
+                _playerLevelSystem.OnSkillEffectPending += HandleSkillEffectPending;
+                // 비활성 중 부여/레벨업 이벤트를 놓쳤을 수 있어 현재 레벨을 직접 동기화한다.
+                ApplyLevel(_playerLevelSystem.GetSkillLevel(_skillId));
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (_playerLevelSystem != null)
+            {
+                _playerLevelSystem.OnSkillEffectPending -= HandleSkillEffectPending;
+            }
+
+            // 스킬이 해제되면(게임오버·씬 언로드 등) 모든 드론을 회수해 잔존하지 않도록 한다.
+            ReleaseAllDrones();
+            _resummonClock.Reset();
+        }
+
+        private void Update()
+        {
+            if (_level < 1)
+            {
+                return;
+            }
+
+            // 드론이 처음 돌진을 시작하면 공유 쿨타임이 시작되고, 경과 시 소비된 드론만 일괄 재소환한다.
+            // 아직 날아가는 중인 드론은 건드리지 않는다(그대로 날아가 자폭).
+            if (_resummonClock.Tick(Time.deltaTime, AnyDroneCharging(), CurrentResummonCooldown))
+            {
+                ResummonConsumedDrones();
+            }
+        }
+
+        private bool AnyDroneCharging()
+        {
+            for (int i = 0; i < _drones.Count; i++)
+            {
+                DokkaebiOrbDrone drone = _drones[i];
+                if (drone != null && drone.State == DokkaebiOrbDrone.DroneState.Charging)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private void ResummonConsumedDrones()
+        {
+            for (int i = 0; i < _drones.Count; i++)
+            {
+                DokkaebiOrbDrone drone = _drones[i];
+                if (drone != null && drone.State == DokkaebiOrbDrone.DroneState.Consumed)
+                {
+                    drone.Resummon();
+                }
+            }
+        }
+
+        private void HandleSkillEffectPending(SkillData skill, int nextLevel)
+        {
+            if (skill == null || skill.EffectType != LevelUpSkillEffectType.SummonDokkaebiOrb)
+            {
+                return;
+            }
+
+            ApplyLevel(nextLevel);
+        }
+
+        /// <summary>레벨을 직접 설정한다(이벤트 핸들러 및 테스트에서 사용). [0, MaxLevel]로 클램프 후 드론 수를 동기화.</summary>
+        public void ApplyLevel(int level)
+        {
+            _level = Mathf.Clamp(level, 0, MaxLevel);
+
+            // 활성 상태가 아니면(OnEnable 이전) 드론 스폰을 보류한다. OnEnable에서 다시 동기화된다.
+            if (isActiveAndEnabled)
+            {
+                SyncDrones();
+            }
+        }
+
+        /// <summary>현재 레벨의 도깨비불 수에 맞춰 드론을 스폰/회수하고, 궤도 위상을 균등 분배한다.</summary>
+        private void SyncDrones()
+        {
+            PruneDestroyedDrones();
+
+            int desired = CurrentDroneCount;
+
+            // 부족하면 스폰, 초과하면(레벨 하향 등) 회수.
+            while (_drones.Count < desired)
+            {
+                if (!TrySpawnDrone())
+                {
+                    break;
+                }
+            }
+
+            while (_drones.Count > desired)
+            {
+                ReleaseDrone(_drones.Count - 1);
+            }
+
+            // 드론들을 궤도에 균등 분배한다(개수 변동 시 재배치).
+            int count = _drones.Count;
+            for (int i = 0; i < count; i++)
+            {
+                float phaseDeg = count > 0 ? (360f / count) * i : 0f;
+                _drones[i].SetOrbitPhase(phaseDeg);
+            }
+        }
+
+        private bool TrySpawnDrone()
+        {
+            // 프리팹 미지정 시 조용히 보류한다(InkTrailSlowSkill의 마크 프리팹 처리와 동일).
+            // 드론이 나타나지 않는 것으로 설정 누락이 즉시 드러난다.
+            if (_dronePrefab == null)
+            {
+                return false;
+            }
+
+            Vector3 spawnPos = OrbitCenter.position;
+
+            // 비활성으로 꺼내 Initialize 후 활성화해야 OnEnable이 올바른 값으로 시작한다.
+            GameObject go = PoolManager.Instance != null
+                ? PoolManager.Instance.GetInactive(_dronePrefab, spawnPos, Quaternion.identity)
+                : InstantiateInactive(spawnPos);
+
+            if (go == null)
+            {
+                return false;
+            }
+
+            var drone = go.GetComponent<DokkaebiOrbDrone>();
+            if (drone == null)
+            {
+                Debug.LogError("[DokkaebiOrbSkill] 드론 프리팹에 DokkaebiOrbDrone 컴포넌트가 없습니다.");
+                ReleaseGameObject(go);
+                return false;
+            }
+
+            drone.Initialize(this, 0f);
+            go.SetActive(true);
+            _drones.Add(drone);
+            return true;
+        }
+
+        private GameObject InstantiateInactive(Vector3 position)
+        {
+            GameObject obj = Instantiate(_dronePrefab, position, Quaternion.identity);
+            obj.SetActive(false);
+            return obj;
+        }
+
+        private void ReleaseAllDrones()
+        {
+            for (int i = _drones.Count - 1; i >= 0; i--)
+            {
+                ReleaseDrone(i);
+            }
+        }
+
+        private void ReleaseDrone(int index)
+        {
+            if (index < 0 || index >= _drones.Count)
+            {
+                return;
+            }
+
+            DokkaebiOrbDrone drone = _drones[index];
+            _drones.RemoveAt(index);
+
+            if (drone != null)
+            {
+                ReleaseGameObject(drone.gameObject);
+            }
+        }
+
+        private void ReleaseGameObject(GameObject go)
+        {
+            if (go == null)
+            {
+                return;
+            }
+
+            if (PoolManager.Instance != null)
+            {
+                PoolManager.Instance.Release(go);
+            }
+            else
+            {
+                Destroy(go);
+            }
+        }
+
+        private void PruneDestroyedDrones()
+        {
+            for (int i = _drones.Count - 1; i >= 0; i--)
+            {
+                if (_drones[i] == null)
+                {
+                    _drones.RemoveAt(i);
+                }
+            }
+        }
+
+        private static float GetPerLevel(float[] perLevel, int level, float fallback)
+        {
+            if (level < 1 || perLevel == null || perLevel.Length == 0)
+            {
+                return fallback;
+            }
+
+            int index = Mathf.Clamp(level - 1, 0, perLevel.Length - 1);
+            return perLevel[index];
+        }
+
+        private static int GetPerLevelInt(int[] perLevel, int level, int fallback)
+        {
+            if (level < 1 || perLevel == null || perLevel.Length == 0)
+            {
+                return fallback;
+            }
+
+            int index = Mathf.Clamp(level - 1, 0, perLevel.Length - 1);
+            return perLevel[index];
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/DokkaebiOrbSkill.cs
+++ b/project1/Assets/Scripts/Combat/DokkaebiOrbSkill.cs
@@ -75,7 +75,7 @@ namespace Mukseon.Gameplay.Combat
         public int Level => _level;
 
         /// <summary>현재 레벨의 도깨비불 수(미보유=0).</summary>
-        public int CurrentDroneCount => _level < 1 ? 0 : Mathf.Max(0, GetPerLevelInt(_droneCountPerLevel, _level, 0));
+        public int CurrentDroneCount => _level < 1 ? 0 : Mathf.Max(0, GetPerLevel(_droneCountPerLevel, _level, 0));
 
         /// <summary>현재 탐지 반경(미보유=0).</summary>
         public float CurrentDetectRange => _level < 1 ? 0f : _baseDetectRange * GetPerLevel(_detectRangeMultiplierPerLevel, _level, 1f);
@@ -316,18 +316,9 @@ namespace Mukseon.Gameplay.Combat
             }
         }
 
-        private static float GetPerLevel(float[] perLevel, int level, float fallback)
-        {
-            if (level < 1 || perLevel == null || perLevel.Length == 0)
-            {
-                return fallback;
-            }
-
-            int index = Mathf.Clamp(level - 1, 0, perLevel.Length - 1);
-            return perLevel[index];
-        }
-
-        private static int GetPerLevelInt(int[] perLevel, int level, int fallback)
+        // 레벨별 배열에서 현재 레벨 값을 읽는다(미보유=fallback, 범위 초과 시 마지막 값으로 클램프).
+        // float/int 등 타입에 무관하게 동작하도록 제네릭으로 통합한다.
+        private static T GetPerLevel<T>(T[] perLevel, int level, T fallback)
         {
             if (level < 1 || perLevel == null || perLevel.Length == 0)
             {

--- a/project1/Assets/Scripts/Combat/DokkaebiOrbSkill.cs
+++ b/project1/Assets/Scripts/Combat/DokkaebiOrbSkill.cs
@@ -7,8 +7,11 @@ namespace Mukseon.Gameplay.Combat
 {
     /// <summary>
     /// 도깨비불 소환(#72) — 발동 방식 ② 쿨타임 자동 발동(공용 스킬).
-    /// 플레이어 주변을 궤도 비행하는 도깨비불 드론(<see cref="DokkaebiOrbDrone"/>)을 레벨별 개수만큼 소환한다.
-    /// 각 드론은 독립적으로 탐지·돌진·자폭하며, 자폭 후 해당 드론만 재소환 쿨타임을 거쳐 재소환된다.
+    /// 플레이어 주변을 궤도 비행하는 도깨비불 드론(<see cref="DokkaebiOrbDrone"/>)을 레벨별 개수(궤도 정원)만큼 소환한다.
+    /// 각 드론은 독립적으로 탐지·돌진·자폭한다. 한번 돌진을 시작한 드론은 squad에서 빠진 일회성 발사체로 간주되어
+    /// 자폭 후 풀로 회수되고, 궤도 정원은 공유 쿨타임(<see cref="DokkaebiOrbResummonClock"/>)이 경과할 때마다
+    /// <b>한 번에 보충</b>된다. 보충 수량은 "정원 − 현재 궤도 드론 수"이며, 비행 중인 드론은 이미 나간 것으로 보고 정원 계산에서 제외한다.
+    /// 따라서 두 개가 자폭하고 한 개가 비행 중이어도, 쿨타임 경과 시 정원(예: 3)이 가득 차도록 보충한다.
     ///
     /// 이 컴포넌트는 레벨 추적과 드론 풀 관리를 담당하고, 개별 드론의 이동/탐지/폭발은
     /// <see cref="DokkaebiOrbDrone"/>이 이 컴포넌트의 현재 수치(반경·데미지·쿨타임 등)를 실시간 조회해 처리한다.
@@ -67,10 +70,15 @@ namespace Mukseon.Gameplay.Combat
         public const int MaxLevel = 5;
 
         private int _level;
+
+        // 소유 중인 모든 드론(궤도 + 비행 중). 비행 중 드론은 자폭 시 NotifyDroneDetonated로 회수된다.
         private readonly List<DokkaebiOrbDrone> _drones = new List<DokkaebiOrbDrone>(MaxLevel);
 
-        // 공유 재소환 쿨타임 — 드론별 개별 쿨타임 대신, 돌진 시작 시 시작해 경과하면 소비된 드론을 일괄 재소환한다.
+        // 공유 재소환 쿨타임 — 궤도 정원이 부족해지면 시작하고, 경과 시 정원까지 한 번에 보충한다.
         private readonly DokkaebiOrbResummonClock _resummonClock = new DokkaebiOrbResummonClock();
+
+        // 다음 스폰 드론의 궤도 시작 위상(도). 스폰마다 한 슬롯씩 진행해, 기존 드론을 이동시키지 않고 분산 배치한다.
+        private float _nextSpawnPhaseDeg;
 
         public int Level => _level;
 
@@ -136,38 +144,43 @@ namespace Mukseon.Gameplay.Combat
                 return;
             }
 
-            // 드론이 처음 돌진을 시작하면 공유 쿨타임이 시작되고, 경과 시 소비된 드론만 일괄 재소환한다.
-            // 아직 날아가는 중인 드론은 건드리지 않는다(그대로 날아가 자폭).
-            if (_resummonClock.Tick(Time.deltaTime, AnyDroneCharging(), CurrentResummonCooldown))
+            // 궤도 정원이 부족하면(드론이 돌진해 나갔거나 자폭으로 소멸) 공유 쿨타임을 돌린다.
+            // 경과하면 정원까지 한 번에 보충한다. 비행 중 드론은 이미 나간 것으로 보고 정원 계산에서 제외된다.
+            bool replenishPending = OrbitingDroneCount() < CurrentDroneCount;
+            if (_resummonClock.Tick(Time.deltaTime, replenishPending, CurrentResummonCooldown))
             {
-                ResummonConsumedDrones();
+                SyncDrones();
             }
         }
 
-        private bool AnyDroneCharging()
+        /// <summary>비행 중 드론이 자폭했을 때 호출 — 추적 목록에서 제거하고 풀로 회수한다(일회성).</summary>
+        public void NotifyDroneDetonated(DokkaebiOrbDrone drone)
         {
-            for (int i = 0; i < _drones.Count; i++)
+            if (drone == null)
             {
-                DokkaebiOrbDrone drone = _drones[i];
-                if (drone != null && drone.State == DokkaebiOrbDrone.DroneState.Charging)
-                {
-                    return true;
-                }
+                return;
             }
 
-            return false;
+            if (_drones.Remove(drone))
+            {
+                ReleaseGameObject(drone.gameObject);
+            }
         }
 
-        private void ResummonConsumedDrones()
+        /// <summary>궤도 상태(squad 구성원) 드론 수. 비행 중(Charging) 드론은 제외한다.</summary>
+        private int OrbitingDroneCount()
         {
+            int count = 0;
             for (int i = 0; i < _drones.Count; i++)
             {
                 DokkaebiOrbDrone drone = _drones[i];
-                if (drone != null && drone.State == DokkaebiOrbDrone.DroneState.Consumed)
+                if (drone != null && drone.State == DokkaebiOrbDrone.DroneState.Orbit)
                 {
-                    drone.Resummon();
+                    count++;
                 }
             }
+
+            return count;
         }
 
         private void HandleSkillEffectPending(SkillData skill, int nextLevel)
@@ -192,34 +205,50 @@ namespace Mukseon.Gameplay.Combat
             }
         }
 
-        /// <summary>현재 레벨의 도깨비불 수에 맞춰 드론을 스폰/회수하고, 궤도 위상을 균등 분배한다.</summary>
+        /// <summary>
+        /// 궤도 드론 수를 정원(<see cref="CurrentDroneCount"/>)에 맞춘다.
+        /// 비행 중(Charging) 드론은 정원 계산에서 제외되며 건드리지 않는다(그대로 날아가 자폭).
+        /// 부족하면 새로 소환하고, 초과하면(레벨 하향) 궤도 드론만 회수한다.
+        /// </summary>
         private void SyncDrones()
         {
             PruneDestroyedDrones();
 
             int desired = CurrentDroneCount;
 
-            // 부족하면 스폰, 초과하면(레벨 하향 등) 회수.
-            while (_drones.Count < desired)
+            // 레벨 하향 등으로 궤도 드론이 과다하면 궤도 드론만 회수한다(비행 중 드론은 보존).
+            while (OrbitingDroneCount() > desired)
+            {
+                if (!ReleaseOneOrbitingDrone())
+                {
+                    break;
+                }
+            }
+
+            // 정원보다 적으면(비행/자폭으로 빠진 슬롯 + 레벨업 증가분) 정원까지 새로 소환한다.
+            while (OrbitingDroneCount() < desired)
             {
                 if (!TrySpawnDrone())
                 {
                     break;
                 }
             }
+        }
 
-            while (_drones.Count > desired)
+        /// <summary>궤도 상태 드론 하나를 회수한다. 회수했으면 true, 궤도 드론이 없으면 false.</summary>
+        private bool ReleaseOneOrbitingDrone()
+        {
+            for (int i = _drones.Count - 1; i >= 0; i--)
             {
-                ReleaseDrone(_drones.Count - 1);
+                DokkaebiOrbDrone drone = _drones[i];
+                if (drone != null && drone.State == DokkaebiOrbDrone.DroneState.Orbit)
+                {
+                    ReleaseDrone(i);
+                    return true;
+                }
             }
 
-            // 드론들을 궤도에 균등 분배한다(개수 변동 시 재배치).
-            int count = _drones.Count;
-            for (int i = 0; i < count; i++)
-            {
-                float phaseDeg = count > 0 ? (360f / count) * i : 0f;
-                _drones[i].SetOrbitPhase(phaseDeg);
-            }
+            return false;
         }
 
         private bool TrySpawnDrone()
@@ -251,7 +280,9 @@ namespace Mukseon.Gameplay.Combat
                 return false;
             }
 
-            drone.Initialize(this, 0f);
+            // 기존 드론을 이동시키지 않고 분산되도록, 스폰마다 한 슬롯씩 진행한 시작 위상을 부여한다.
+            drone.Initialize(this, _nextSpawnPhaseDeg);
+            _nextSpawnPhaseDeg = Mathf.Repeat(_nextSpawnPhaseDeg + 360f / Mathf.Max(1, CurrentDroneCount), 360f);
             go.SetActive(true);
             _drones.Add(drone);
             return true;

--- a/project1/Assets/Scripts/Combat/DokkaebiOrbSkill.cs.meta
+++ b/project1/Assets/Scripts/Combat/DokkaebiOrbSkill.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 22c7d46f74ce4cac8065fad939b74293

--- a/project1/Assets/Scripts/Combat/DokkaebiOrbTargeting.cs
+++ b/project1/Assets/Scripts/Combat/DokkaebiOrbTargeting.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 도깨비불 소환(#72)의 적 탐색 — 순수 로직.
+    /// 원점 기준 탐지 범위 내에서 가장 가까운, 살아있고 타격 가능한 적을 찾는다.
+    /// 물리 OverlapCircle 대신 거리 비교(sqrMagnitude)를 사용해 기존 타겟팅과 일관성을 맞추고
+    /// EditMode 단위 테스트가 가능하도록 한다.
+    /// </summary>
+    public static class DokkaebiOrbTargeting
+    {
+        /// <summary>
+        /// <paramref name="origin"/> 기준 <paramref name="range"/>(경계 포함) 내에서 가장 가까운 타격 가능 적을 반환한다.
+        /// 범위 내에 적이 없으면 null.
+        /// </summary>
+        public static EnemyHealth FindNearestTarget(
+            Vector2 origin,
+            float range,
+            IReadOnlyList<EnemyHealth> enemies)
+        {
+            if (enemies == null || range <= 0f || enemies.Count == 0)
+            {
+                return null;
+            }
+
+            float sqrRange = range * range;
+            EnemyHealth nearest = null;
+            float nearestSqr = float.PositiveInfinity;
+
+            for (int i = 0; i < enemies.Count; i++)
+            {
+                EnemyHealth enemy = enemies[i];
+                if (enemy == null || !enemy.IsAlive || !enemy.IsTargetable)
+                {
+                    continue;
+                }
+
+                float sqrDistance = ((Vector2)enemy.transform.position - origin).sqrMagnitude;
+                if (sqrDistance > sqrRange || sqrDistance >= nearestSqr)
+                {
+                    continue;
+                }
+
+                nearest = enemy;
+                nearestSqr = sqrDistance;
+            }
+
+            return nearest;
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/DokkaebiOrbTargeting.cs.meta
+++ b/project1/Assets/Scripts/Combat/DokkaebiOrbTargeting.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cc6e5043d0b0467796c2acb4b52fdb92

--- a/project1/Assets/Scripts/Combat/RadialDamage.cs
+++ b/project1/Assets/Scripts/Combat/RadialDamage.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 원점 기준 반경 내의 살아있고 타격 가능한 적 전체에 데미지를 적용하는 공용 순수 로직.
+    /// 항마의 결계(#73) 틱 데미지와 도깨비불 소환(#72) 자폭 폭발이 공통으로 사용한다.
+    /// 물리 충돌 대신 거리 비교(sqrMagnitude)를 사용해 기존 타겟팅(SwipeAttackTargeting 등)과 일관성을 맞춘다.
+    /// </summary>
+    public static class RadialDamage
+    {
+        /// <summary>
+        /// 원점(<paramref name="origin"/>) 기준 반경(<paramref name="radius"/>, 경계 포함) 내의 적 전체에
+        /// <paramref name="damage"/>를 적용하고, 피해를 입힌 적 수를 반환한다(반경 밖 적은 영향 없음).
+        /// </summary>
+        public static int ApplyInRadius(
+            Vector2 origin,
+            float radius,
+            float damage,
+            IReadOnlyList<EnemyHealth> enemies,
+            object source)
+        {
+            if (enemies == null || radius <= 0f || damage <= 0f || enemies.Count == 0)
+            {
+                return 0;
+            }
+
+            // ApplyDamage로 적이 사망하면 EnemyHealth.ActiveEnemies에서 즉시 제거되어
+            // 순회 중 컬렉션이 변경(인덱스 밀림 → 다음 적 스킵)될 수 있다. 스냅샷을 떠서 순회한다.
+            var targets = new List<EnemyHealth>(enemies);
+            float sqrRadius = radius * radius;
+            int hitCount = 0;
+
+            for (int i = 0; i < targets.Count; i++)
+            {
+                EnemyHealth enemy = targets[i];
+                if (enemy == null || !enemy.IsAlive || !enemy.IsTargetable)
+                {
+                    continue;
+                }
+
+                if (((Vector2)enemy.transform.position - origin).sqrMagnitude > sqrRadius)
+                {
+                    continue;
+                }
+
+                enemy.ApplyDamage(damage, source);
+                hitCount++;
+            }
+
+            return hitCount;
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/RadialDamage.cs.meta
+++ b/project1/Assets/Scripts/Combat/RadialDamage.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4994070fed17492e8ba2116134eda9a3

--- a/project1/Assets/Settings/Data/Characters/Character_Baksu.asset
+++ b/project1/Assets/Settings/Data/Characters/Character_Baksu.asset
@@ -26,4 +26,5 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 409eb7a6cfdb5704887435b77656ff18, type: 2}
   - {fileID: 11400000, guid: 4607d94a2a2945347a2e658b78885046, type: 2}
   - {fileID: 11400000, guid: 7f23f3279b754c889acee2fc9ee0145c, type: 2}
+  - {fileID: 11400000, guid: 6fb04def2a19460a901d79965eeb8454, type: 2}
   _startingSkills: []

--- a/project1/Assets/Settings/Data/Characters/Character_Mudang.asset
+++ b/project1/Assets/Settings/Data/Characters/Character_Mudang.asset
@@ -27,5 +27,6 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 409eb7a6cfdb5704887435b77656ff18, type: 2}
   - {fileID: 11400000, guid: 4607d94a2a2945347a2e658b78885046, type: 2}
   - {fileID: 11400000, guid: 7f23f3279b754c889acee2fc9ee0145c, type: 2}
+  - {fileID: 11400000, guid: 6fb04def2a19460a901d79965eeb8454, type: 2}
   _startingSkills:
   - {fileID: 11400000, guid: be007eb0bf48ffd41bba6d449a38320f, type: 2}

--- a/project1/Assets/Settings/Data/Skills/Skill_DokkaebiOrb.asset
+++ b/project1/Assets/Settings/Data/Skills/Skill_DokkaebiOrb.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9c108d14243300c4b992897d5c4b7f43, type: 3}
+  m_Name: Skill_DokkaebiOrb
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Progression.SkillData
+  _skillId: dokkaebi_orb
+  _displayName: "도깨비불 소환"
+  _description: "플레이어 주변을 궤도 비행하는
+    도깨비불을 소환. 탐지 범위 내
+    가장 가까운 적을 향해 돌진해 자폭하고,
+    일정 쿨타임 후 재소환된다."
+  _effectType: 10
+  _statType: 0
+  _value: 1
+  _maxLevel: 5
+  _icon: {fileID: 0}

--- a/project1/Assets/Settings/Data/Skills/Skill_DokkaebiOrb.asset.meta
+++ b/project1/Assets/Settings/Data/Skills/Skill_DokkaebiOrb.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6fb04def2a19460a901d79965eeb8454
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/project1/Assets/Tests/EditMode/DokkaebiOrbTests.cs
+++ b/project1/Assets/Tests/EditMode/DokkaebiOrbTests.cs
@@ -1,0 +1,285 @@
+using System.Collections.Generic;
+using Mukseon.Core.Input;
+using Mukseon.Gameplay.Combat;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Mukseon.Tests.EditMode
+{
+    public class RadialDamageTests
+    {
+        private GameObject _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new GameObject("Root");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_root != null)
+            {
+                Object.DestroyImmediate(_root);
+            }
+        }
+
+        [Test]
+        public void ApplyInRadius_DamagesEnemiesInRange_SkipsOutOfRange()
+        {
+            EnemyHealth near = CreateEnemy("Near", new Vector3(1f, 0f, 0f));   // 반경 2 안
+            EnemyHealth edge = CreateEnemy("Edge", new Vector3(2f, 0f, 0f));   // 정확히 반경 = 포함
+            EnemyHealth far = CreateEnemy("Far", new Vector3(5f, 0f, 0f));     // 반경 밖
+
+            var enemies = new List<EnemyHealth> { near, edge, far };
+            int hit = RadialDamage.ApplyInRadius(Vector2.zero, 2f, 5f, enemies, this);
+
+            Assert.That(hit, Is.EqualTo(2));
+            Assert.That(near.CurrentHealth, Is.EqualTo(95f).Within(1e-4f));
+            Assert.That(edge.CurrentHealth, Is.EqualTo(95f).Within(1e-4f));
+            Assert.That(far.CurrentHealth, Is.EqualTo(100f).Within(1e-4f)); // 영향 없음
+        }
+
+        [Test]
+        public void ApplyInRadius_SkipsNonTargetableAndDead()
+        {
+            EnemyHealth untargetable = CreateEnemy("Untargetable", new Vector3(0.5f, 0f, 0f));
+            untargetable.IsTargetable = false;
+
+            EnemyHealth dead = CreateEnemy("Dead", new Vector3(0.5f, 0f, 0f));
+            dead.ApplyDamage(100f, this);
+            Assert.That(dead.IsAlive, Is.False);
+
+            var enemies = new List<EnemyHealth> { untargetable, dead };
+            int hit = RadialDamage.ApplyInRadius(Vector2.zero, 2f, 5f, enemies, this);
+
+            Assert.That(hit, Is.EqualTo(0));
+            Assert.That(untargetable.CurrentHealth, Is.EqualTo(100f).Within(1e-4f));
+        }
+
+        [Test]
+        public void ApplyInRadius_ZeroRadiusOrDamage_DoesNothing()
+        {
+            EnemyHealth enemy = CreateEnemy("In", new Vector3(0.5f, 0f, 0f));
+            var enemies = new List<EnemyHealth> { enemy };
+
+            Assert.That(RadialDamage.ApplyInRadius(Vector2.zero, 0f, 5f, enemies, this), Is.EqualTo(0));
+            Assert.That(RadialDamage.ApplyInRadius(Vector2.zero, 2f, 0f, enemies, this), Is.EqualTo(0));
+            Assert.That(enemy.CurrentHealth, Is.EqualTo(100f).Within(1e-4f));
+        }
+
+        private EnemyHealth CreateEnemy(string name, Vector3 position)
+        {
+            var go = new GameObject(name);
+            go.transform.SetParent(_root.transform);
+            go.transform.position = position;
+
+            var eh = go.AddComponent<EnemyHealth>();
+            eh.SetSwipeDirection(SwipeDirection.Up);
+            eh.SetMaxHealth(100f);
+            eh.ResetHealth();
+            return eh;
+        }
+    }
+
+    public class DokkaebiOrbTargetingTests
+    {
+        private GameObject _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new GameObject("Root");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_root != null)
+            {
+                Object.DestroyImmediate(_root);
+            }
+        }
+
+        [Test]
+        public void FindNearestTarget_ReturnsClosestInRange()
+        {
+            EnemyHealth far = CreateEnemy("Far", new Vector3(3f, 0f, 0f));
+            EnemyHealth near = CreateEnemy("Near", new Vector3(1f, 0f, 0f));
+            EnemyHealth mid = CreateEnemy("Mid", new Vector3(2f, 0f, 0f));
+
+            var enemies = new List<EnemyHealth> { far, near, mid };
+            EnemyHealth result = DokkaebiOrbTargeting.FindNearestTarget(Vector2.zero, 5f, enemies);
+
+            Assert.That(result, Is.SameAs(near));
+        }
+
+        [Test]
+        public void FindNearestTarget_IgnoresOutOfRange()
+        {
+            EnemyHealth outside = CreateEnemy("Outside", new Vector3(10f, 0f, 0f));
+            var enemies = new List<EnemyHealth> { outside };
+
+            Assert.That(DokkaebiOrbTargeting.FindNearestTarget(Vector2.zero, 4f, enemies), Is.Null);
+        }
+
+        [Test]
+        public void FindNearestTarget_SkipsDeadAndUntargetable_PicksNextValid()
+        {
+            EnemyHealth dead = CreateEnemy("Dead", new Vector3(0.5f, 0f, 0f));
+            dead.ApplyDamage(100f, this);
+
+            EnemyHealth untargetable = CreateEnemy("Untargetable", new Vector3(0.8f, 0f, 0f));
+            untargetable.IsTargetable = false;
+
+            EnemyHealth valid = CreateEnemy("Valid", new Vector3(1.5f, 0f, 0f));
+
+            var enemies = new List<EnemyHealth> { dead, untargetable, valid };
+            EnemyHealth result = DokkaebiOrbTargeting.FindNearestTarget(Vector2.zero, 5f, enemies);
+
+            Assert.That(result, Is.SameAs(valid));
+        }
+
+        [Test]
+        public void FindNearestTarget_NullOrEmpty_ReturnsNull()
+        {
+            Assert.That(DokkaebiOrbTargeting.FindNearestTarget(Vector2.zero, 5f, null), Is.Null);
+            Assert.That(DokkaebiOrbTargeting.FindNearestTarget(Vector2.zero, 5f, new List<EnemyHealth>()), Is.Null);
+        }
+
+        private EnemyHealth CreateEnemy(string name, Vector3 position)
+        {
+            var go = new GameObject(name);
+            go.transform.SetParent(_root.transform);
+            go.transform.position = position;
+
+            var eh = go.AddComponent<EnemyHealth>();
+            eh.SetSwipeDirection(SwipeDirection.Up);
+            eh.SetMaxHealth(100f);
+            eh.ResetHealth();
+            return eh;
+        }
+    }
+
+    public class DokkaebiOrbSkillTests
+    {
+        private GameObject _go;
+        private DokkaebiOrbSkill _skill;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _go = new GameObject("DokkaebiOrbSkill");
+            _skill = _go.AddComponent<DokkaebiOrbSkill>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_go != null)
+            {
+                Object.DestroyImmediate(_go);
+            }
+        }
+
+        [Test]
+        public void NotOwned_HasNoDronesOrStats()
+        {
+            Assert.That(_skill.Level, Is.EqualTo(0));
+            Assert.That(_skill.CurrentDroneCount, Is.EqualTo(0));
+            Assert.That(_skill.CurrentDetectRange, Is.EqualTo(0f));
+            Assert.That(_skill.CurrentExplosionDamage, Is.EqualTo(0f));
+        }
+
+        // skill_balance_mvp.md §1: 드론 수 / 탐지 배수 / 폭발 데미지 / 재소환 쿨타임 (기본 탐지 반경 4).
+        [TestCase(1, 1, 4.0f, 50f, 5.0f)]
+        [TestCase(2, 1, 4.8f, 65f, 4.5f)]
+        [TestCase(3, 2, 4.8f, 65f, 4.5f)]
+        [TestCase(4, 2, 5.2f, 80f, 4.0f)]
+        [TestCase(5, 3, 5.2f, 100f, 3.5f)]
+        public void PerLevel_ResolvesBalanceValues(
+            int level, int droneCount, float detectRange, float explosionDamage, float resummonCooldown)
+        {
+            _skill.ApplyLevel(level);
+
+            Assert.That(_skill.CurrentDroneCount, Is.EqualTo(droneCount));
+            Assert.That(_skill.CurrentDetectRange, Is.EqualTo(detectRange).Within(1e-4f));
+            Assert.That(_skill.CurrentExplosionDamage, Is.EqualTo(explosionDamage).Within(1e-4f));
+            Assert.That(_skill.CurrentResummonCooldown, Is.EqualTo(resummonCooldown).Within(1e-4f));
+        }
+
+        [Test]
+        public void ApplyLevel_ClampsToRange()
+        {
+            _skill.ApplyLevel(99);
+            Assert.That(_skill.Level, Is.EqualTo(DokkaebiOrbSkill.MaxLevel));
+
+            _skill.ApplyLevel(-3);
+            Assert.That(_skill.Level, Is.EqualTo(0));
+        }
+    }
+
+    public class DokkaebiOrbResummonClockTests
+    {
+        [Test]
+        public void NoCharging_NeverFires_StaysStopped()
+        {
+            var clock = new DokkaebiOrbResummonClock();
+            for (int i = 0; i < 10; i++)
+            {
+                Assert.That(clock.Tick(1f, anyDroneCharging: false, cooldown: 3f), Is.False);
+            }
+
+            Assert.That(clock.IsRunning, Is.False);
+        }
+
+        [Test]
+        public void StartsOnCharge_FiresAfterCooldown_ThenStopsWhenNoneCharging()
+        {
+            var clock = new DokkaebiOrbResummonClock();
+
+            // 돌진 시작 → 쿨타임 시작(시작 프레임은 차감하지 않음).
+            Assert.That(clock.Tick(1f, anyDroneCharging: true, cooldown: 3f), Is.False);
+            Assert.That(clock.IsRunning, Is.True);
+
+            // 드론이 자폭해 더는 돌진하지 않음(소비됨). 쿨타임 경과까지 카운트다운.
+            Assert.That(clock.Tick(1f, false, 3f), Is.False); // 3 → 2
+            Assert.That(clock.Tick(1f, false, 3f), Is.False); // 2 → 1
+            Assert.That(clock.Tick(1f, false, 3f), Is.True);  // 1 → 0 : 일괄 재소환 신호
+
+            // 돌진 중인 드론이 없으므로 클럭은 멈춘다.
+            Assert.That(clock.IsRunning, Is.False);
+            Assert.That(clock.Tick(1f, false, 3f), Is.False);
+        }
+
+        [Test]
+        public void KeepsCadence_WhileDronesStillCharging()
+        {
+            var clock = new DokkaebiOrbResummonClock();
+
+            clock.Tick(1f, true, 3f);                          // start (timer=3)
+            Assert.That(clock.Tick(1f, true, 3f), Is.False);   // 3 → 2
+            Assert.That(clock.Tick(1f, true, 3f), Is.False);   // 2 → 1
+            Assert.That(clock.Tick(1f, true, 3f), Is.True);    // 1 → 0 : fire, restart (still charging)
+            Assert.That(clock.IsRunning, Is.True);
+
+            Assert.That(clock.Tick(1f, true, 3f), Is.False);   // 3 → 2
+            Assert.That(clock.Tick(1f, true, 3f), Is.False);   // 2 → 1
+            Assert.That(clock.Tick(1f, true, 3f), Is.True);    // fires again
+        }
+
+        [Test]
+        public void Reset_StopsClock()
+        {
+            var clock = new DokkaebiOrbResummonClock();
+            clock.Tick(1f, true, 3f);
+            Assert.That(clock.IsRunning, Is.True);
+
+            clock.Reset();
+            Assert.That(clock.IsRunning, Is.False);
+            Assert.That(clock.Remaining, Is.EqualTo(0f));
+            Assert.That(clock.Tick(1f, false, 3f), Is.False);
+        }
+    }
+}

--- a/project1/Assets/Tests/EditMode/DokkaebiOrbTests.cs
+++ b/project1/Assets/Tests/EditMode/DokkaebiOrbTests.cs
@@ -223,50 +223,65 @@ namespace Mukseon.Tests.EditMode
     public class DokkaebiOrbResummonClockTests
     {
         [Test]
-        public void NoCharging_NeverFires_StaysStopped()
+        public void NotPending_NeverFires_StaysStopped()
         {
             var clock = new DokkaebiOrbResummonClock();
             for (int i = 0; i < 10; i++)
             {
-                Assert.That(clock.Tick(1f, anyDroneCharging: false, cooldown: 3f), Is.False);
+                Assert.That(clock.Tick(1f, replenishPending: false, cooldown: 3f), Is.False);
             }
 
             Assert.That(clock.IsRunning, Is.False);
         }
 
         [Test]
-        public void StartsOnCharge_FiresAfterCooldown_ThenStopsWhenNoneCharging()
+        public void StartsWhenPending_FiresAfterCooldown_ThenStopsWhenFilled()
         {
             var clock = new DokkaebiOrbResummonClock();
 
-            // 돌진 시작 → 쿨타임 시작(시작 프레임은 차감하지 않음).
-            Assert.That(clock.Tick(1f, anyDroneCharging: true, cooldown: 3f), Is.False);
+            // 정원 부족 → 쿨타임 시작(시작 프레임은 차감하지 않음).
+            Assert.That(clock.Tick(1f, replenishPending: true, cooldown: 3f), Is.False);
             Assert.That(clock.IsRunning, Is.True);
 
-            // 드론이 자폭해 더는 돌진하지 않음(소비됨). 쿨타임 경과까지 카운트다운.
-            Assert.That(clock.Tick(1f, false, 3f), Is.False); // 3 → 2
-            Assert.That(clock.Tick(1f, false, 3f), Is.False); // 2 → 1
-            Assert.That(clock.Tick(1f, false, 3f), Is.True);  // 1 → 0 : 일괄 재소환 신호
+            Assert.That(clock.Tick(1f, true, 3f), Is.False); // 3 → 2
+            Assert.That(clock.Tick(1f, true, 3f), Is.False); // 2 → 1
+            Assert.That(clock.Tick(1f, true, 3f), Is.True);  // 1 → 0 : 정원 보충 신호
+            Assert.That(clock.IsRunning, Is.False);
 
-            // 돌진 중인 드론이 없으므로 클럭은 멈춘다.
+            // 보충으로 정원이 가득 차면(부족 해제) 멈춘 상태를 유지한다.
+            Assert.That(clock.Tick(1f, false, 3f), Is.False);
+            Assert.That(clock.IsRunning, Is.False);
+        }
+
+        [Test]
+        public void PendingClearedMidCountdown_Cancels()
+        {
+            var clock = new DokkaebiOrbResummonClock();
+
+            clock.Tick(1f, true, 3f);                          // start (timer=3)
+            Assert.That(clock.IsRunning, Is.True);
+
+            // 카운트다운 도중 정원이 채워지면(레벨업 등) 발화 없이 취소된다.
+            Assert.That(clock.Tick(1f, false, 3f), Is.False);
             Assert.That(clock.IsRunning, Is.False);
             Assert.That(clock.Tick(1f, false, 3f), Is.False);
         }
 
         [Test]
-        public void KeepsCadence_WhileDronesStillCharging()
+        public void RestartsIfStillPendingAfterFire()
         {
             var clock = new DokkaebiOrbResummonClock();
 
-            clock.Tick(1f, true, 3f);                          // start (timer=3)
+            clock.Tick(1f, true, 3f);                          // start
             Assert.That(clock.Tick(1f, true, 3f), Is.False);   // 3 → 2
             Assert.That(clock.Tick(1f, true, 3f), Is.False);   // 2 → 1
-            Assert.That(clock.Tick(1f, true, 3f), Is.True);    // 1 → 0 : fire, restart (still charging)
-            Assert.That(clock.IsRunning, Is.True);
+            Assert.That(clock.Tick(1f, true, 3f), Is.True);    // fire #1
 
+            // 보충 후에도 여전히 부족하면(예: 비행 중 드론이 남아 정원 미달) 다음 주기를 새로 시작한다.
+            Assert.That(clock.Tick(1f, true, 3f), Is.False);   // restart, timer=3
             Assert.That(clock.Tick(1f, true, 3f), Is.False);   // 3 → 2
             Assert.That(clock.Tick(1f, true, 3f), Is.False);   // 2 → 1
-            Assert.That(clock.Tick(1f, true, 3f), Is.True);    // fires again
+            Assert.That(clock.Tick(1f, true, 3f), Is.True);    // fire #2
         }
 
         [Test]
@@ -280,19 +295,6 @@ namespace Mukseon.Tests.EditMode
             Assert.That(clock.IsRunning, Is.False);
             Assert.That(clock.Remaining, Is.EqualTo(0f));
             Assert.That(clock.Tick(1f, false, 3f), Is.False);
-        }
-
-        [Test]
-        public void Elapse_CarriesOvershoot_WhenStillCharging()
-        {
-            var clock = new DokkaebiOrbResummonClock();
-
-            clock.Tick(2f, true, 3f);                          // start (timer=3, 시작 프레임 미차감)
-            Assert.That(clock.Tick(2f, true, 3f), Is.False);   // 3 → 1
-            Assert.That(clock.Tick(2f, true, 3f), Is.True);    // 1 → -1 : fire, 이월 → timer = -1 + 3 = 2
-
-            // 오버슈트(-1)가 버려지지 않고 이월되어 다음 주기가 2초로 시작된다(주기 누적 밀림 방지).
-            Assert.That(clock.Remaining, Is.EqualTo(2f).Within(1e-4f));
         }
     }
 }

--- a/project1/Assets/Tests/EditMode/DokkaebiOrbTests.cs
+++ b/project1/Assets/Tests/EditMode/DokkaebiOrbTests.cs
@@ -281,5 +281,18 @@ namespace Mukseon.Tests.EditMode
             Assert.That(clock.Remaining, Is.EqualTo(0f));
             Assert.That(clock.Tick(1f, false, 3f), Is.False);
         }
+
+        [Test]
+        public void Elapse_CarriesOvershoot_WhenStillCharging()
+        {
+            var clock = new DokkaebiOrbResummonClock();
+
+            clock.Tick(2f, true, 3f);                          // start (timer=3, 시작 프레임 미차감)
+            Assert.That(clock.Tick(2f, true, 3f), Is.False);   // 3 → 1
+            Assert.That(clock.Tick(2f, true, 3f), Is.True);    // 1 → -1 : fire, 이월 → timer = -1 + 3 = 2
+
+            // 오버슈트(-1)가 버려지지 않고 이월되어 다음 주기가 2초로 시작된다(주기 누적 밀림 방지).
+            Assert.That(clock.Remaining, Is.EqualTo(2f).Within(1e-4f));
+        }
     }
 }

--- a/project1/Assets/Tests/EditMode/DokkaebiOrbTests.cs.meta
+++ b/project1/Assets/Tests/EditMode/DokkaebiOrbTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 18b27eedb8f0412a900b67d30b3444ff


### PR DESCRIPTION
## 개요
도깨비불 소환 스킬(#72) 구현. 발동 방식 ② 쿨타임 자동 발동(공용 스킬). 플레이어 주변을 궤도 비행하는 도깨비불 드론을 레벨별 개수만큼 소환하고, 각 드론이 독립적으로 탐지·돌진·자폭한다.

Closes #72

## 레벨별 수치 (skill_balance_mvp.md §1)
| 레벨 | 드론 수 | 탐지 배수 | 폭발 데미지 | 재소환 쿨타임 |
|------|--------|---------|-----------|------------|
| 1 | 1 | ×1.0 (4.0) | 50 | 5.0초 |
| 2 | 1 | ×1.2 (4.8) | 65 | 4.5초 |
| 3 | 2 | ×1.2 (4.8) | 65 | 4.5초 |
| 4 | 2 | ×1.3 (5.2) | 80 | 4.0초 |
| 5 | 3 | ×1.3 (5.2) | 100 | 3.5초 |

## 구현
- **`DokkaebiOrbSkill`** — 레벨 추적(`OnSkillEffectPending` 구독 + `OnEnable` 동기화), 레벨별 수치, 드론 풀 스폰/회수·궤도 균등 분배, 공유 재소환 쿨타임 구동.
- **`DokkaebiOrbDrone`** — `Orbit → Charging → Consumed` 상태머신. 탐지는 **드론 자신 위치 기준**. 돌진 중 타깃 소실 시 드론 위치 기준 재탐색, 없으면 마지막 타깃 위치까지 날아가 자폭(궤도 복귀 없음 — 여러 드론이 한 적을 노릴 때의 순간이동 방지).
- **`DokkaebiOrbResummonClock`** — 공유 재소환 쿨타임(순수 로직). 드론이 돌진을 시작할 때 시작 → 경과 시 **소비된 드론만 일괄 재소환**. 비행 중/궤도만 도는 드론은 미관여. 주변에 적이 없어 전체가 궤도만 돌면 재소환하지 않음.
- **`DokkaebiOrbTargeting`** — 범위 내 최근접 타격 가능 적 탐색(순수 로직).
- **`RadialDamage`** — 반경 데미지 공용 헬퍼로 추출, `BarrierTickDamage`(#73)를 위임 처리해 중복 제거.

## 데이터 / 에디터 연결
- `Skill_DokkaebiOrb.asset` (EffectType=`SummonDokkaebiOrb`, maxLevel=5).
- 드론 프리팹 생성(`Assets/Prefabs/Skills/DokkaebiOrbDrone.prefab`), `Player`에 `DokkaebiOrbSkill` 부착·참조 연결, `PoolManager` 프리셋(3/8) 사전 할당, `Character_Mudang`/`Character_Baksu` 획득 풀 등록.

## 동작 (DoD)
- [x] 스킬 획득 즉시 레벨 1 드론 1개가 궤도 비행
- [x] 탐지 범위 내 적 발견 시 추적하여 자폭
- [x] 공유 쿨타임 경과 시 소비된 드론 일괄 재소환
- [x] 레벨 3에서 2개, 레벨 5에서 3개 동시 운용
- [x] 모든 드론은 오브젝트 풀링으로 관리

## 검증
- Unity 컴파일 에러 없음.
- 라이브 에디터 런타임 검증: 반경 데미지/타게팅/레벨별 수치 15/15, 공유 쿨타임 클럭 4/4 PASS.
- 플레이 모드 육안 확인 완료(요청자).
- EditMode 테스트 추가: `RadialDamage` / `DokkaebiOrbTargeting` / `DokkaebiOrbSkill` 레벨별 수치 / `DokkaebiOrbResummonClock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)