### PR TITLE
feat: 강신 더블 탭 입력 감지 (홀드 폐기 / 탭·스와이프 분기) (#60)

### DIFF
--- a/project1/Assets/SampleScene.unity
+++ b/project1/Assets/SampleScene.unity
@@ -599,8 +599,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 76326102252468148bbc337f030e9e4e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.GangshinInvincibilityLink
-  _gangshinController: {fileID: 0}
-  _playerHealth: {fileID: 0}
+  _gangshinController: {fileID: 187285048}
+  _playerHealth: {fileID: 187285038}
 --- !u!114 &187285048
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -613,8 +613,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b22f6c7a1a8671e4881d8b1233a7418e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.GangshinController
-  _inputDetector: {fileID: 0}
-  _playerStatSystem: {fileID: 0}
+  _inputDetector: {fileID: 187285049}
+  _playerStatSystem: {fileID: 187285037}
   _maxGauge: 100
   _gaugePerKill: 20
   _activeDuration: 6

--- a/project1/Assets/SampleScene.unity
+++ b/project1/Assets/SampleScene.unity
@@ -175,6 +175,9 @@ GameObject:
   - component: {fileID: 187285044}
   - component: {fileID: 187285045}
   - component: {fileID: 187285046}
+  - component: {fileID: 187285049}
+  - component: {fileID: 187285048}
+  - component: {fileID: 187285047}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -584,6 +587,57 @@ MonoBehaviour:
   - 4.5
   - 4
   - 3.5
+--- !u!114 &187285047
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 187285028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76326102252468148bbc337f030e9e4e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.GangshinInvincibilityLink
+  _gangshinController: {fileID: 0}
+  _playerHealth: {fileID: 0}
+--- !u!114 &187285048
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 187285028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b22f6c7a1a8671e4881d8b1233a7418e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.GangshinController
+  _inputDetector: {fileID: 0}
+  _playerStatSystem: {fileID: 0}
+  _maxGauge: 100
+  _gaugePerKill: 20
+  _activeDuration: 6
+  _cooldownDuration: 10
+  _activeTimeScale: 0.7
+  _dealActivationPulse: 1
+  _activationPulseDamage: 999
+  _buffAttackPowerWhileActive: 1
+  _attackPowerBonusPercent: 1
+--- !u!114 &187285049
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 187285028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bcd87213526dd4c4f9953be4c8a87ec3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Core.Input.GangshinInputDetector
+  _doubleTapInterval: 0.3
+  _maxTapTravel: 20
 --- !u!1 &275740323
 GameObject:
   m_ObjectHideFlags: 0

--- a/project1/Assets/Scripts/Input/GangshinInputDetector.cs
+++ b/project1/Assets/Scripts/Input/GangshinInputDetector.cs
@@ -46,8 +46,8 @@ namespace Mukseon.Core.Input
             _inputEnabled = enabled;
             if (!enabled)
             {
+                // 누름·더블 탭 추적 리셋은 CancelPress가 함께 처리한다.
                 CancelPress();
-                _recognizer?.Reset();
             }
         }
 
@@ -140,7 +140,10 @@ namespace Mukseon.Core.Input
 
         private void CancelPress()
         {
+            // 누름 추적과 더블 탭 추적을 함께 끊는다. 터치 취소(TouchPhase.Canceled)나 입력 비활성화(#42) 시,
+            // 취소 이전의 첫 탭이 이후 탭과 묶여 더블 탭으로 오인되지 않도록 한다.
             _isPressing = false;
+            _recognizer?.Reset();
         }
     }
 }

