### PR TITLE
feat: 강신 필살기 효과 구현 — 살풀이 검무 / 파천의 징 (#30)

### DIFF
--- a/project1/Assets/SampleScene.unity
+++ b/project1/Assets/SampleScene.unity
@@ -620,6 +620,8 @@ MonoBehaviour:
   _activeDuration: 6
   _cooldownDuration: 10
   _activeTimeScale: 0.7
+  _equippedAbility: {fileID: 0}
+  _abilityLevel: 1
   _dealActivationPulse: 1
   _activationPulseDamage: 999
   _buffAttackPowerWhileActive: 1

--- a/project1/Assets/Scripts/Combat/EnemyMover.cs
+++ b/project1/Assets/Scripts/Combat/EnemyMover.cs
@@ -40,7 +40,14 @@ namespace Mukseon.Gameplay.Combat
         // Tick에서 소비 후 1로 리셋한다. 매 프레임 가장 강한 슬로우(가장 작은 값)만 반영된다.
         private float _slowThisFrame = 1f;
 
+        // 기절(Stun) 남은 시간(초). 0보다 크면 이동을 완전히 정지한다. 강신 파천의 징(#30) 등이 부여한다.
+        // 슬로우와 달리 지속 시간 동안 상태가 유지되며, Tick에서 deltaTime만큼 감소한다.
+        private float _stunTimer;
+
         public EnemyMovePattern MovePattern => _movePattern;
+
+        /// <summary>기절 상태 여부. 기절 중에는 이동을 정지한다.</summary>
+        public bool IsStunned => _stunTimer > 0f;
 
         private void Awake()
         {
@@ -49,8 +56,9 @@ namespace Mukseon.Gameplay.Combat
 
         private void OnEnable()
         {
-            // 풀 재사용 가드: 슬로우 상태로 사망하면 Tick의 조기 반환으로 리셋이 누락되므로 여기서 초기화한다.
+            // 풀 재사용 가드: 슬로우/기절 상태로 사망하면 Tick의 조기 반환으로 리셋이 누락되므로 여기서 초기화한다.
             _slowThisFrame = 1f;
+            _stunTimer = 0f;
             _spawnPosition = transform.position;
 
             if (_playerTarget == null)
@@ -84,6 +92,14 @@ namespace Mukseon.Gameplay.Combat
                 return;
             }
 
+            // 기절 중에는 타이머만 감소시키고 이동은 정지한다. 슬로우 요청은 이번 프레임에 소비된 것으로 처리한다.
+            if (_stunTimer > 0f)
+            {
+                _stunTimer = Mathf.Max(0f, _stunTimer - Mathf.Max(0f, deltaTime));
+                _slowThisFrame = 1f;
+                return;
+            }
+
             float step = _enemyHealth.MoveSpeed * Mathf.Max(0f, deltaTime) * _slowThisFrame;
 
             switch (_movePattern)
@@ -113,6 +129,20 @@ namespace Mukseon.Gameplay.Combat
         public void RequestSlow(float multiplier)
         {
             _slowThisFrame = Mathf.Min(_slowThisFrame, Mathf.Clamp01(multiplier));
+        }
+
+        /// <summary>
+        /// 기절(Stun)을 부여한다. 지속 시간 동안 이동이 정지된다(강신 파천의 징 #30).
+        /// 이미 기절 중이면 남은 시간과 요청 시간 중 더 긴 값을 사용해 기절이 짧아지지 않게 한다.
+        /// </summary>
+        public void ApplyStun(float duration)
+        {
+            if (duration <= 0f)
+            {
+                return;
+            }
+
+            _stunTimer = Mathf.Max(_stunTimer, duration);
         }
 
         /// <summary>플레이어 방향으로 직선 이동 (창귀)</summary>

--- a/project1/Assets/Scripts/Combat/GangshinAbilityBaksoo.cs
+++ b/project1/Assets/Scripts/Combat/GangshinAbilityBaksoo.cs
@@ -77,12 +77,22 @@ namespace Mukseon.Gameplay.Combat
             if (_pendingDelay > 0f)
             {
                 _pendingDelay -= deltaTime;
-                if (_pendingDelay <= 0f && _wavesRemaining > 0)
+                if (_pendingDelay > 0f)
                 {
-                    StartWave();
+                    return; // 아직 대기 중.
                 }
 
-                return;
+                if (_wavesRemaining <= 0)
+                {
+                    _pendingDelay = 0f;
+                    return;
+                }
+
+                // 대기 종료. 딜레이를 초과한 시간(-_pendingDelay)을 새 파동의 진행 시간으로 이월해
+                // 프레임 레이트가 낮아도 2번째 파동 시작 타이밍이 밀리지 않게 한다(프레임 독립).
+                deltaTime = -_pendingDelay;
+                _pendingDelay = 0f;
+                StartWave();
             }
 
             if (!_waveActive)
@@ -152,9 +162,10 @@ namespace Mukseon.Gameplay.Combat
             }
 
             // 부모(플레이어) 스케일을 보정해 월드 지름이 정확히 2*반경이 되도록 한다.
+            // 좌우 반전(lossyScale.x < 0) 시 스케일이 음수가 되면 렌더링에 부작용이 생기므로 절댓값을 쓴다.
             Transform parent = _waveRing.transform.parent;
-            float parentScale = parent != null ? parent.lossyScale.x : 1f;
-            if (Mathf.Abs(parentScale) < 0.0001f)
+            float parentScale = parent != null ? Mathf.Abs(parent.lossyScale.x) : 1f;
+            if (parentScale < 0.0001f)
             {
                 parentScale = 1f;
             }

--- a/project1/Assets/Scripts/Combat/GangshinAbilityBaksoo.cs
+++ b/project1/Assets/Scripts/Combat/GangshinAbilityBaksoo.cs
@@ -1,0 +1,170 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 파천의 징 [박수 기본 강신, #30]. 먹물 파동이 중앙에서 바깥으로 뻗어나가며 전체 피해 + 기절(Stun).
+    /// Lv3에서는 파동을 2회 연속 발사한다(2번째 파동은 잠시 딜레이 후, 기절 중인 적에 적중해 대량 피해).
+    ///
+    /// 이슈 문서상 명칭은 GangshinAbility_Baksoo이나, 프로젝트 네이밍 규칙(클래스 PascalCase)에 맞춰
+    /// GangshinAbilityBaksoo로 정의한다.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class GangshinAbilityBaksoo : GangshinAbilityBase
+    {
+        [Header("Wave")]
+        [SerializeField, Min(0.1f), Tooltip("파동이 도달하는 최대 반경(월드 유닛). 화면을 덮을 만큼 크게.")]
+        private float _maxRadius = 12f;
+
+        [SerializeField, Min(0.05f), Tooltip("파동이 최대 반경까지 확장되는 데 걸리는 시간(초).")]
+        private float _waveDuration = 0.4f;
+
+        [SerializeField, Min(0.01f), Tooltip("Lv3 2번째 파동 발사 전 딜레이(초).")]
+        private float _secondWaveDelay = 0.35f;
+
+        [Header("VFX (선택)")]
+        [SerializeField, Tooltip("파동을 시각화하는 흰 원 SpriteRenderer(플레이어 자식). 반경에 맞춰 스케일된다.")]
+        private SpriteRenderer _waveRing;
+
+        // 발동 컨텍스트 및 현재 레벨 수치.
+        private GangshinSlotContext _context;
+        private float _damage;
+        private float _stunDuration;
+
+        // 파동 진행 상태.
+        private readonly HashSet<EnemyHealth> _hitSet = new HashSet<EnemyHealth>();
+        private bool _waveActive;
+        private float _elapsed;
+        private float _radius;
+        private int _wavesRemaining;
+        private float _pendingDelay;
+
+        internal float CurrentRadius => _radius;
+        internal bool IsWaveActive => _waveActive;
+        internal int WavesRemaining => _wavesRemaining;
+
+        public override void Activate(GangshinSlotContext context)
+        {
+            _context = context;
+            GangshinAbilityLevel level = _data != null ? _data.GetLevel(context.Level) : default;
+            _damage = level.Damage;
+            _stunDuration = level.StunDuration;
+
+            // Lv3(DoubleWave)은 2회, 그 외는 1회 발사.
+            _wavesRemaining = level.DoubleWave ? 2 : 1;
+            _pendingDelay = 0f;
+
+            StartWave();
+        }
+
+        private void Update()
+        {
+            if (!_waveActive && _pendingDelay <= 0f)
+            {
+                return;
+            }
+
+            // 파동은 게임 월드와 동일하게 스케일 시간으로 확장한다(발동 중 슬로우 연출과 일관).
+            Tick(Time.deltaTime);
+        }
+
+        internal void Tick(float deltaTime)
+        {
+            deltaTime = Mathf.Max(0f, deltaTime);
+
+            // Lv3 2번째 파동 대기: 딜레이가 끝나면 새 파동을 시작한다.
+            if (_pendingDelay > 0f)
+            {
+                _pendingDelay -= deltaTime;
+                if (_pendingDelay <= 0f && _wavesRemaining > 0)
+                {
+                    StartWave();
+                }
+
+                return;
+            }
+
+            if (!_waveActive)
+            {
+                return;
+            }
+
+            _elapsed += deltaTime;
+            float progress = _waveDuration > 0f ? Mathf.Clamp01(_elapsed / _waveDuration) : 1f;
+            _radius = _maxRadius * progress;
+
+            // 확장하는 파면(원점~_radius)에 새로 들어온 적에게만 데미지·기절을 적용한다.
+            GangshinAbilityEffects.ApplyExpandingRing(
+                _context.Origin, _radius, _damage, _stunDuration, _context.Enemies, _hitSet, _context.Source);
+
+            UpdateRingVisual(progress);
+
+            if (progress >= 1f)
+            {
+                EndWave();
+            }
+        }
+
+        private void StartWave()
+        {
+            _hitSet.Clear();
+            _elapsed = 0f;
+            _radius = 0f;
+            _waveActive = true;
+            _wavesRemaining--;
+
+            if (_waveRing != null)
+            {
+                _waveRing.enabled = true;
+            }
+        }
+
+        private void EndWave()
+        {
+            _waveActive = false;
+
+            if (_wavesRemaining > 0)
+            {
+                // 남은 파동(Lv3 2번째)을 잠시 딜레이 후 발사한다.
+                _pendingDelay = Mathf.Max(0.01f, _secondWaveDelay);
+                return;
+            }
+
+            if (_waveRing != null)
+            {
+                _waveRing.enabled = false;
+            }
+        }
+
+        /// <summary>흰 원 파동 비주얼을 현재 반경(지름 = 2*반경)에 맞춰 스케일하고, 파면이 나아갈수록 옅게 페이드한다.</summary>
+        private void UpdateRingVisual(float progress)
+        {
+            if (_waveRing == null || _waveRing.sprite == null)
+            {
+                return;
+            }
+
+            float spriteWorldSize = _waveRing.sprite.bounds.size.x;
+            if (spriteWorldSize <= 0.0001f)
+            {
+                return;
+            }
+
+            // 부모(플레이어) 스케일을 보정해 월드 지름이 정확히 2*반경이 되도록 한다.
+            Transform parent = _waveRing.transform.parent;
+            float parentScale = parent != null ? parent.lossyScale.x : 1f;
+            if (Mathf.Abs(parentScale) < 0.0001f)
+            {
+                parentScale = 1f;
+            }
+
+            float scale = (_radius * 2f) / (spriteWorldSize * parentScale);
+            _waveRing.transform.localScale = new Vector3(scale, scale, 1f);
+
+            Color color = _waveRing.color;
+            color.a = Mathf.Lerp(1f, 0f, progress);
+            _waveRing.color = color;
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/GangshinAbilityBaksoo.cs.meta
+++ b/project1/Assets/Scripts/Combat/GangshinAbilityBaksoo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4a3da725bfba4bc5a644c0686b5f7c44

--- a/project1/Assets/Scripts/Combat/GangshinAbilityBase.cs
+++ b/project1/Assets/Scripts/Combat/GangshinAbilityBase.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 강신 스킬 효과의 추상 기반(#30). GangshinController가 Active 진입 시 장착된 Ability의
+    /// <see cref="Activate"/>를 호출한다. 데미지 / 기절 등 실제 전투 로직은 순수 로직
+    /// <see cref="GangshinAbilityEffects"/>로 분리해 테스트 용이성을 확보한다.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public abstract class GangshinAbilityBase : MonoBehaviour
+    {
+        [Header("Data")]
+        [SerializeField]
+        protected GangshinAbilityData _data;
+
+        public GangshinAbilityData Data => _data;
+
+        /// <summary>표시 이름(데이터 미지정 시 오브젝트 이름).</summary>
+        public string DisplayName => _data != null ? _data.DisplayName : name;
+
+        /// <summary>
+        /// 지정 레벨(1-based)의 발동에 필요한 게이지 비율(0~1). 데이터 미지정 시 1(100%)로 간주한다.
+        /// 게이지 임계값 연동(#59)에서 사용.
+        /// </summary>
+        public float GetRequiredGaugeNormalized(int level)
+        {
+            return _data != null ? _data.GetLevel(level).RequiredGaugeNormalized : 1f;
+        }
+
+        /// <summary>강신을 발동한다. GangshinController가 호출한다.</summary>
+        public abstract void Activate(GangshinSlotContext context);
+
+        internal void SetDataForTests(GangshinAbilityData data)
+        {
+            _data = data;
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/GangshinAbilityBase.cs.meta
+++ b/project1/Assets/Scripts/Combat/GangshinAbilityBase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cfbafcae64014d94a2efc151621ed612

--- a/project1/Assets/Scripts/Combat/GangshinAbilityData.cs
+++ b/project1/Assets/Scripts/Combat/GangshinAbilityData.cs
@@ -1,0 +1,68 @@
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 강신 스킬 1개의 데이터(gangshin_system.md — 필요한 데이터 항목).
+    /// 레벨별 수치 테이블과 표시 정보를 담는다. 레벨 관리는 슬롯 / 강화 카드 시스템(#59, #66)이 담당한다.
+    /// </summary>
+    [CreateAssetMenu(fileName = "GangshinAbilityData", menuName = "Mukseon/Data/Gangshin Ability Data")]
+    public class GangshinAbilityData : ScriptableObject
+    {
+        [SerializeField]
+        private string _abilityId = "gangshin.default";
+
+        [SerializeField]
+        private string _displayName = "강신";
+
+        [SerializeField, TextArea]
+        private string _description;
+
+        [SerializeField]
+        private Sprite _icon;
+
+        [SerializeField, Tooltip("레벨별 수치(index 0 = Lv1). gangshin_balance_mvp.md 참조.")]
+        private GangshinAbilityLevel[] _levels =
+        {
+            new GangshinAbilityLevel(500f, 100f, 0f, false),
+        };
+
+        public string AbilityId => string.IsNullOrWhiteSpace(_abilityId) ? name : _abilityId;
+        public string DisplayName => string.IsNullOrWhiteSpace(_displayName) ? name : _displayName;
+        public string Description => _description;
+        public Sprite Icon => _icon;
+        public int MaxLevel => _levels != null && _levels.Length > 0 ? _levels.Length : 1;
+
+        /// <summary>
+        /// 지정 레벨(1-based)의 수치를 반환한다. 범위를 벗어나면 최소 / 최대 레벨로 클램프한다.
+        /// 레벨 테이블이 비어 있으면 기본값(모든 필드 0)을 반환한다.
+        /// </summary>
+        public GangshinAbilityLevel GetLevel(int level)
+        {
+            if (_levels == null || _levels.Length == 0)
+            {
+                return default;
+            }
+
+            int index = Mathf.Clamp(level - 1, 0, _levels.Length - 1);
+            return _levels[index];
+        }
+
+        public bool IsValid(out string reason)
+        {
+            if (_levels == null || _levels.Length == 0)
+            {
+                reason = "Level table is empty.";
+                return false;
+            }
+
+            reason = null;
+            return true;
+        }
+
+        internal void ConfigureForTests(params GangshinAbilityLevel[] levels)
+        {
+            _levels = levels;
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/GangshinAbilityData.cs.meta
+++ b/project1/Assets/Scripts/Combat/GangshinAbilityData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: deac3e316b9c4fac842e750a8b239c1a

--- a/project1/Assets/Scripts/Combat/GangshinAbilityEffects.cs
+++ b/project1/Assets/Scripts/Combat/GangshinAbilityEffects.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 강신 발동 효과의 공용 순수 로직(#30). 데미지 적용과 기절 부여를 담당한다.
+    /// MonoBehaviour에 의존하지 않아 EditMode 테스트에서 임의의 적 목록으로 검증할 수 있다.
+    /// </summary>
+    public static class GangshinAbilityEffects
+    {
+        /// <summary>
+        /// 화면 전체(목록 내 살아있고 타격 가능한 모든 적)에 데미지를 적용한다(살풀이 검무).
+        /// stunDuration &gt; 0이면 데미지 후 생존한 적에게 기절도 부여한다. 피해를 입힌 적 수를 반환한다.
+        /// </summary>
+        public static int ApplyToAll(
+            IReadOnlyList<EnemyHealth> enemies,
+            float damage,
+            float stunDuration,
+            object source)
+        {
+            if (enemies == null || damage <= 0f || enemies.Count == 0)
+            {
+                return 0;
+            }
+
+            // ApplyDamage로 적이 사망하면 ActiveEnemies에서 즉시 제거되어 순회 중 컬렉션이 변경될 수 있다.
+            // 스냅샷을 떠서 순회한다(RadialDamage와 동일한 방어).
+            var targets = new List<EnemyHealth>(enemies);
+            int hitCount = 0;
+
+            for (int i = 0; i < targets.Count; i++)
+            {
+                if (TryHit(targets[i], damage, stunDuration, source))
+                {
+                    hitCount++;
+                }
+            }
+
+            return hitCount;
+        }
+
+        /// <summary>
+        /// 원점 기준 반경(outerRadius, 경계 포함) 내이면서 아직 맞지 않은(alreadyHit 미포함) 적에게
+        /// 데미지·기절을 적용한다(파천의 징 파동). 파동이 확장하며 매 스텝 호출되어, 파면이 지나간 적을
+        /// 한 번씩만 타격하도록 alreadyHit 집합으로 중복을 방지한다. 이번 스텝에 새로 맞은 적 수를 반환한다.
+        /// </summary>
+        public static int ApplyExpandingRing(
+            Vector2 origin,
+            float outerRadius,
+            float damage,
+            float stunDuration,
+            IReadOnlyList<EnemyHealth> enemies,
+            HashSet<EnemyHealth> alreadyHit,
+            object source)
+        {
+            if (enemies == null || alreadyHit == null || outerRadius <= 0f || damage <= 0f || enemies.Count == 0)
+            {
+                return 0;
+            }
+
+            var targets = new List<EnemyHealth>(enemies);
+            float sqrRadius = outerRadius * outerRadius;
+            int hitCount = 0;
+
+            for (int i = 0; i < targets.Count; i++)
+            {
+                EnemyHealth enemy = targets[i];
+                if (enemy == null || alreadyHit.Contains(enemy))
+                {
+                    continue;
+                }
+
+                // 파면(원점~outerRadius) 밖의 적은 아직 파동이 도달하지 않았다.
+                if (((Vector2)enemy.transform.position - origin).sqrMagnitude > sqrRadius)
+                {
+                    continue;
+                }
+
+                if (TryHit(enemy, damage, stunDuration, source))
+                {
+                    // 실제로 타격한 적만 중복 방지 집합에 등록한다(사망/무적 적은 다음 스텝에 재평가돼도 무해).
+                    alreadyHit.Add(enemy);
+                    hitCount++;
+                }
+            }
+
+            return hitCount;
+        }
+
+        private static bool TryHit(EnemyHealth enemy, float damage, float stunDuration, object source)
+        {
+            if (enemy == null || !enemy.IsAlive || !enemy.IsTargetable)
+            {
+                return false;
+            }
+
+            enemy.ApplyDamage(damage, source);
+
+            // 데미지로 사망했으면 기절은 의미 없다. 생존 + 이동 AI 보유 시에만 기절을 부여한다.
+            if (stunDuration > 0f && enemy.IsAlive && enemy.Mover != null)
+            {
+                enemy.Mover.ApplyStun(stunDuration);
+            }
+
+            return true;
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/GangshinAbilityEffects.cs
+++ b/project1/Assets/Scripts/Combat/GangshinAbilityEffects.cs
@@ -25,13 +25,13 @@ namespace Mukseon.Gameplay.Combat
             }
 
             // ApplyDamage로 적이 사망하면 ActiveEnemies에서 즉시 제거되어 순회 중 컬렉션이 변경될 수 있다.
-            // 스냅샷을 떠서 순회한다(RadialDamage와 동일한 방어).
-            var targets = new List<EnemyHealth>(enemies);
+            // 역순으로 순회하면 사망한 적(현재 인덱스)이 제거돼도 앞쪽 인덱스가 밀리지 않아,
+            // 리스트 복사(GC 할당) 없이 안전하다. 화면 전체 타격은 순서가 무관하다.
             int hitCount = 0;
 
-            for (int i = 0; i < targets.Count; i++)
+            for (int i = enemies.Count - 1; i >= 0; i--)
             {
-                if (TryHit(targets[i], damage, stunDuration, source))
+                if (TryHit(enemies[i], damage, stunDuration, source))
                 {
                     hitCount++;
                 }
@@ -59,13 +59,14 @@ namespace Mukseon.Gameplay.Combat
                 return 0;
             }
 
-            var targets = new List<EnemyHealth>(enemies);
+            // 파동은 확장하는 동안 매 프레임 호출된다. 리스트 복사 대신 역순 순회로 GC 할당을 제거한다
+            // (사망한 적은 현재 인덱스에서 제거되므로 앞쪽 인덱스가 밀리지 않아 안전하다).
             float sqrRadius = outerRadius * outerRadius;
             int hitCount = 0;
 
-            for (int i = 0; i < targets.Count; i++)
+            for (int i = enemies.Count - 1; i >= 0; i--)
             {
-                EnemyHealth enemy = targets[i];
+                EnemyHealth enemy = enemies[i];
                 if (enemy == null || alreadyHit.Contains(enemy))
                 {
                     continue;

--- a/project1/Assets/Scripts/Combat/GangshinAbilityEffects.cs.meta
+++ b/project1/Assets/Scripts/Combat/GangshinAbilityEffects.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e78157a4f001404f87600332b3945cc5

--- a/project1/Assets/Scripts/Combat/GangshinAbilityLevel.cs
+++ b/project1/Assets/Scripts/Combat/GangshinAbilityLevel.cs
@@ -1,0 +1,43 @@
+using System;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 강신 스킬의 레벨별 발동 수치(gangshin_balance_mvp.md).
+    /// 살풀이 검무 / 파천의 징이 공용으로 사용하며, 사용하지 않는 필드는 0 / false로 둔다.
+    /// </summary>
+    [Serializable]
+    public struct GangshinAbilityLevel
+    {
+        [SerializeField, Min(0f), Tooltip("발동 데미지")]
+        private float _damage;
+
+        [SerializeField, Range(0f, 100f), Tooltip("발동에 필요한 게이지 비율(%). 예: 100 또는 90.")]
+        private float _requiredGaugePercent;
+
+        [SerializeField, Min(0f), Tooltip("적 기절 지속시간(초). 0이면 기절 없음.")]
+        private float _stunDuration;
+
+        [SerializeField, Tooltip("파동을 2회 연속 발사한다(파천의 징 Lv3).")]
+        private bool _doubleWave;
+
+        public GangshinAbilityLevel(float damage, float requiredGaugePercent, float stunDuration, bool doubleWave)
+        {
+            _damage = Mathf.Max(0f, damage);
+            _requiredGaugePercent = Mathf.Clamp(requiredGaugePercent, 0f, 100f);
+            _stunDuration = Mathf.Max(0f, stunDuration);
+            _doubleWave = doubleWave;
+        }
+
+        public float Damage => Mathf.Max(0f, _damage);
+        public float RequiredGaugePercent => Mathf.Clamp(_requiredGaugePercent, 0f, 100f);
+
+        /// <summary>발동에 필요한 게이지 정규화 값(0~1). 게이지 임계값 연동(#59)에서 사용.</summary>
+        public float RequiredGaugeNormalized => RequiredGaugePercent / 100f;
+
+        public float StunDuration => Mathf.Max(0f, _stunDuration);
+        public bool StunsEnemies => StunDuration > 0f;
+        public bool DoubleWave => _doubleWave;
+    }
+}

--- a/project1/Assets/Scripts/Combat/GangshinAbilityLevel.cs.meta
+++ b/project1/Assets/Scripts/Combat/GangshinAbilityLevel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 94b1101d05ff49959cc1a1f824658c7c

--- a/project1/Assets/Scripts/Combat/GangshinAbilityMudang.cs
+++ b/project1/Assets/Scripts/Combat/GangshinAbilityMudang.cs
@@ -1,0 +1,60 @@
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 살풀이 검무 [무당 기본 강신, #30]. 하얀 소창이 화면 전체를 휩쓸어 모든 적에게 즉시 데미지를 준다.
+    /// Lv3에서 기절 효과가 추가된다(gangshin_balance_mvp.md).
+    ///
+    /// 이슈 문서상 명칭은 GangshinAbility_Mudang이나, 프로젝트 네이밍 규칙(클래스 PascalCase)에 맞춰
+    /// GangshinAbilityMudang으로 정의한다.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class GangshinAbilityMudang : GangshinAbilityBase
+    {
+        [Header("VFX (선택)")]
+        [SerializeField, Tooltip("발동 시 잠시 표시되는 소창 스윕 연출. 미지정 시 스킵.")]
+        private GameObject _sweepVfx;
+
+        [SerializeField, Min(0f), Tooltip("소창 스윕 연출 표시 시간(초).")]
+        private float _sweepVfxDuration = 0.6f;
+
+        private float _vfxHideTimer;
+
+        public override void Activate(GangshinSlotContext context)
+        {
+            GangshinAbilityLevel level = _data != null ? _data.GetLevel(context.Level) : default;
+
+            // 화면 전체 적에게 데미지( + Lv3 기절)를 즉시 적용한다.
+            GangshinAbilityEffects.ApplyToAll(context.Enemies, level.Damage, level.StunDuration, context.Source);
+
+            PlaySweepVfx();
+        }
+
+        private void PlaySweepVfx()
+        {
+            if (_sweepVfx == null)
+            {
+                return;
+            }
+
+            _sweepVfx.SetActive(true);
+            _vfxHideTimer = Mathf.Max(0f, _sweepVfxDuration);
+        }
+
+        private void Update()
+        {
+            if (_vfxHideTimer <= 0f)
+            {
+                return;
+            }
+
+            // 강신 발동 중 Time.timeScale이 낮아지므로 unscaledDeltaTime으로 연출 길이를 일정하게 유지한다.
+            _vfxHideTimer -= Time.unscaledDeltaTime;
+            if (_vfxHideTimer <= 0f && _sweepVfx != null)
+            {
+                _sweepVfx.SetActive(false);
+            }
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/GangshinAbilityMudang.cs
+++ b/project1/Assets/Scripts/Combat/GangshinAbilityMudang.cs
@@ -38,8 +38,17 @@ namespace Mukseon.Gameplay.Combat
                 return;
             }
 
+            // 지속시간이 0 이하면 타이머 기반 자동 비활성화가 동작하지 않아 VFX가 영구히 남는다.
+            // 이 경우 켜지 않고 즉시 꺼둔다(설정 실수 방어).
+            if (_sweepVfxDuration <= 0f)
+            {
+                _sweepVfx.SetActive(false);
+                _vfxHideTimer = 0f;
+                return;
+            }
+
             _sweepVfx.SetActive(true);
-            _vfxHideTimer = Mathf.Max(0f, _sweepVfxDuration);
+            _vfxHideTimer = _sweepVfxDuration;
         }
 
         private void Update()

--- a/project1/Assets/Scripts/Combat/GangshinAbilityMudang.cs.meta
+++ b/project1/Assets/Scripts/Combat/GangshinAbilityMudang.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 550b157e437d4d1e9495af899ac820ec

--- a/project1/Assets/Scripts/Combat/GangshinController.cs
+++ b/project1/Assets/Scripts/Combat/GangshinController.cs
@@ -34,8 +34,15 @@ namespace Mukseon.Gameplay.Combat
         [SerializeField, Range(0.05f, 1f)]
         private float _activeTimeScale = 0.7f;
 
-        [Header("Effects")]
-        [SerializeField]
+        [Header("Ability")]
+        [SerializeField, Tooltip("발동 시 실행할 강신 필살기(#30). 미지정 시 아래 레거시 펄스로 대체.")]
+        private GangshinAbilityBase _equippedAbility;
+
+        [SerializeField, Min(1), Tooltip("발동 레벨(1-based). 슬롯/강화 카드 시스템(#59, #66) 연동 전까지 임시로 사용.")]
+        private int _abilityLevel = 1;
+
+        [Header("Effects (Legacy Fallback)")]
+        [SerializeField, Tooltip("장착 Ability가 없을 때만 사용하는 레거시 전체 펄스.")]
         private bool _dealActivationPulse = true;
 
         [SerializeField, Min(0f)]
@@ -183,6 +190,22 @@ namespace Mukseon.Gameplay.Combat
                 _playerStatSystem.AddModifier(
                     StatType.AttackPower,
                     new StatModifier(_attackPowerBonusPercent, StatModifierType.Percent, this));
+            }
+
+            ActivateEquippedAbility();
+        }
+
+        /// <summary>
+        /// 장착된 강신 필살기(#30)를 발동한다. 미장착 시 레거시 전체 펄스로 대체한다.
+        /// 대상 적 목록으로 현재 활성 적 전체를 전달한다.
+        /// </summary>
+        private void ActivateEquippedAbility()
+        {
+            if (_equippedAbility != null)
+            {
+                _equippedAbility.Activate(new GangshinSlotContext(
+                    transform.position, _abilityLevel, this, EnemyHealth.ActiveEnemies));
+                return;
             }
 
             if (_dealActivationPulse)

--- a/project1/Assets/Scripts/Combat/GangshinController.cs
+++ b/project1/Assets/Scripts/Combat/GangshinController.cs
@@ -87,6 +87,23 @@ namespace Mukseon.Gameplay.Combat
             NotifyGaugeChanged();
         }
 
+#if UNITY_EDITOR
+        // 인스펙터에서 _abilityLevel을 장착 Ability의 레벨 테이블 범위 밖으로 설정하면 GetLevel이 조용히
+        // 마지막 레벨로 클램프된다(예: Lv3 기대 → Lv1 수치). 실수를 조기에 발견하도록 경고만 남긴다(#59 전 임시 필드).
+        private void OnValidate()
+        {
+            if (_equippedAbility != null && _equippedAbility.Data != null
+                && _abilityLevel > _equippedAbility.Data.MaxLevel)
+            {
+                Debug.LogWarning(
+                    $"[GangshinController] _abilityLevel({_abilityLevel})이 " +
+                    $"{_equippedAbility.Data.name}의 MaxLevel({_equippedAbility.Data.MaxLevel})을 초과합니다. " +
+                    "GetLevel이 최대 레벨로 클램프됩니다.",
+                    this);
+            }
+        }
+#endif
+
         private void OnEnable()
         {
             if (_inputDetector != null)

--- a/project1/Assets/Scripts/Combat/GangshinScreenEffect.cs
+++ b/project1/Assets/Scripts/Combat/GangshinScreenEffect.cs
@@ -1,0 +1,101 @@
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 강신 발동 중 화면 색상 반전 연출(#30). GangshinController의 상태 변화를 구독해
+    /// Active 진입 시 풀스크린 오버레이를 페이드 인, 종료 시 페이드 아웃한다.
+    ///
+    /// 실제 "색상 반전"은 오버레이 그래픽에 색 반전 머티리얼(예: 풀스크린 반전 셰이더 / Blend 설정)을
+    /// 인스펙터에서 지정해 얻는다. 머티리얼 미지정 시 지정한 오버레이 색으로 대체 연출(플래시)한다.
+    /// 스크립트는 표시 여부(알파)만 제어해 뷰 레이어와 로직을 분리한다.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class GangshinScreenEffect : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField, Tooltip("구독할 강신 컨트롤러. 미지정 시 부모에서 탐색.")]
+        private GangshinController _controller;
+
+        [SerializeField, Tooltip("풀스크린 오버레이 CanvasGroup. 미지정 시 이 오브젝트에서 탐색.")]
+        private CanvasGroup _overlay;
+
+        [Header("Fade")]
+        [SerializeField, Range(0f, 1f)]
+        private float _activeAlpha = 1f;
+
+        [SerializeField, Min(0f), Tooltip("발동 진입 시 페이드 인 시간(초).")]
+        private float _fadeInDuration = 0.12f;
+
+        [SerializeField, Min(0f), Tooltip("발동 종료 시 페이드 아웃 시간(초).")]
+        private float _fadeOutDuration = 0.3f;
+
+        private float _targetAlpha;
+        private float _fadeRate;
+
+        private void Awake()
+        {
+            if (_controller == null)
+            {
+                _controller = GetComponentInParent<GangshinController>();
+            }
+
+            if (_overlay == null)
+            {
+                _overlay = GetComponent<CanvasGroup>();
+            }
+
+            if (_overlay != null)
+            {
+                _overlay.alpha = 0f;
+                _overlay.blocksRaycasts = false;
+                _overlay.interactable = false;
+            }
+        }
+
+        private void OnEnable()
+        {
+            if (_controller != null)
+            {
+                _controller.OnStateChanged += HandleStateChanged;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (_controller != null)
+            {
+                _controller.OnStateChanged -= HandleStateChanged;
+            }
+
+            if (_overlay != null)
+            {
+                _overlay.alpha = 0f;
+            }
+
+            _targetAlpha = 0f;
+        }
+
+        private void HandleStateChanged(GangshinState state)
+        {
+            bool active = state == GangshinState.Active;
+            _targetAlpha = active ? Mathf.Clamp01(_activeAlpha) : 0f;
+
+            float duration = active ? _fadeInDuration : _fadeOutDuration;
+            float span = Mathf.Clamp01(_activeAlpha);
+            // duration이 0이면 즉시 목표 알파로 전환한다.
+            _fadeRate = duration > 0f ? span / duration : float.MaxValue;
+        }
+
+        private void Update()
+        {
+            if (_overlay == null || Mathf.Approximately(_overlay.alpha, _targetAlpha))
+            {
+                return;
+            }
+
+            // 발동 중 Time.timeScale이 낮아지므로 unscaledDeltaTime으로 연출 속도를 일정하게 유지한다.
+            _overlay.alpha = Mathf.MoveTowards(_overlay.alpha, _targetAlpha, _fadeRate * Time.unscaledDeltaTime);
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/GangshinScreenEffect.cs.meta
+++ b/project1/Assets/Scripts/Combat/GangshinScreenEffect.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: acc09a153cdb4a8fb1b962ef85694f95

--- a/project1/Assets/Scripts/Combat/GangshinSlotContext.cs
+++ b/project1/Assets/Scripts/Combat/GangshinSlotContext.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 강신 발동 시 Ability에 전달되는 컨텍스트(#30). 슬롯 시스템(#59)이 장착 슬롯 정보를 채워 전달한다.
+    /// 효과 대상 적 목록(Enemies)을 명시적으로 받아, EditMode 테스트에서 임의의 목록을 주입할 수 있게 한다.
+    /// </summary>
+    public readonly struct GangshinSlotContext
+    {
+        /// <summary>발동 원점(플레이어 위치). 파동 / 범위 계산의 중심.</summary>
+        public readonly Vector2 Origin;
+
+        /// <summary>발동 레벨(1-based). 강화 카드(#66)로 상승.</summary>
+        public readonly int Level;
+
+        /// <summary>데미지 출처(귀속 처리용).</summary>
+        public readonly object Source;
+
+        /// <summary>효과 대상 적 목록. 보통 <see cref="EnemyHealth.ActiveEnemies"/>.</summary>
+        public readonly IReadOnlyList<EnemyHealth> Enemies;
+
+        public GangshinSlotContext(Vector2 origin, int level, object source, IReadOnlyList<EnemyHealth> enemies)
+        {
+            Origin = origin;
+            Level = Mathf.Max(1, level);
+            Source = source;
+            Enemies = enemies;
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/GangshinSlotContext.cs.meta
+++ b/project1/Assets/Scripts/Combat/GangshinSlotContext.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4f3e1fb0f30c4006aced1bf0aef28e52

--- a/project1/Assets/Tests/EditMode/EnemyMoverTests.cs
+++ b/project1/Assets/Tests/EditMode/EnemyMoverTests.cs
@@ -135,5 +135,51 @@ namespace Mukseon.Tests.EditMode
             _mover.SetMovePattern(EnemyMovePattern.TrackPlayer);
             Assert.That(_mover.MovePattern, Is.EqualTo(EnemyMovePattern.TrackPlayer));
         }
+
+        [Test]
+        public void Stun_StopsMovement_ThenResumesAfterDuration()
+        {
+            var playerGo = new GameObject("Player");
+
+            try
+            {
+                playerGo.transform.position = new Vector3(10f, 0f, 0f);
+                _enemyGo.transform.position = Vector3.zero;
+                _enemyHealth.SetMoveSpeed(5f);
+                _mover.SetMovePattern(EnemyMovePattern.TrackPlayer);
+                _mover.SetPlayerTarget(playerGo.transform);
+
+                _mover.ApplyStun(0.25f);
+                Assert.That(_mover.IsStunned, Is.True);
+
+                // 기절 중에는 이동하지 않는다.
+                _mover.Tick(DeltaTime); // 0.10s 소비
+                _mover.Tick(DeltaTime); // 0.20s 소비
+                Assert.That(_enemyGo.transform.position, Is.EqualTo(Vector3.zero));
+
+                // 기절이 끝나면 이동을 재개한다.
+                _mover.Tick(DeltaTime); // 0.30s → 기절 해제
+                Assert.That(_mover.IsStunned, Is.False);
+                _mover.Tick(DeltaTime);
+                Assert.That(_enemyGo.transform.position.x, Is.GreaterThan(0f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(playerGo);
+            }
+        }
+
+        [Test]
+        public void ApplyStun_KeepsLongerRemainingDuration()
+        {
+            _mover.ApplyStun(1.0f);
+            _mover.Tick(0.3f); // 남은 0.7s
+
+            // 더 짧은 기절을 부여해도 남은 시간이 줄어들지 않는다.
+            _mover.ApplyStun(0.2f);
+            _mover.Tick(0.5f); // 남은 0.2s → 아직 기절 중
+
+            Assert.That(_mover.IsStunned, Is.True);
+        }
     }
 }

--- a/project1/Assets/Tests/EditMode/GangshinAbilityTests.cs
+++ b/project1/Assets/Tests/EditMode/GangshinAbilityTests.cs
@@ -1,0 +1,269 @@
+using System.Collections.Generic;
+using Mukseon.Core.Input;
+using Mukseon.Gameplay.Combat;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Mukseon.Tests.EditMode
+{
+    /// <summary>강신 필살기 효과(#30) — 데이터/순수 로직/Ability 동작 검증.</summary>
+    public class GangshinAbilityTests
+    {
+        private GameObject _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new GameObject("Root");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_root != null)
+            {
+                Object.DestroyImmediate(_root);
+            }
+        }
+
+        // ----- GangshinAbilityData -----
+
+        [Test]
+        public void GetLevel_ClampsToTableRange()
+        {
+            GangshinAbilityData data = ScriptableObject.CreateInstance<GangshinAbilityData>();
+            try
+            {
+                data.ConfigureForTests(
+                    new GangshinAbilityLevel(500f, 100f, 0f, false),
+                    new GangshinAbilityLevel(700f, 100f, 0f, false),
+                    new GangshinAbilityLevel(1000f, 90f, 1.5f, true));
+
+                Assert.That(data.MaxLevel, Is.EqualTo(3));
+                Assert.That(data.GetLevel(1).Damage, Is.EqualTo(500f));
+                Assert.That(data.GetLevel(3).Damage, Is.EqualTo(1000f));
+                Assert.That(data.GetLevel(3).RequiredGaugeNormalized, Is.EqualTo(0.9f).Within(1e-4f));
+
+                // 범위 밖은 최소/최대로 클램프.
+                Assert.That(data.GetLevel(0).Damage, Is.EqualTo(500f));
+                Assert.That(data.GetLevel(99).Damage, Is.EqualTo(1000f));
+                Assert.That(data.GetLevel(99).DoubleWave, Is.True);
+            }
+            finally
+            {
+                Object.DestroyImmediate(data);
+            }
+        }
+
+        // ----- GangshinAbilityEffects.ApplyToAll -----
+
+        [Test]
+        public void ApplyToAll_DamagesEveryAliveTargetableEnemy_RegardlessOfDistance()
+        {
+            EnemyHealth near = CreateEnemy("Near", new Vector3(0.5f, 0f, 0f), 1000f);
+            EnemyHealth far = CreateEnemy("Far", new Vector3(50f, 0f, 0f), 1000f);
+
+            var enemies = new List<EnemyHealth> { near, far };
+            int hit = GangshinAbilityEffects.ApplyToAll(enemies, 500f, 0f, this);
+
+            Assert.That(hit, Is.EqualTo(2));
+            Assert.That(near.CurrentHealth, Is.EqualTo(500f).Within(1e-4f));
+            Assert.That(far.CurrentHealth, Is.EqualTo(500f).Within(1e-4f)); // 거리 무관 — 화면 전체
+        }
+
+        [Test]
+        public void ApplyToAll_SkipsDeadAndUntargetableEnemies()
+        {
+            EnemyHealth dead = CreateEnemy("Dead", Vector3.zero, 100f);
+            dead.ApplyDamage(100f, this);
+            EnemyHealth untargetable = CreateEnemy("Untargetable", Vector3.zero, 100f);
+            untargetable.IsTargetable = false;
+
+            var enemies = new List<EnemyHealth> { dead, untargetable };
+            int hit = GangshinAbilityEffects.ApplyToAll(enemies, 500f, 0f, this);
+
+            Assert.That(hit, Is.EqualTo(0));
+            Assert.That(untargetable.CurrentHealth, Is.EqualTo(100f).Within(1e-4f));
+        }
+
+        [Test]
+        public void ApplyToAll_AppliesStun_ToSurvivingEnemiesWithMover()
+        {
+            EnemyHealth survivor = CreateEnemy("Survivor", Vector3.zero, 1000f);
+            EnemyMover mover = survivor.gameObject.AddComponent<EnemyMover>();
+
+            GangshinAbilityEffects.ApplyToAll(new List<EnemyHealth> { survivor }, 100f, 2f, this);
+
+            Assert.That(mover.IsStunned, Is.True);
+        }
+
+        // ----- GangshinAbilityEffects.ApplyExpandingRing -----
+
+        [Test]
+        public void ApplyExpandingRing_HitsOnlyEnemiesWithinRadius_AndNotAlreadyHit()
+        {
+            EnemyHealth inside = CreateEnemy("Inside", new Vector3(2f, 0f, 0f), 1000f);
+            EnemyHealth outside = CreateEnemy("Outside", new Vector3(8f, 0f, 0f), 1000f);
+            var enemies = new List<EnemyHealth> { inside, outside };
+            var alreadyHit = new HashSet<EnemyHealth>();
+
+            // 반경 3: inside만 파면 안.
+            int firstStep = GangshinAbilityEffects.ApplyExpandingRing(
+                Vector2.zero, 3f, 300f, 0f, enemies, alreadyHit, this);
+            Assert.That(firstStep, Is.EqualTo(1));
+            Assert.That(inside.CurrentHealth, Is.EqualTo(700f).Within(1e-4f));
+            Assert.That(outside.CurrentHealth, Is.EqualTo(1000f).Within(1e-4f));
+
+            // 반경 10: outside 새로 진입, inside는 이미 맞았으므로 중복 타격 없음.
+            int secondStep = GangshinAbilityEffects.ApplyExpandingRing(
+                Vector2.zero, 10f, 300f, 0f, enemies, alreadyHit, this);
+            Assert.That(secondStep, Is.EqualTo(1));
+            Assert.That(inside.CurrentHealth, Is.EqualTo(700f).Within(1e-4f)); // 변화 없음
+            Assert.That(outside.CurrentHealth, Is.EqualTo(700f).Within(1e-4f));
+        }
+
+        // ----- GangshinAbilityMudang (살풀이 검무) -----
+
+        [Test]
+        public void Mudang_Activate_DamagesAllEnemies()
+        {
+            var go = new GameObject("Mudang");
+            go.transform.SetParent(_root.transform);
+            var ability = go.AddComponent<GangshinAbilityMudang>();
+            GangshinAbilityData data = ScriptableObject.CreateInstance<GangshinAbilityData>();
+
+            try
+            {
+                data.ConfigureForTests(new GangshinAbilityLevel(500f, 100f, 0f, false));
+                ability.SetDataForTests(data);
+
+                EnemyHealth a = CreateEnemy("A", Vector3.zero, 1000f);
+                EnemyHealth b = CreateEnemy("B", new Vector3(30f, 0f, 0f), 1000f);
+                var enemies = new List<EnemyHealth> { a, b };
+
+                ability.Activate(new GangshinSlotContext(Vector2.zero, 1, this, enemies));
+
+                Assert.That(a.CurrentHealth, Is.EqualTo(500f).Within(1e-4f));
+                Assert.That(b.CurrentHealth, Is.EqualTo(500f).Within(1e-4f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(data);
+            }
+        }
+
+        [Test]
+        public void Mudang_Activate_Level3_StunsSurvivingEnemies()
+        {
+            var go = new GameObject("Mudang");
+            go.transform.SetParent(_root.transform);
+            var ability = go.AddComponent<GangshinAbilityMudang>();
+            GangshinAbilityData data = ScriptableObject.CreateInstance<GangshinAbilityData>();
+
+            try
+            {
+                data.ConfigureForTests(
+                    new GangshinAbilityLevel(500f, 100f, 0f, false),
+                    new GangshinAbilityLevel(700f, 100f, 0f, false),
+                    new GangshinAbilityLevel(1000f, 90f, 1.5f, false)); // Lv3 기절
+                ability.SetDataForTests(data);
+
+                EnemyHealth enemy = CreateEnemy("Tank", Vector3.zero, 5000f);
+                EnemyMover mover = enemy.gameObject.AddComponent<EnemyMover>();
+
+                ability.Activate(new GangshinSlotContext(Vector2.zero, 3, this, new List<EnemyHealth> { enemy }));
+
+                Assert.That(enemy.CurrentHealth, Is.EqualTo(4000f).Within(1e-4f));
+                Assert.That(mover.IsStunned, Is.True);
+            }
+            finally
+            {
+                Object.DestroyImmediate(data);
+            }
+        }
+
+        // ----- GangshinAbilityBaksoo (파천의 징) -----
+
+        [Test]
+        public void Baksoo_Activate_WaveExpands_AndDamagesEnemy()
+        {
+            var go = new GameObject("Baksoo");
+            go.transform.SetParent(_root.transform);
+            var ability = go.AddComponent<GangshinAbilityBaksoo>();
+            GangshinAbilityData data = ScriptableObject.CreateInstance<GangshinAbilityData>();
+
+            try
+            {
+                data.ConfigureForTests(new GangshinAbilityLevel(300f, 100f, 1.5f, false));
+                ability.SetDataForTests(data);
+
+                EnemyHealth enemy = CreateEnemy("E", new Vector3(1f, 0f, 0f), 1000f);
+                EnemyMover mover = enemy.gameObject.AddComponent<EnemyMover>();
+
+                ability.Activate(new GangshinSlotContext(Vector2.zero, 1, this, new List<EnemyHealth> { enemy }));
+                Assert.That(ability.IsWaveActive, Is.True);
+
+                // 파동이 최대 반경(기본 12)까지 확장되도록 충분히 Tick.
+                for (int i = 0; i < 20; i++)
+                {
+                    ability.Tick(0.05f);
+                }
+
+                Assert.That(enemy.CurrentHealth, Is.EqualTo(700f).Within(1e-4f));
+                Assert.That(mover.IsStunned, Is.True);
+                Assert.That(ability.IsWaveActive, Is.False);
+            }
+            finally
+            {
+                Object.DestroyImmediate(data);
+            }
+        }
+
+        [Test]
+        public void Baksoo_Level3_DoubleWave_HitsEnemyTwice()
+        {
+            var go = new GameObject("Baksoo");
+            go.transform.SetParent(_root.transform);
+            var ability = go.AddComponent<GangshinAbilityBaksoo>();
+            GangshinAbilityData data = ScriptableObject.CreateInstance<GangshinAbilityData>();
+
+            try
+            {
+                data.ConfigureForTests(new GangshinAbilityLevel(600f, 90f, 2.5f, true)); // DoubleWave
+                ability.SetDataForTests(data);
+
+                EnemyHealth enemy = CreateEnemy("E", new Vector3(1f, 0f, 0f), 5000f);
+
+                ability.Activate(new GangshinSlotContext(Vector2.zero, 1, this, new List<EnemyHealth> { enemy }));
+
+                // 넉넉히 Tick하여 1파 + 딜레이 + 2파를 모두 소화.
+                for (int i = 0; i < 60; i++)
+                {
+                    ability.Tick(0.05f);
+                }
+
+                // 파동 2회 적중 → 600 * 2 = 1200 피해.
+                Assert.That(enemy.CurrentHealth, Is.EqualTo(3800f).Within(1e-4f));
+                Assert.That(ability.IsWaveActive, Is.False);
+                Assert.That(ability.WavesRemaining, Is.EqualTo(0));
+            }
+            finally
+            {
+                Object.DestroyImmediate(data);
+            }
+        }
+
+        private EnemyHealth CreateEnemy(string name, Vector3 position, float maxHealth)
+        {
+            var go = new GameObject(name);
+            go.transform.SetParent(_root.transform);
+            go.transform.position = position;
+
+            var eh = go.AddComponent<EnemyHealth>();
+            eh.SetSwipeDirection(SwipeDirection.Up);
+            eh.SetMaxHealth(maxHealth);
+            eh.ResetHealth();
+            return eh;
+        }
+    }
+}

--- a/project1/Assets/Tests/EditMode/GangshinAbilityTests.cs.meta
+++ b/project1/Assets/Tests/EditMode/GangshinAbilityTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a62f6978620544f99883a38bba36d9de


### PR DESCRIPTION
## 개요
Closes #30

무당/박수의 기본 강신 필살기(살풀이 검무 / 파천의 징)의 **효과 로직과 연출**을 구현합니다.
`gangshin_balance_mvp.md`의 레벨별 수치를 따르며, 슬롯 시스템(#59)·강화 카드(#66) 연동은 후속 이슈 소관입니다.

## 구현 내용

### 강신 스킬 추상 구조
- `GangshinAbilityBase` — 추상 MonoBehaviour, `Activate(GangshinSlotContext)` 인터페이스
- `GangshinAbilityData`(SO) + `GangshinAbilityLevel` — 레벨별 수치 테이블(데미지·필요게이지%·기절시간·이중파동)
- `GangshinSlotContext` — 발동 원점/레벨/출처/대상 적목록 전달 (슬롯 시스템 #59 연동 대비)

### 효과 로직 (순수 C#)
- `GangshinAbilityEffects` — MonoBehaviour 비의존, EditMode 단위 테스트 가능
  - `ApplyToAll`: 화면 전체 적 즉시 데미지(+기절)
  - `ApplyExpandingRing`: 확장 파동 — 파면이 지나간 적을 중복 방지 집합으로 1회씩 타격

### 개별 강신
- **살풀이 검무**(`GangshinAbilityMudang`): 화면 전체 즉시 타격, Lv3 기절 추가
- **파천의 징**(`GangshinAbilityBaksoo`): 중앙→바깥 확장 파동 + 기절, Lv3 이중 파동(딜레이 후 2발 — 기절 중인 적에 2번째 적중)

### 시스템 연동
- `EnemyMover` — 기절 처리 `ApplyStun(duration)`/`IsStunned` (이동 정지, 풀 재사용 시 리셋)
- `GangshinController` — 하드코딩 펄스 → **장착 Ability 위임**(미장착 시 레거시 펄스 폴백)
- `GangshinScreenEffect` — 발동 중 색상 반전 오버레이 페이드(상태 이벤트 구독)
- 발동 중 무적: 기존 `GangshinInvincibilityLink` 재사용 / 게이지 0 초기화: 기존 런타임

## DoD
- [x] 무당/박수 레벨별 데미지 화면 전체 적용
- [x] 파동 확장 + 레벨별 기절 지속시간
- [x] Lv3 살풀이 검무 기절 추가
- [x] Lv3 파천의 징 이중 파동
- [x] 발동 중 색상 반전 연출(컴포넌트)
- [x] 발동 중 무적

## 테스트
EditMode **전체 166개 통과(실패 0)** — 신규 강신 효과/데이터/Ability/기절 테스트 포함.

## 리뷰어 참고
- **클래스명**: 이슈 표기 `GangshinAbility_Mudang/_Baksoo` → CLAUDE.md PascalCase 규칙에 맞춰 `GangshinAbilityMudang/Baksoo`로 정의(주석에 매핑 명시).
- **Lv3 90% 게이지 발동 임계값**: 데이터에는 저장하되 실제 발동 임계값 연동은 게이지/카드 시스템(#59, #66) 소관이라 이번엔 미연동.
- **VFX/색상반전 최종 아트**: 로직·훅·파동 링 스케일링은 코드로 완성. 소창 이펙트·반전 셰이더 머티리얼 등 인스펙터 아트 연결은 에디터 작업으로 남김.
- `SampleScene.unity` 2줄 변경: `GangshinController` 새 필드 기본값 자동 직렬화.

## 관련 이슈
- 선행/관련: #59(4슬롯 시스템), #60(더블 탭 입력, 완료)
- SFX: #38(오디오 시스템) — `OnActivated` 이벤트로 연동 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)