### PR TITLE
fix: 일시정지(게임오버/레벨업 선택) 중 입력 비활성화 (#42)

### DIFF
--- a/project1/Assets/Scripts/Combat/GameplayInputGate.cs
+++ b/project1/Assets/Scripts/Combat/GameplayInputGate.cs
@@ -1,0 +1,218 @@
+using System.Collections.Generic;
+using Mukseon.Core.Input;
+using Mukseon.Gameplay.Progression;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 게임오버 또는 레벨업 스킬 선택으로 게임이 일시정지(Time.timeScale = 0)되는 동안,
+    /// unscaledTime 기반으로 계속 동작하는 입력 감지기(스와이프/강신)를 일괄 비활성화한다(#42).
+    ///
+    /// 입력 감지기(<see cref="SwipeInputDetector"/>, <see cref="GangshinInputDetector"/>)는
+    /// Mukseon.Core.Input 계층이라 게임오버/레벨업 같은 게임플레이 상태를 알지 못한다. 이 게이트가
+    /// 그 사이를 잇는 어댑터로서, 여러 억제 원인을 <see cref="InputSuppressionState"/>로 합산해 반영한다.
+    ///
+    /// GameplayHudBootstrapper와 동일하게 RuntimeInitializeOnLoadMethod로 자가 생성되어
+    /// 씬 편집 없이 동작하며, 씬이 바뀌면 참조를 다시 해석한다.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public sealed class GameplayInputGate : MonoBehaviour
+    {
+        private const string RootObjectName = "GameplayInputGateRuntime";
+        private const float ResolveRetryInterval = 0.5f;
+
+        private readonly InputSuppressionState _suppression = new InputSuppressionState();
+
+        private SwipeInputDetector _swipeInputDetector;
+        private GangshinInputDetector _gangshinInputDetector;
+        private GameOverHandler _gameOverHandler;
+        private PlayerLevelSystem _playerLevelSystem;
+
+        private float _resolveRetryTimer;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void EnsureGate()
+        {
+            if (FindExisting() != null)
+            {
+                return;
+            }
+
+            GameObject root = new GameObject(RootObjectName);
+            root.AddComponent<GameplayInputGate>();
+        }
+
+        private static GameplayInputGate FindExisting()
+        {
+#if UNITY_2023_1_OR_NEWER
+            return FindFirstObjectByType<GameplayInputGate>(FindObjectsInactive.Include);
+#else
+            return FindObjectOfType<GameplayInputGate>();
+#endif
+        }
+
+        private void Awake()
+        {
+            DontDestroyOnLoad(gameObject);
+            SceneManager.sceneLoaded += HandleSceneLoaded;
+            ResolveAndReset();
+        }
+
+        private void OnDestroy()
+        {
+            SceneManager.sceneLoaded -= HandleSceneLoaded;
+            UnsubscribeAll();
+        }
+
+        private void Update()
+        {
+            // 모든 참조가 해석되면 더 이상 할 일이 없으므로 매 프레임 비용을 들이지 않는다.
+            if (!NeedsResolve())
+            {
+                return;
+            }
+
+            _resolveRetryTimer -= Time.unscaledDeltaTime;
+            if (_resolveRetryTimer <= 0f)
+            {
+                _resolveRetryTimer = ResolveRetryInterval;
+                ResolveSources();
+                ApplyToDetectors();
+            }
+        }
+
+        private void HandleSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            ResolveAndReset();
+        }
+
+        // 씬이 새로 로드되면 이전 씬의 구독을 끊고 억제 상태를 초기화한 뒤 다시 해석한다.
+        private void ResolveAndReset()
+        {
+            UnsubscribeAll();
+            _swipeInputDetector = null;
+            _gangshinInputDetector = null;
+            _gameOverHandler = null;
+            _playerLevelSystem = null;
+            _suppression.Clear();
+            _resolveRetryTimer = 0f;
+            ResolveSources();
+            ApplyToDetectors();
+        }
+
+        private void ResolveSources()
+        {
+            if (_swipeInputDetector == null)
+            {
+                _swipeInputDetector = FindSceneObject<SwipeInputDetector>();
+            }
+
+            if (_gangshinInputDetector == null)
+            {
+                _gangshinInputDetector = FindSceneObject<GangshinInputDetector>();
+            }
+
+            if (_gameOverHandler == null)
+            {
+                _gameOverHandler = FindSceneObject<GameOverHandler>();
+                if (_gameOverHandler != null)
+                {
+                    _gameOverHandler.OnGameOver += HandleGameOver;
+                    // 이미 게임오버 상태인 씬에 뒤늦게 붙은 경우를 반영한다.
+                    if (_gameOverHandler.IsGameOver)
+                    {
+                        _suppression.SetReason(InputSuppressionReason.GameOver, true);
+                    }
+                }
+            }
+
+            if (_playerLevelSystem == null)
+            {
+                _playerLevelSystem = FindSceneObject<PlayerLevelSystem>();
+                if (_playerLevelSystem != null)
+                {
+                    _playerLevelSystem.OnLevelSelectionOpened += HandleSelectionOpened;
+                    _playerLevelSystem.OnLevelSelectionClosed += HandleSelectionClosed;
+                    // 이미 선택지가 열린 상태에 뒤늦게 붙은 경우를 반영한다.
+                    if (_playerLevelSystem.IsSelectionOpen)
+                    {
+                        _suppression.SetReason(InputSuppressionReason.LevelUpSelection, true);
+                    }
+                }
+            }
+        }
+
+        private bool NeedsResolve()
+        {
+            return _swipeInputDetector == null ||
+                   _gangshinInputDetector == null ||
+                   _gameOverHandler == null ||
+                   _playerLevelSystem == null;
+        }
+
+        private void UnsubscribeAll()
+        {
+            if (_gameOverHandler != null)
+            {
+                _gameOverHandler.OnGameOver -= HandleGameOver;
+            }
+
+            if (_playerLevelSystem != null)
+            {
+                _playerLevelSystem.OnLevelSelectionOpened -= HandleSelectionOpened;
+                _playerLevelSystem.OnLevelSelectionClosed -= HandleSelectionClosed;
+            }
+        }
+
+        private void HandleGameOver()
+        {
+            if (_suppression.SetReason(InputSuppressionReason.GameOver, true))
+            {
+                ApplyToDetectors();
+            }
+        }
+
+        private void HandleSelectionOpened(int level, IReadOnlyList<SkillData> choices)
+        {
+            if (_suppression.SetReason(InputSuppressionReason.LevelUpSelection, true))
+            {
+                ApplyToDetectors();
+            }
+        }
+
+        private void HandleSelectionClosed(int level)
+        {
+            if (_suppression.SetReason(InputSuppressionReason.LevelUpSelection, false))
+            {
+                ApplyToDetectors();
+            }
+        }
+
+        // 합산된 억제 상태를 두 입력 감지기에 동일하게 반영한다.
+        private void ApplyToDetectors()
+        {
+            bool enabled = _suppression.IsInputEnabled;
+
+            if (_swipeInputDetector != null)
+            {
+                _swipeInputDetector.SetInputEnabled(enabled);
+            }
+
+            if (_gangshinInputDetector != null)
+            {
+                _gangshinInputDetector.SetInputEnabled(enabled);
+            }
+        }
+
+        private static T FindSceneObject<T>() where T : UnityEngine.Object
+        {
+#if UNITY_2023_1_OR_NEWER
+            return FindFirstObjectByType<T>(FindObjectsInactive.Include);
+#else
+            return FindObjectOfType<T>();
+#endif
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/GameplayInputGate.cs
+++ b/project1/Assets/Scripts/Combat/GameplayInputGate.cs
@@ -23,6 +23,14 @@ namespace Mukseon.Gameplay.Combat
         private const string RootObjectName = "GameplayInputGateRuntime";
         private const float ResolveRetryInterval = 0.5f;
 
+        // 비게임플레이 씬(메뉴/로비/로딩)에는 GameOverHandler·PlayerLevelSystem이 없어 NeedsResolve가
+        // 영구히 true가 된다. 그 경우 매 프레임 FindFirstObjectByType를 반복하지 않도록, 일정 횟수
+        // (≈ MaxResolveRetries × ResolveRetryInterval 초) 시도 후 폴링을 멈춘다. 씬이 새로 로드되면
+        // ResolveAndReset에서 다시 초기화되어 게임플레이 씬에서 정상적으로 재해석된다.
+        private const int MaxResolveRetries = 6;
+
+        private static GameplayInputGate _instance;
+
         private readonly InputSuppressionState _suppression = new InputSuppressionState();
 
         private SwipeInputDetector _swipeInputDetector;
@@ -31,6 +39,8 @@ namespace Mukseon.Gameplay.Combat
         private PlayerLevelSystem _playerLevelSystem;
 
         private float _resolveRetryTimer;
+        private int _resolveRetryCount;
+        private bool _stopPolling;
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         private static void EnsureGate()
@@ -55,6 +65,15 @@ namespace Mukseon.Gameplay.Combat
 
         private void Awake()
         {
+            // 수동 씬 배치나 예기치 못한 경로로 인스턴스가 중복 생성되면 이벤트 구독이 중복되므로,
+            // 기존 인스턴스가 있으면 새로 생긴 쪽을 파괴한다(EnsureGate의 1차 방어에 대한 안전망).
+            if (_instance != null && _instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            _instance = this;
             DontDestroyOnLoad(gameObject);
             SceneManager.sceneLoaded += HandleSceneLoaded;
             ResolveAndReset();
@@ -62,14 +81,20 @@ namespace Mukseon.Gameplay.Combat
 
         private void OnDestroy()
         {
+            if (_instance == this)
+            {
+                _instance = null;
+            }
+
             SceneManager.sceneLoaded -= HandleSceneLoaded;
             UnsubscribeAll();
         }
 
         private void Update()
         {
-            // 모든 참조가 해석되면 더 이상 할 일이 없으므로 매 프레임 비용을 들이지 않는다.
-            if (!NeedsResolve())
+            // 모든 참조가 해석됐거나(NeedsResolve == false) 재시도 한도에 도달하면(_stopPolling)
+            // 매 프레임 비용을 들이지 않는다.
+            if (_stopPolling || !NeedsResolve())
             {
                 return;
             }
@@ -80,6 +105,12 @@ namespace Mukseon.Gameplay.Combat
                 _resolveRetryTimer = ResolveRetryInterval;
                 ResolveSources();
                 ApplyToDetectors();
+
+                _resolveRetryCount++;
+                if (_resolveRetryCount >= MaxResolveRetries)
+                {
+                    _stopPolling = true;
+                }
             }
         }
 
@@ -98,6 +129,8 @@ namespace Mukseon.Gameplay.Combat
             _playerLevelSystem = null;
             _suppression.Clear();
             _resolveRetryTimer = 0f;
+            _resolveRetryCount = 0;
+            _stopPolling = false;
             ResolveSources();
             ApplyToDetectors();
         }

--- a/project1/Assets/Scripts/Combat/GameplayInputGate.cs.meta
+++ b/project1/Assets/Scripts/Combat/GameplayInputGate.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e0fd70ee621143d68c20d3d2f6877ac7

--- a/project1/Assets/Scripts/Input/GangshinInputDetector.cs
+++ b/project1/Assets/Scripts/Input/GangshinInputDetector.cs
@@ -22,9 +22,33 @@ namespace Mukseon.Core.Input
         private float _lastTapTime = float.NegativeInfinity;
         private bool _isPressing;
         private bool _holdTriggered;
+        private bool _inputEnabled = true;
+
+        /// <summary>현재 강신(홀드/더블 탭) 입력 감지가 활성 상태인지 여부.</summary>
+        public bool IsInputEnabled => _inputEnabled;
+
+        /// <summary>
+        /// 외부(게임오버/레벨업 일시정지)에서 강신 입력 감지를 켜고 끈다(#42).
+        /// 비활성화 시 진행 중이던 누름/더블 탭 추적을 취소해, 일시정지 경계를 넘는 입력이
+        /// 재활성화 직후 강신을 오발동하지 않도록 한다.
+        /// </summary>
+        public void SetInputEnabled(bool enabled)
+        {
+            _inputEnabled = enabled;
+            if (!enabled)
+            {
+                CancelPress();
+                _lastTapTime = float.NegativeInfinity;
+            }
+        }
 
         private void Update()
         {
+            if (!_inputEnabled)
+            {
+                return;
+            }
+
 #if UNITY_EDITOR
             if (UnityEngine.Input.touchCount == 0)
             {

--- a/project1/Assets/Scripts/Input/InputSuppressionState.cs
+++ b/project1/Assets/Scripts/Input/InputSuppressionState.cs
@@ -1,0 +1,64 @@
+using System;
+
+namespace Mukseon.Core.Input
+{
+    /// <summary>
+    /// 입력을 일시적으로 막는 원인. 게임오버와 레벨업 스킬 선택은 서로 독립적으로 발생할 수 있으므로
+    /// 비트 플래그로 두어, 한 원인이 해제되어도 다른 원인이 남아 있으면 입력을 계속 막을 수 있게 한다.
+    /// </summary>
+    [Flags]
+    public enum InputSuppressionReason
+    {
+        None = 0,
+        GameOver = 1 << 0,
+        LevelUpSelection = 1 << 1,
+    }
+
+    /// <summary>
+    /// 여러 게임 상태(게임오버, 레벨업 선택 등)가 각각 입력을 막을 수 있으므로, 활성화된 모든 원인을
+    /// 비트 플래그로 누적한다. 원인이 하나도 없을 때만 입력이 활성 상태(<see cref="IsInputEnabled"/>)다.
+    /// MonoBehaviour에 의존하지 않는 순수 로직이라 단위 테스트가 용이하다(#42).
+    /// </summary>
+    public sealed class InputSuppressionState
+    {
+        private InputSuppressionReason _activeReasons;
+
+        public InputSuppressionReason ActiveReasons => _activeReasons;
+
+        /// <summary>활성화된 억제 원인이 하나도 없으면 true.</summary>
+        public bool IsInputEnabled => _activeReasons == InputSuppressionReason.None;
+
+        /// <summary>
+        /// 특정 원인을 켜거나 끈다. 그 결과 입력 활성/비활성 상태가 실제로 바뀌었을 때만 true를 반환한다.
+        /// (구독자가 상태가 바뀐 순간에만 감지기에 반영하도록 하기 위함)
+        /// </summary>
+        public bool SetReason(InputSuppressionReason reason, bool active)
+        {
+            if (reason == InputSuppressionReason.None)
+            {
+                return false;
+            }
+
+            bool wasEnabled = IsInputEnabled;
+
+            if (active)
+            {
+                _activeReasons |= reason;
+            }
+            else
+            {
+                _activeReasons &= ~reason;
+            }
+
+            return wasEnabled != IsInputEnabled;
+        }
+
+        /// <summary>모든 억제 원인을 해제한다(씬 재시작 등). 상태가 바뀌었으면 true를 반환한다.</summary>
+        public bool Clear()
+        {
+            bool wasEnabled = IsInputEnabled;
+            _activeReasons = InputSuppressionReason.None;
+            return wasEnabled != IsInputEnabled;
+        }
+    }
+}

--- a/project1/Assets/Scripts/Input/InputSuppressionState.cs.meta
+++ b/project1/Assets/Scripts/Input/InputSuppressionState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8659ad27b1994885b73c67058a3af701

--- a/project1/Assets/Scripts/Input/SwipeInputDetector.cs
+++ b/project1/Assets/Scripts/Input/SwipeInputDetector.cs
@@ -23,9 +23,32 @@ namespace Mukseon.Core.Input
 
         private Vector2 _startPosition;
         private bool _isTrackingSwipe;
+        private bool _inputEnabled = true;
+
+        /// <summary>현재 스와이프 입력 감지가 활성 상태인지 여부.</summary>
+        public bool IsInputEnabled => _inputEnabled;
+
+        /// <summary>
+        /// 외부(게임오버/레벨업 일시정지)에서 스와이프 입력 감지를 켜고 끈다(#42).
+        /// 비활성화 시 진행 중이던 스와이프 추적을 취소해, 일시정지 경계를 넘는 입력이
+        /// 재활성화 직후 오발동하지 않도록 한다.
+        /// </summary>
+        public void SetInputEnabled(bool enabled)
+        {
+            _inputEnabled = enabled;
+            if (!enabled)
+            {
+                _isTrackingSwipe = false;
+            }
+        }
 
         private void Update()
         {
+            if (!_inputEnabled)
+            {
+                return;
+            }
+
 #if UNITY_EDITOR
             if (UnityEngine.Input.touchCount == 0)
             {

--- a/project1/Assets/Scripts/Progression/PlayerLevelSystem.cs
+++ b/project1/Assets/Scripts/Progression/PlayerLevelSystem.cs
@@ -109,6 +109,10 @@ namespace Mukseon.Gameplay.Progression
             {
                 ResumeGameTime();
                 IsSelectionOpen = false;
+                // 선택지가 열린 채 비활성화되면 닫힘 이벤트를 발화해, 이를 구독하는 측(예: 입력 비활성화
+                // 게이트, HUD)이 억제/표시 상태를 정리하도록 한다. 이벤트가 없으면 씬 전환 없는 재시작
+                // 등에서 입력이 영구 차단될 수 있다(#42).
+                OnLevelSelectionClosed?.Invoke(CurrentLevel);
             }
         }
 

--- a/project1/Assets/Tests/EditMode/GangshinInputDetectorTests.cs
+++ b/project1/Assets/Tests/EditMode/GangshinInputDetectorTests.cs
@@ -1,0 +1,73 @@
+using Mukseon.Core.Input;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Mukseon.Tests.EditMode
+{
+    public class GangshinInputDetectorTests
+    {
+        [Test]
+        public void IsInputEnabled_DefaultsToTrue()
+        {
+            var go = new GameObject("GangshinInputDetectorTest");
+            try
+            {
+                var detector = go.AddComponent<GangshinInputDetector>();
+                Assert.That(detector.IsInputEnabled, Is.True);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void SetInputEnabled_TogglesIsInputEnabled()
+        {
+            var go = new GameObject("GangshinInputDetectorTest");
+            try
+            {
+                var detector = go.AddComponent<GangshinInputDetector>();
+
+                detector.SetInputEnabled(false);
+                Assert.That(detector.IsInputEnabled, Is.False);
+
+                detector.SetInputEnabled(true);
+                Assert.That(detector.IsInputEnabled, Is.True);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(go);
+            }
+        }
+
+        // 비활성화 → 재활성화 시 더블 탭 추적 상태(_lastTapTime)가 리셋되는지 검증한다.
+        // 리셋이 없으면 일시정지 직전 들어온 탭이 재개 직후 첫 탭만으로 더블 탭 조건을 충족해
+        // 강신이 오발동될 수 있다(#42). _lastTapTime은 private이므로 리플렉션으로 확인한다.
+        [Test]
+        public void SetInputEnabled_False_ResetsLastTapTime()
+        {
+            var go = new GameObject("GangshinInputDetectorTest");
+            try
+            {
+                var detector = go.AddComponent<GangshinInputDetector>();
+
+                var field = typeof(GangshinInputDetector).GetField(
+                    "_lastTapTime",
+                    System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+                Assert.That(field, Is.Not.Null, "_lastTapTime 필드를 찾을 수 없습니다.");
+
+                // 직전 탭 시각이 기록된 상황을 모사한다.
+                field.SetValue(detector, 5f);
+
+                detector.SetInputEnabled(false);
+
+                Assert.That((float)field.GetValue(detector), Is.EqualTo(float.NegativeInfinity));
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(go);
+            }
+        }
+    }
+}

--- a/project1/Assets/Tests/EditMode/GangshinInputDetectorTests.cs.meta
+++ b/project1/Assets/Tests/EditMode/GangshinInputDetectorTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2ad0bf71c3414fc8b90503f112a64350

--- a/project1/Assets/Tests/EditMode/InputSuppressionStateTests.cs
+++ b/project1/Assets/Tests/EditMode/InputSuppressionStateTests.cs
@@ -1,0 +1,101 @@
+using Mukseon.Core.Input;
+using NUnit.Framework;
+
+namespace Mukseon.Tests.EditMode
+{
+    public class InputSuppressionStateTests
+    {
+        [Test]
+        public void Default_InputIsEnabled_WithNoReasons()
+        {
+            var state = new InputSuppressionState();
+
+            Assert.That(state.IsInputEnabled, Is.True);
+            Assert.That(state.ActiveReasons, Is.EqualTo(InputSuppressionReason.None));
+        }
+
+        [Test]
+        public void SetReason_GameOver_DisablesInput_AndReportsChange()
+        {
+            var state = new InputSuppressionState();
+
+            bool changed = state.SetReason(InputSuppressionReason.GameOver, true);
+
+            Assert.That(changed, Is.True);
+            Assert.That(state.IsInputEnabled, Is.False);
+        }
+
+        [Test]
+        public void SetReason_LevelUpSelection_DisablesInput()
+        {
+            var state = new InputSuppressionState();
+
+            state.SetReason(InputSuppressionReason.LevelUpSelection, true);
+
+            Assert.That(state.IsInputEnabled, Is.False);
+        }
+
+        [Test]
+        public void SetReason_SameReasonTwice_ReportsNoChangeOnSecondCall()
+        {
+            var state = new InputSuppressionState();
+
+            state.SetReason(InputSuppressionReason.GameOver, true);
+            bool changedAgain = state.SetReason(InputSuppressionReason.GameOver, true);
+
+            Assert.That(changedAgain, Is.False);
+            Assert.That(state.IsInputEnabled, Is.False);
+        }
+
+        [Test]
+        public void ClearingOneOfTwoReasons_KeepsInputDisabled()
+        {
+            var state = new InputSuppressionState();
+            state.SetReason(InputSuppressionReason.GameOver, true);
+            state.SetReason(InputSuppressionReason.LevelUpSelection, true);
+
+            // 레벨업 선택만 닫혀도 게임오버가 남아 있으므로 입력은 여전히 막혀야 한다.
+            bool changed = state.SetReason(InputSuppressionReason.LevelUpSelection, false);
+
+            Assert.That(changed, Is.False);
+            Assert.That(state.IsInputEnabled, Is.False);
+        }
+
+        [Test]
+        public void ClearingLastReason_ReEnablesInput_AndReportsChange()
+        {
+            var state = new InputSuppressionState();
+            state.SetReason(InputSuppressionReason.LevelUpSelection, true);
+
+            bool changed = state.SetReason(InputSuppressionReason.LevelUpSelection, false);
+
+            Assert.That(changed, Is.True);
+            Assert.That(state.IsInputEnabled, Is.True);
+        }
+
+        [Test]
+        public void SetReason_None_IsNoOp()
+        {
+            var state = new InputSuppressionState();
+
+            bool changed = state.SetReason(InputSuppressionReason.None, true);
+
+            Assert.That(changed, Is.False);
+            Assert.That(state.IsInputEnabled, Is.True);
+        }
+
+        [Test]
+        public void Clear_RemovesAllReasons_AndReEnablesInput()
+        {
+            var state = new InputSuppressionState();
+            state.SetReason(InputSuppressionReason.GameOver, true);
+            state.SetReason(InputSuppressionReason.LevelUpSelection, true);
+
+            bool changed = state.Clear();
+
+            Assert.That(changed, Is.True);
+            Assert.That(state.IsInputEnabled, Is.True);
+            Assert.That(state.ActiveReasons, Is.EqualTo(InputSuppressionReason.None));
+        }
+    }
+}

--- a/project1/Assets/Tests/EditMode/InputSuppressionStateTests.cs.meta
+++ b/project1/Assets/Tests/EditMode/InputSuppressionStateTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 02ce458add514e09af2c315f35413642

--- a/project1/Assets/Tests/EditMode/SwipeInputDetectorTests.cs
+++ b/project1/Assets/Tests/EditMode/SwipeInputDetectorTests.cs
@@ -40,5 +40,40 @@ namespace Mukseon.Tests.EditMode
                 UnityEngine.Object.DestroyImmediate(go);
             }
         }
+
+        [Test]
+        public void IsInputEnabled_DefaultsToTrue()
+        {
+            var go = new GameObject("SwipeInputDetectorTest");
+            try
+            {
+                var detector = go.AddComponent<SwipeInputDetector>();
+                Assert.That(detector.IsInputEnabled, Is.True);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void SetInputEnabled_TogglesIsInputEnabled()
+        {
+            var go = new GameObject("SwipeInputDetectorTest");
+            try
+            {
+                var detector = go.AddComponent<SwipeInputDetector>();
+
+                detector.SetInputEnabled(false);
+                Assert.That(detector.IsInputEnabled, Is.False);
+
+                detector.SetInputEnabled(true);
+                Assert.That(detector.IsInputEnabled, Is.True);
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(go);
+            }
+        }
     }
 }


### PR DESCRIPTION
## 개요
게임오버와 레벨업 스킬 선택은 `Time.timeScale = 0`으로 일시정지하지만, 입력 감지기가 `Time.unscaledTime` 기반으로 동작해 **일시정지 중에도 스와이프/강신 입력이 계속 감지되던 문제**를 수정합니다.

Closes #42

## 변경 사항

| 파일 | 내용 |
|------|------|
| `Input/InputSuppressionState.cs` 🆕 | 게임오버·레벨업 등 여러 억제 원인을 **비트플래그로 합산**하는 순수 C# 클래스. 한 원인이 해제돼도 다른 원인이 남으면 입력 차단 유지. MonoBehaviour 무의존 → 단위 테스트 용이 |
| `Input/SwipeInputDetector.cs` | `SetInputEnabled(bool)` / `IsInputEnabled` 추가. 비활성 시 `Update()` 조기 반환 + 진행 중 스와이프 추적 취소 |
| `Input/GangshinInputDetector.cs` | 동일 API 추가. 비활성 시 누름/더블탭 추적 취소(경계 넘는 강신 오발동 방지) |
| `Combat/GameplayInputGate.cs` 🆕 | `GameOverHandler` / `PlayerLevelSystem` 이벤트를 구독해 두 감지기에 억제 상태를 반영하는 **자가 부트스트랩 코디네이터**(`GameplayHudBootstrapper` 선례 동일, 씬 편집 불필요) |
| `Tests/EditMode/InputSuppressionStateTests.cs` 🆕 | 합산 로직 8종 테스트 |
| `Tests/EditMode/SwipeInputDetectorTests.cs` | 게이팅 API 토글 테스트 2종 |

## 설계 근거
입력 감지기(`Mukseon.Core.Input`)는 게임오버/레벨업 같은 게임플레이 상태를 알아선 안 되므로(계층 분리), 둘 사이를 잇는 어댑터(`GameplayInputGate`)를 두고 의사결정 로직은 순수 클래스(`InputSuppressionState`)로 분리했습니다.

## 완료 기준 (DoD)
- [x] 게임오버 시 스와이프 입력 무시
- [x] 게임오버 시 더블탭(강신) 입력 무시
- [x] 레벨업 선택지 표시 중 스와이프 무시 + 선택 완료(UI 닫힘) 후 정상 복구
- [ ] ⚠️ 슬롯 교체 입력 / 별도 `DoubleTapDetector`(#60)는 아직 코드에 없는 미래 작업물 → #60 완료 시 `GameplayInputGate.ApplyToDetectors`에 한 줄 추가로 확장

## 검증
- 라이브 Unity 에디터에서 컴파일 클린 확인 (`No compile errors`)
- EditMode 테스트는 별도 실행 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)