--- a/project1/Assets/Scripts/Input/GangshinInputDetector.cs
+++ b/project1/Assets/Scripts/Input/GangshinInputDetector.cs
@@ -3,33 +3,42 @@ using UnityEngine;
 
 namespace Mukseon.Core.Input
 {
+    /// <summary>
+    /// 강신 발동 입력(더블 탭)을 감지한다. 기획 변경(#60)으로 길게 누르기(홀드) 발동은 폐기되고
+    /// 더블 탭으로 단일화되었다. 탭/드래그 분류와 더블 탭 판정은 순수 로직
+    /// <see cref="TapGestureRecognizer"/>가 담당하며, 본 컴포넌트는 입력 소스를 읽어 전달하는 얇은 래퍼다.
+    /// </summary>
     [DisallowMultipleComponent]
     public class GangshinInputDetector : MonoBehaviour
     {
-        [SerializeField, Min(0.05f)]
-        private float _holdDuration = 0.45f;
-
+        // 더블 탭 간격(초). 탭 두 번이 이 시간 이내면 더블 탭으로 인식한다(#60: 300ms).
         [SerializeField, Min(0.05f)]
         private float _doubleTapInterval = 0.3f;
 
+        // 탭/드래그 분기 임계값(px). 이동 거리가 이 값 미만이면 탭, 이상이면 드래그(스와이프)로 본다(#60: 20px).
         [SerializeField, Min(1f)]
-        private float _maxTapTravel = 24f;
+        private float _maxTapTravel = 20f;
 
+        /// <summary>더블 탭으로 강신 발동이 요청되었을 때 발생.</summary>
         public event Action OnActivationRequested;
 
+        private TapGestureRecognizer _recognizer;
         private Vector2 _pressStartPosition;
-        private float _pressStartTime;
-        private float _lastTapTime = float.NegativeInfinity;
         private bool _isPressing;
-        private bool _holdTriggered;
         private bool _inputEnabled = true;
 
-        /// <summary>현재 강신(홀드/더블 탭) 입력 감지가 활성 상태인지 여부.</summary>
+        /// <summary>현재 강신(더블 탭) 입력 감지가 활성 상태인지 여부.</summary>
         public bool IsInputEnabled => _inputEnabled;
+
+        private void Awake()
+        {
+            // 인스펙터에서 덮어쓴 직렬화 값을 반영하기 위해 역직렬화가 끝난 Awake에서 인식기를 만든다.
+            _recognizer = new TapGestureRecognizer(_maxTapTravel, _doubleTapInterval);
+        }
 
         /// <summary>
         /// 외부(게임오버/레벨업 일시정지)에서 강신 입력 감지를 켜고 끈다(#42).
-        /// 비활성화 시 진행 중이던 누름/더블 탭 추적을 취소해, 일시정지 경계를 넘는 입력이
+        /// 비활성화 시 진행 중이던 누름과 더블 탭 추적을 취소해, 일시정지 경계를 넘는 입력이
         /// 재활성화 직후 강신을 오발동하지 않도록 한다.
         /// </summary>
         public void SetInputEnabled(bool enabled)
@@ -38,7 +47,7 @@ namespace Mukseon.Core.Input
             if (!enabled)
             {
                 CancelPress();
-                _lastTapTime = float.NegativeInfinity;
+                _recognizer?.Reset();
             }
         }
 
@@ -73,10 +82,6 @@ namespace Mukseon.Core.Input
                 case TouchPhase.Began:
                     BeginPress(touch.position);
                     break;
-                case TouchPhase.Moved:
-                case TouchPhase.Stationary:
-                    UpdateHold(touch.position);
-                    break;
                 case TouchPhase.Ended:
                     EndPress(touch.position);
                     break;
@@ -94,11 +99,6 @@ namespace Mukseon.Core.Input
                 BeginPress(UnityEngine.Input.mousePosition);
             }
 
-            if (_isPressing)
-            {
-                UpdateHold(UnityEngine.Input.mousePosition);
-            }
-
             if (UnityEngine.Input.GetMouseButtonUp(0))
             {
                 EndPress(UnityEngine.Input.mousePosition);
@@ -109,29 +109,7 @@ namespace Mukseon.Core.Input
         private void BeginPress(Vector2 position)
         {
             _pressStartPosition = position;
-            _pressStartTime = Time.unscaledTime;
             _isPressing = true;
-            _holdTriggered = false;
-        }
-
-        private void UpdateHold(Vector2 currentPosition)
-        {
-            if (!_isPressing || _holdTriggered)
-            {
-                return;
-            }
-
-            if (Vector2.Distance(_pressStartPosition, currentPosition) > _maxTapTravel)
-            {
-                return;
-            }
-
-            if (Time.unscaledTime - _pressStartTime >= _holdDuration)
-            {
-                _holdTriggered = true;
-                _lastTapTime = float.NegativeInfinity;
-                OnActivationRequested?.Invoke();
-            }
         }
 
         private void EndPress(Vector2 endPosition)
@@ -141,29 +119,28 @@ namespace Mukseon.Core.Input
                 return;
             }
 
-            bool isTap = !_holdTriggered &&
-                Vector2.Distance(_pressStartPosition, endPosition) <= _maxTapTravel;
+            _isPressing = false;
 
-            if (isTap)
+            if (_recognizer == null)
             {
-                if (Time.unscaledTime - _lastTapTime <= _doubleTapInterval)
-                {
-                    _lastTapTime = float.NegativeInfinity;
-                    OnActivationRequested?.Invoke();
-                }
-                else
-                {
-                    _lastTapTime = Time.unscaledTime;
-                }
+                return;
             }
 
-            CancelPress();
+            // 누름→뗌 한 번을 인식기에 넘겨 분류한다. 드래그(스와이프)는 None이라 강신을 발동하지 않는다.
+            if (_recognizer.RegisterPress(_pressStartPosition, endPosition, Time.unscaledTime)
+                    == TapGestureRecognizer.Gesture.DoubleTap)
+            {
+#if UNITY_EDITOR
+                // 플레이모드 입력 검증용 로그(에디터 전용). 게이지 충전 여부와 무관하게 더블 탭 감지 자체를 확인한다.
+                Debug.Log("[GangshinInputDetector] Double tap detected → activation requested");
+#endif
+                OnActivationRequested?.Invoke();
+            }
         }
 
         private void CancelPress()
         {
             _isPressing = false;
-            _holdTriggered = false;
         }
     }
 }

--- a/project1/Assets/Scripts/Input/TapGestureRecognizer.cs
+++ b/project1/Assets/Scripts/Input/TapGestureRecognizer.cs
@@ -53,7 +53,10 @@ namespace Mukseon.Core.Input
 
             // 직전 탭과의 간격이 더블 탭 허용 범위 안이면 더블 탭 확정.
             // (_lastTapTime이 음의 무한대인 첫 탭은 간격이 +무한대가 되어 이 분기를 타지 않는다.)
-            if (endTime - _lastTapTime <= _doubleTapInterval)
+            // 시간이 역전되어(시각 리셋·비단조적 시각 주입 등) elapsed가 음수가 되면 더블 탭으로 오인하지
+            // 않도록 0 이상인지도 함께 확인한다.
+            float elapsed = endTime - _lastTapTime;
+            if (elapsed >= 0f && elapsed <= _doubleTapInterval)
             {
                 // 더블 탭 확정 후에는 추적을 끊어, 세 번째 탭이 또다시 더블 탭으로 이어지지 않게 한다.
                 _lastTapTime = float.NegativeInfinity;

--- a/project1/Assets/Scripts/Input/TapGestureRecognizer.cs
+++ b/project1/Assets/Scripts/Input/TapGestureRecognizer.cs
@@ -1,0 +1,77 @@
+using UnityEngine;
+
+namespace Mukseon.Core.Input
+{
+    /// <summary>
+    /// 한 번의 누름→뗌(press→release) 제스처를 탭/드래그로 분류하고, 연속된 탭의 더블 탭 여부를 판정하는
+    /// 순수 로직. MonoBehaviour나 UnityEngine.Input에 의존하지 않아 단위 테스트가 용이하다(#60).
+    /// 시간은 호출자가 전달한다(보통 Time.unscaledTime — 일시정지 중에도 일관되게 동작하도록).
+    /// </summary>
+    public sealed class TapGestureRecognizer
+    {
+        public enum Gesture
+        {
+            None = 0,      // 탭이 아님(이동 거리가 임계값 이상 = 드래그/스와이프)
+            Tap = 1,       // 단일 탭(더블 탭 후보)
+            DoubleTap = 2  // 더블 탭 확정
+        }
+
+        // 누름→뗌 이동 거리가 이 값(px) 미만이면 탭, 이상이면 드래그로 본다(#60: 분기 임계값 20px).
+        private readonly float _tapTravelThreshold;
+
+        // 직전 탭과 다음 탭 사이 간격이 이 값(초) 이하이면 더블 탭으로 인식한다(#60: 300ms).
+        private readonly float _doubleTapInterval;
+
+        // 직전에 인식된 단일 탭의 시각. 더블 탭이 확정되거나 Reset되면 음의 무한대로 초기화한다.
+        private float _lastTapTime = float.NegativeInfinity;
+
+        public TapGestureRecognizer(float tapTravelThreshold, float doubleTapInterval)
+        {
+            _tapTravelThreshold = Mathf.Max(0f, tapTravelThreshold);
+            _doubleTapInterval = Mathf.Max(0f, doubleTapInterval);
+        }
+
+        public float TapTravelThreshold => _tapTravelThreshold;
+        public float DoubleTapInterval => _doubleTapInterval;
+
+        /// <summary>
+        /// 완료된 누름→뗌 제스처 하나를 평가한다.
+        /// 이동 거리가 임계값 이상이면 드래그로 보고 <see cref="Gesture.None"/>을 반환하며, 더블 탭 추적도 끊는다
+        /// (드래그가 직전 탭과 묶여 더블 탭으로 오인되지 않도록).
+        /// </summary>
+        /// <param name="startPosition">누름 시작 스크린 좌표</param>
+        /// <param name="endPosition">뗀 순간 스크린 좌표</param>
+        /// <param name="endTime">뗀 시각(초). 보통 Time.unscaledTime.</param>
+        public Gesture RegisterPress(Vector2 startPosition, Vector2 endPosition, float endTime)
+        {
+            // 임계값 이상 이동 → 스와이프(드래그)로 분류. 탭이 아니므로 더블 탭 후보 추적을 끊는다.
+            if (Vector2.Distance(startPosition, endPosition) >= _tapTravelThreshold)
+            {
+                _lastTapTime = float.NegativeInfinity;
+                return Gesture.None;
+            }
+
+            // 직전 탭과의 간격이 더블 탭 허용 범위 안이면 더블 탭 확정.
+            // (_lastTapTime이 음의 무한대인 첫 탭은 간격이 +무한대가 되어 이 분기를 타지 않는다.)
+            if (endTime - _lastTapTime <= _doubleTapInterval)
+            {
+                // 더블 탭 확정 후에는 추적을 끊어, 세 번째 탭이 또다시 더블 탭으로 이어지지 않게 한다.
+                _lastTapTime = float.NegativeInfinity;
+                return Gesture.DoubleTap;
+            }
+
+            // 단일 탭: 다음 탭과의 더블 탭 판정을 위해 시각을 기록한다.
+            _lastTapTime = endTime;
+            return Gesture.Tap;
+        }
+
+        /// <summary>
+        /// 더블 탭 추적 상태를 초기화한다. 입력 비활성화/일시정지 경계를 넘는 탭이 재개 직후
+        /// 첫 탭만으로 더블 탭을 충족해 오발동하지 않도록 한다(#42).
+        /// </summary>
+        public void Reset()
+        {
+            _lastTapTime = float.NegativeInfinity;
+        }
+    }
+}

--- a/project1/Assets/Scripts/Input/TapGestureRecognizer.cs.meta
+++ b/project1/Assets/Scripts/Input/TapGestureRecognizer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ce5fe22a7e674e24a874a5c4def27c8d

--- a/project1/Assets/Settings/Scenes/URP2DSceneTemplate.unity
+++ b/project1/Assets/Settings/Scenes/URP2DSceneTemplate.unity
@@ -769,9 +769,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bcd87213526dd4c4f9953be4c8a87ec3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Core.Input.GangshinInputDetector
-  _holdDuration: 0.45
   _doubleTapInterval: 0.3
-  _maxTapTravel: 24
+  _maxTapTravel: 20
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/project1/Assets/Tests/EditMode/GangshinInputDetectorTests.cs
+++ b/project1/Assets/Tests/EditMode/GangshinInputDetectorTests.cs
@@ -41,28 +41,33 @@ namespace Mukseon.Tests.EditMode
             }
         }
 
-        // 비활성화 → 재활성화 시 더블 탭 추적 상태(_lastTapTime)가 리셋되는지 검증한다.
-        // 리셋이 없으면 일시정지 직전 들어온 탭이 재개 직후 첫 탭만으로 더블 탭 조건을 충족해
-        // 강신이 오발동될 수 있다(#42). _lastTapTime은 private이므로 리플렉션으로 확인한다.
+        // 비활성화 시 더블 탭 추적이 리셋되는지 검증한다(#42). 리셋이 없으면 일시정지 직전 들어온 탭이
+        // 재개 직후 첫 탭만으로 더블 탭 조건을 충족해 강신이 오발동될 수 있다.
+        // 더블 탭 판정은 TapGestureRecognizer가 담당하므로, EditMode에서 Awake가 호출되지 않는 점을 감안해
+        // 인식기를 리플렉션으로 주입한 뒤 동작으로 리셋 여부를 확인한다.
         [Test]
-        public void SetInputEnabled_False_ResetsLastTapTime()
+        public void SetInputEnabled_False_ResetsDoubleTapTracking()
         {
             var go = new GameObject("GangshinInputDetectorTest");
             try
             {
                 var detector = go.AddComponent<GangshinInputDetector>();
 
+                var recognizer = new TapGestureRecognizer(20f, 0.3f);
                 var field = typeof(GangshinInputDetector).GetField(
-                    "_lastTapTime",
+                    "_recognizer",
                     System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-                Assert.That(field, Is.Not.Null, "_lastTapTime 필드를 찾을 수 없습니다.");
+                Assert.That(field, Is.Not.Null, "_recognizer 필드를 찾을 수 없습니다.");
+                field.SetValue(detector, recognizer);
 
-                // 직전 탭 시각이 기록된 상황을 모사한다.
-                field.SetValue(detector, 5f);
+                // 첫 탭으로 더블 탭 후보 상태를 만든다.
+                recognizer.RegisterPress(Vector2.zero, Vector2.zero, 1f);
 
                 detector.SetInputEnabled(false);
 
-                Assert.That((float)field.GetValue(detector), Is.EqualTo(float.NegativeInfinity));
+                // 리셋되었으므로 곧바로 들어온 탭은 더블 탭이 아니라 단일 탭이어야 한다.
+                var result = recognizer.RegisterPress(Vector2.zero, Vector2.zero, 1.1f);
+                Assert.That(result, Is.EqualTo(TapGestureRecognizer.Gesture.Tap));
             }
             finally
             {

--- a/project1/Assets/Tests/EditMode/TapGestureRecognizerTests.cs
+++ b/project1/Assets/Tests/EditMode/TapGestureRecognizerTests.cs
@@ -1,0 +1,112 @@
+using Mukseon.Core.Input;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Mukseon.Tests.EditMode
+{
+    public class TapGestureRecognizerTests
+    {
+        private const float TravelThreshold = 20f;
+        private const float DoubleTapInterval = 0.3f;
+
+        private static TapGestureRecognizer CreateRecognizer()
+            => new TapGestureRecognizer(TravelThreshold, DoubleTapInterval);
+
+        // 이동 거리가 임계값 미만이면 탭으로 분류된다.
+        [Test]
+        public void Press_BelowTravelThreshold_IsTap()
+        {
+            var recognizer = CreateRecognizer();
+
+            var result = recognizer.RegisterPress(new Vector2(100f, 100f), new Vector2(110f, 105f), 1f); // ≈11px
+
+            Assert.That(result, Is.EqualTo(TapGestureRecognizer.Gesture.Tap));
+        }
+
+        // 이동 거리가 임계값 이상이면 드래그(스와이프)로 보고 탭으로 인식하지 않는다(None).
+        [Test]
+        public void Press_AtOrAboveTravelThreshold_IsNone()
+        {
+            var recognizer = CreateRecognizer();
+
+            var result = recognizer.RegisterPress(new Vector2(100f, 100f), new Vector2(125f, 100f), 1f); // 25px
+
+            Assert.That(result, Is.EqualTo(TapGestureRecognizer.Gesture.None));
+        }
+
+        // 임계값과 정확히 같은 이동 거리는 드래그(None) 쪽으로 분류된다(>= 경계).
+        [Test]
+        public void Press_ExactlyAtThreshold_IsNone()
+        {
+            var recognizer = CreateRecognizer();
+
+            var result = recognizer.RegisterPress(Vector2.zero, new Vector2(TravelThreshold, 0f), 1f);
+
+            Assert.That(result, Is.EqualTo(TapGestureRecognizer.Gesture.None));
+        }
+
+        // 더블 탭 간격 이내의 두 번째 탭은 더블 탭으로 확정된다.
+        [Test]
+        public void TwoTapsWithinInterval_SecondIsDoubleTap()
+        {
+            var recognizer = CreateRecognizer();
+
+            Assert.That(recognizer.RegisterPress(Vector2.zero, Vector2.zero, 1.0f),
+                Is.EqualTo(TapGestureRecognizer.Gesture.Tap));
+            Assert.That(recognizer.RegisterPress(Vector2.zero, Vector2.zero, 1.2f), // 0.2s ≤ 0.3s
+                Is.EqualTo(TapGestureRecognizer.Gesture.DoubleTap));
+        }
+
+        // 더블 탭 간격을 넘어선 두 번째 탭은 다시 단일 탭이다.
+        [Test]
+        public void TwoTapsBeyondInterval_BothAreSingleTaps()
+        {
+            var recognizer = CreateRecognizer();
+
+            Assert.That(recognizer.RegisterPress(Vector2.zero, Vector2.zero, 1.0f),
+                Is.EqualTo(TapGestureRecognizer.Gesture.Tap));
+            Assert.That(recognizer.RegisterPress(Vector2.zero, Vector2.zero, 1.5f), // 0.5s > 0.3s
+                Is.EqualTo(TapGestureRecognizer.Gesture.Tap));
+        }
+
+        // 탭과 탭 사이에 드래그가 끼면 더블 탭 추적이 끊겨, 이어지는 탭은 단일 탭이 된다.
+        [Test]
+        public void DragBetweenTaps_BreaksDoubleTap()
+        {
+            var recognizer = CreateRecognizer();
+
+            recognizer.RegisterPress(Vector2.zero, Vector2.zero, 1.0f);                 // 탭
+            recognizer.RegisterPress(Vector2.zero, new Vector2(50f, 0f), 1.1f);         // 드래그 → None, 추적 끊김
+            var result = recognizer.RegisterPress(Vector2.zero, Vector2.zero, 1.15f);   // 단일 탭이어야 함
+
+            Assert.That(result, Is.EqualTo(TapGestureRecognizer.Gesture.Tap));
+        }
+
+        // 세 번 연속 탭은 (탭 → 더블 탭 → 탭)이 되어, 한 번에 두 번의 더블 탭이 나오지 않는다.
+        [Test]
+        public void TripleTap_DoesNotProduceTwoDoubleTaps()
+        {
+            var recognizer = CreateRecognizer();
+
+            Assert.That(recognizer.RegisterPress(Vector2.zero, Vector2.zero, 1.0f),
+                Is.EqualTo(TapGestureRecognizer.Gesture.Tap));
+            Assert.That(recognizer.RegisterPress(Vector2.zero, Vector2.zero, 1.1f),
+                Is.EqualTo(TapGestureRecognizer.Gesture.DoubleTap));
+            Assert.That(recognizer.RegisterPress(Vector2.zero, Vector2.zero, 1.2f),
+                Is.EqualTo(TapGestureRecognizer.Gesture.Tap));
+        }
+
+        // Reset 후에는 직전 탭 추적이 사라져, 간격이 짧아도 더블 탭이 아니라 단일 탭이 된다(#42).
+        [Test]
+        public void Reset_ClearsDoubleTapTracking()
+        {
+            var recognizer = CreateRecognizer();
+
+            recognizer.RegisterPress(Vector2.zero, Vector2.zero, 1.0f); // 탭
+            recognizer.Reset();
+            var result = recognizer.RegisterPress(Vector2.zero, Vector2.zero, 1.1f); // 리셋 없으면 더블 탭이었을 입력
+
+            Assert.That(result, Is.EqualTo(TapGestureRecognizer.Gesture.Tap));
+        }
+    }
+}

--- a/project1/Assets/Tests/EditMode/TapGestureRecognizerTests.cs
+++ b/project1/Assets/Tests/EditMode/TapGestureRecognizerTests.cs
@@ -108,5 +108,18 @@ namespace Mukseon.Tests.EditMode
 
             Assert.That(result, Is.EqualTo(TapGestureRecognizer.Gesture.Tap));
         }
+
+        // 시간이 역전되어 두 번째 탭의 시각이 더 과거이면(비단조적 시각 주입), 음수 간격을 더블 탭으로 오인하지 않는다.
+        [Test]
+        public void NonMonotonicTime_DoesNotProduceDoubleTap()
+        {
+            var recognizer = CreateRecognizer();
+
+            Assert.That(recognizer.RegisterPress(Vector2.zero, Vector2.zero, 5.0f),
+                Is.EqualTo(TapGestureRecognizer.Gesture.Tap));
+            // 두 번째 탭이 더 과거 시각(1.0초)으로 들어와도 더블 탭이 아니라 단일 탭으로 처리되어야 한다.
+            Assert.That(recognizer.RegisterPress(Vector2.zero, Vector2.zero, 1.0f),
+                Is.EqualTo(TapGestureRecognizer.Gesture.Tap));
+        }
     }
 }

--- a/project1/Assets/Tests/EditMode/TapGestureRecognizerTests.cs.meta
+++ b/project1/Assets/Tests/EditMode/TapGestureRecognizerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 19e7aecb56364c779b57bc8f560d04fd


### PR DESCRIPTION
## 개요
`docs/features/gangshin_system.md` 기준, 강신 발동 조작을 **더블 탭**으로 단일화하고 기존 **길게 누르기(홀드) 발동을 폐기**한다. 탭/스와이프는 이동 거리 임계값으로 분기해 입력 충돌을 막는다. Closes #60.

## 변경 사항
- **`TapGestureRecognizer`(신규)**: 누름→뗌 1회를 탭/드래그로 분류하고 더블 탭을 판정하는 순수 C# 로직. 시간을 호출자가 주입(보통 `Time.unscaledTime`)해 단위 테스트가 용이하다. (`GangshinRuntime`·`InputSuppressionState`의 순수 로직 분리 패턴을 따름)
- **`GangshinInputDetector`(수정)**: 홀드 로직 제거, 더블 탭 단일화. 인식기를 사용하는 얇은 래퍼로 축소. `OnActivationRequested`·`SetInputEnabled`(#42) 계약 유지.
- **임계값 정책**: 탭/드래그 분기 **20px**, 공격 스와이프 발동은 기존 **75px 유지**(20~75px는 의도된 데드존 — 기존 타격 손맛 보존).
- **씬 통합**: 실제 플레이 씬 `SampleScene`의 `Player`에 강신 3종(`GangshinController`/`GangshinInputDetector`/`GangshinInvincibilityLink`)이 누락돼 있어 추가. `URP2DSceneTemplate`은 사라진 `_holdDuration` 필드 제거 및 `_maxTapTravel` 24→20.
- **에디터 전용 로그**: 더블 탭 감지 시점에 `[GangshinInputDetector] Double tap detected …` 로그 추가(`#if UNITY_EDITOR`, `SwipeInputDetector` 컨벤션과 동일). 빌드 미포함.

## DoD 매핑
- [x] 두 번 탭(≤300ms) → 더블 탭 → 강신 발동 요청
- [x] 드래그 <20px → 탭(스와이프 미발동), ≥20px → 드래그(탭 미발동)
- [x] 발동 가능(Ready) 상태에서만 발동 / 불가 시 더블 탭 무시 (`GangshinController` 기존 게이팅)
- [x] 강신 발동 중에도 스와이프 정상 처리(`SwipeInputDetector` 미변경)
- [x] 홀드 폐기 · `Time.unscaledTime` 기준 · 임계값 인스펙터 노출 · #42 입력 비활성화 시 리셋

## 테스트
- **`TapGestureRecognizerTests`(신규, 9케이스)**: 임계값 경계, 더블 탭 간격 내/외, 드래그로 더블 탭 차단, 트리플 탭, Reset 등.
- **`GangshinInputDetectorTests`(갱신)**: 사라진 `_lastTapTime` 참조 테스트를 인식기 주입 방식의 #42 리셋 검증으로 교체.
- Unity 에디터 컴파일 에러 없음 확인. 플레이모드에서 더블 탭 로그 출력 확인.

> ⚠️ EditMode 테스트는 작성자 환경에 러너가 없어 자동 실행은 못 했습니다. 리뷰 시 Unity Test Runner로 한 번 돌려주세요.

## 후속/관련
- #59(강신 4슬롯), #30(강신 필살기 효과)에서 본 입력 경로 위에 슬롯 교체/발동 효과를 올릴 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)