### PR TITLE
feat: 세이브/로드 순수 저장 레이어 (SaveData / SaveService / JSON 직렬화) (#33)

### DIFF
--- a/docs/06_ArchitectureAndData.md
+++ b/docs/06_ArchitectureAndData.md
@@ -20,12 +20,20 @@
 
 ## 6.3 세이브 및 로드 (Save & Load)
 신당(로비)에서의 영구 성장 요소 저장을 위한 구조입니다.
-- **저장 방식**: 빠르고 쉬운 구현을 위해 `JSON` 직렬화 후 `Application.persistentDataPath`에 저장합니다.
+- **저장 방식**: 빠르고 쉬운 구현을 위해 `JSON` 직렬화(`JsonUtility`) 후 `Application.persistentDataPath`에 저장합니다.
+  - `JsonUtility`는 `Dictionary`를 직렬화하지 못하므로, `UpgradeLevels`는 직렬화 가능한 키-값 리스트 래퍼(`SerializableStringIntMap`)로 저장합니다.
+  - 저장은 임시 파일에 먼저 기록한 뒤 교체(원자적 쓰기)하여 쓰기 중단 시 손상을 방지합니다.
+- **네이밍**: 메타 재화 '영혼'은 인런 EXP '혼불'(코드 토큰 `Soul*`)과 충돌하므로 `Spirit` 토큰으로 분리합니다.
 - **저장 데이터 모델 (`SaveData.cs`)**:
+  - `SaveDataVersion` (마이그레이션 대비 스키마 버전)
   - `TotalGold` (누적 금화)
-  - `TotalSouls` (누적 영혼)
-  - `UpgradeLevels` (Dictionary 형태, 예: `{"MaxHP": 3, "MagnetRadius": 1}`)
+  - `TotalSpirit` (누적 영혼)
+  - `UpgradeLevels` (`SerializableStringIntMap`, 예: `{"MaxHP": 3, "MagnetRadius": 1}`)
   - `UnlockedCharacters` (무당 기본 활성화, 박수 구매 여부 등)
+  - `UnlockedSkills` (영혼으로 해금된 신규 스킬 ID 목록, 기본 11종 제외)
+  - `TutorialCompleted` (튜토리얼 완료 플래그, #39)
+- **구성 요소**: `SaveData`(모델) / `ISaveStorage`·`JsonSaveStorage`(파일 IO) / `SaveMigration`(버전 승격·정규화) / `SaveService`(로드·저장·`OnChanged`).
+- **범위(#33)**: 순수 저장 레이어까지만 담당하며, 실제 저장 트리거(신당 구매·결과 적립·해금·튜토리얼)는 각 소유 이슈(#34/#36/#61/#39)가 연결합니다.
  
 ## 6.4 적 AI 아키텍처 (Enemy AI Architecture)
 

--- a/project1/Assets/Scripts/Persistence.meta
+++ b/project1/Assets/Scripts/Persistence.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c4c774be8f2771b4cb0ea2e9a560d98a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/project1/Assets/Scripts/Persistence/ISaveStorage.cs
+++ b/project1/Assets/Scripts/Persistence/ISaveStorage.cs
@@ -12,8 +12,8 @@ namespace Mukseon.Core.Persistence
         /// <summary>저장 데이터를 읽어 반환한다. 파일이 없거나 읽을 수 없으면 null을 반환한다.</summary>
         SaveData Load();
 
-        /// <summary>저장 데이터를 영속화한다(원자적 쓰기).</summary>
-        void Save(SaveData data);
+        /// <summary>저장 데이터를 영속화한다(원자적 쓰기). 성공 여부를 반환한다.</summary>
+        bool Save(SaveData data);
 
         /// <summary>저장 파일을 삭제한다(존재하지 않으면 무시).</summary>
         void Delete();

--- a/project1/Assets/Scripts/Persistence/ISaveStorage.cs
+++ b/project1/Assets/Scripts/Persistence/ISaveStorage.cs
@@ -1,0 +1,21 @@
+namespace Mukseon.Core.Persistence
+{
+    /// <summary>
+    /// 세이브 데이터의 영속 저장소 추상화(#33). 파일 IO를 캡슐화하여
+    /// 서비스 계층을 순수하게 유지하고, 테스트에서 대체 구현을 주입할 수 있게 한다.
+    /// </summary>
+    public interface ISaveStorage
+    {
+        /// <summary>저장 파일이 존재하는지 여부.</summary>
+        bool Exists();
+
+        /// <summary>저장 데이터를 읽어 반환한다. 파일이 없거나 읽을 수 없으면 null을 반환한다.</summary>
+        SaveData Load();
+
+        /// <summary>저장 데이터를 영속화한다(원자적 쓰기).</summary>
+        void Save(SaveData data);
+
+        /// <summary>저장 파일을 삭제한다(존재하지 않으면 무시).</summary>
+        void Delete();
+    }
+}

--- a/project1/Assets/Scripts/Persistence/ISaveStorage.cs.meta
+++ b/project1/Assets/Scripts/Persistence/ISaveStorage.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e2aec171c649f8a45afbb9f581e2cf8e

--- a/project1/Assets/Scripts/Persistence/JsonSaveStorage.cs
+++ b/project1/Assets/Scripts/Persistence/JsonSaveStorage.cs
@@ -1,0 +1,96 @@
+using System;
+using System.IO;
+using UnityEngine;
+
+namespace Mukseon.Core.Persistence
+{
+    /// <summary>
+    /// JsonUtility 기반 파일 저장소(#33). 기본적으로 Application.persistentDataPath에 JSON으로 저장한다.
+    /// 저장 시 임시 파일에 먼저 완전히 기록한 뒤 교체(File.Replace/Move)하여,
+    /// 쓰기 도중 중단되더라도 기존 저장 파일이 손상되지 않도록 한다(원자적 쓰기).
+    /// </summary>
+    public class JsonSaveStorage : ISaveStorage
+    {
+        private const string DefaultFileName = "save.json";
+        private const string TempSuffix = ".tmp";
+
+        private readonly string _filePath;
+
+        public JsonSaveStorage()
+            : this(Path.Combine(Application.persistentDataPath, DefaultFileName))
+        {
+        }
+
+        /// <summary>저장 경로를 직접 지정한다(테스트에서 임시 경로 주입용).</summary>
+        public JsonSaveStorage(string filePath)
+        {
+            _filePath = filePath;
+        }
+
+        public string FilePath => _filePath;
+
+        public bool Exists() => File.Exists(_filePath);
+
+        public SaveData Load()
+        {
+            if (!File.Exists(_filePath))
+            {
+                return null;
+            }
+
+            try
+            {
+                string json = File.ReadAllText(_filePath);
+                if (string.IsNullOrWhiteSpace(json))
+                {
+                    return null;
+                }
+
+                return JsonUtility.FromJson<SaveData>(json);
+            }
+            catch (Exception exception)
+            {
+                Debug.LogError($"[JsonSaveStorage] 저장 파일을 읽지 못했습니다: {exception.Message}");
+                return null;
+            }
+        }
+
+        public void Save(SaveData data)
+        {
+            if (data == null)
+            {
+                return;
+            }
+
+            string directory = Path.GetDirectoryName(_filePath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            string json = JsonUtility.ToJson(data, prettyPrint: true);
+            string tempPath = _filePath + TempSuffix;
+
+            // 임시 파일에 먼저 완전히 기록한 뒤 원자적으로 교체한다.
+            File.WriteAllText(tempPath, json);
+
+            if (File.Exists(_filePath))
+            {
+                // File.Replace는 대상이 존재해야 하며, 교체를 원자적으로 수행한다.
+                File.Replace(tempPath, _filePath, null);
+            }
+            else
+            {
+                File.Move(tempPath, _filePath);
+            }
+        }
+
+        public void Delete()
+        {
+            if (File.Exists(_filePath))
+            {
+                File.Delete(_filePath);
+            }
+        }
+    }
+}

--- a/project1/Assets/Scripts/Persistence/JsonSaveStorage.cs
+++ b/project1/Assets/Scripts/Persistence/JsonSaveStorage.cs
@@ -14,33 +14,46 @@ namespace Mukseon.Core.Persistence
         private const string DefaultFileName = "save.json";
         private const string TempSuffix = ".tmp";
 
-        private readonly string _filePath;
+        // Application.persistentDataPath는 메인 스레드에서만 접근 가능하므로, 생성자에서 즉시 참조하지 않고
+        // 실제 IO가 일어나는 시점(FilePath 접근)까지 경로 결정을 지연한다(DI/백그라운드 스레드/정적 초기화 안전).
+        private readonly string _customFilePath;
+        private string _resolvedFilePath;
 
         public JsonSaveStorage()
-            : this(Path.Combine(Application.persistentDataPath, DefaultFileName))
         {
         }
 
         /// <summary>저장 경로를 직접 지정한다(테스트에서 임시 경로 주입용).</summary>
         public JsonSaveStorage(string filePath)
         {
-            _filePath = filePath;
+            _customFilePath = filePath;
         }
 
-        public string FilePath => _filePath;
+        public string FilePath
+        {
+            get
+            {
+                if (_resolvedFilePath == null)
+                {
+                    _resolvedFilePath = _customFilePath ?? Path.Combine(Application.persistentDataPath, DefaultFileName);
+                }
 
-        public bool Exists() => File.Exists(_filePath);
+                return _resolvedFilePath;
+            }
+        }
+
+        public bool Exists() => File.Exists(FilePath);
 
         public SaveData Load()
         {
-            if (!File.Exists(_filePath))
+            if (!File.Exists(FilePath))
             {
                 return null;
             }
 
             try
             {
-                string json = File.ReadAllText(_filePath);
+                string json = File.ReadAllText(FilePath);
                 if (string.IsNullOrWhiteSpace(json))
                 {
                     return null;
@@ -55,41 +68,67 @@ namespace Mukseon.Core.Persistence
             }
         }
 
-        public void Save(SaveData data)
+        public bool Save(SaveData data)
         {
             if (data == null)
             {
-                return;
+                return false;
             }
 
-            string directory = Path.GetDirectoryName(_filePath);
-            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            string tempPath = FilePath + TempSuffix;
+            try
             {
-                Directory.CreateDirectory(directory);
+                string directory = Path.GetDirectoryName(FilePath);
+                if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                string json = JsonUtility.ToJson(data, prettyPrint: true);
+
+                // 임시 파일에 먼저 완전히 기록한 뒤 원자적으로 교체한다.
+                File.WriteAllText(tempPath, json);
+
+                if (File.Exists(FilePath))
+                {
+                    // File.Replace는 대상이 존재해야 하며, 교체를 원자적으로 수행한다.
+                    File.Replace(tempPath, FilePath, null);
+                }
+                else
+                {
+                    File.Move(tempPath, FilePath);
+                }
+
+                return true;
             }
-
-            string json = JsonUtility.ToJson(data, prettyPrint: true);
-            string tempPath = _filePath + TempSuffix;
-
-            // 임시 파일에 먼저 완전히 기록한 뒤 원자적으로 교체한다.
-            File.WriteAllText(tempPath, json);
-
-            if (File.Exists(_filePath))
+            catch (Exception exception)
             {
-                // File.Replace는 대상이 존재해야 하며, 교체를 원자적으로 수행한다.
-                File.Replace(tempPath, _filePath, null);
-            }
-            else
-            {
-                File.Move(tempPath, _filePath);
+                // Load()와 대칭적으로 IO 실패를 방어한다. 저장 트리거가 게임플레이 핸들러 한복판에서
+                // 호출되더라도(#34/#36/#61/#39) 저장 실패가 예외로 전파되지 않도록 한다.
+                Debug.LogError($"[JsonSaveStorage] 저장 파일을 저장하지 못했습니다: {exception.Message}");
+
+                // 실패 시 남은 임시 파일을 정리한다(2차 예외는 무시).
+                if (File.Exists(tempPath))
+                {
+                    try
+                    {
+                        File.Delete(tempPath);
+                    }
+                    catch
+                    {
+                        // 정리 실패는 무시한다.
+                    }
+                }
+
+                return false;
             }
         }
 
         public void Delete()
         {
-            if (File.Exists(_filePath))
+            if (File.Exists(FilePath))
             {
-                File.Delete(_filePath);
+                File.Delete(FilePath);
             }
         }
     }

--- a/project1/Assets/Scripts/Persistence/JsonSaveStorage.cs.meta
+++ b/project1/Assets/Scripts/Persistence/JsonSaveStorage.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c7a68abf72fe30049b8b120e70c4460c

--- a/project1/Assets/Scripts/Persistence/SaveData.cs
+++ b/project1/Assets/Scripts/Persistence/SaveData.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+
+namespace Mukseon.Core.Persistence
+{
+    /// <summary>
+    /// 메타 진행 영구 저장 데이터 모델(#33). JsonUtility로 직렬화되므로 필드는 public이며,
+    /// 필드명이 곧 JSON 키가 된다 — 기존 필드명을 바꾸면 세이브 호환이 깨진다.
+    /// 실제 저장 트리거(신당 구매/적립/해금/튜토리얼)는 각 소유 이슈(#34/#36/#61/#39)가 담당한다.
+    /// </summary>
+    [Serializable]
+    public class SaveData
+    {
+        /// <summary>현재 세이브 스키마 버전. 필드 추가/구조 변경 시 올리고 SaveMigration에 단계를 추가한다.</summary>
+        public const int CurrentVersion = 1;
+
+        /// <summary>게임 시작부터 기본 해금되는 캐릭터(무당). CharacterData 에셋의 CharacterId와 일치해야 한다.</summary>
+        public const string DefaultUnlockedCharacterId = "character.mudang";
+
+        public int SaveDataVersion = CurrentVersion;
+
+        /// <summary>누적 골드(영구 성장 재화).</summary>
+        public long TotalGold;
+
+        /// <summary>누적 영혼(콘텐츠 해금 재화). 인런 EXP '혼불'(Soul*)과 구분되는 'Spirit'.</summary>
+        public long TotalSpirit;
+
+        /// <summary>신당 업그레이드 ID → 레벨. 키는 ShrineUpgradeData(#34)가 정의한다.</summary>
+        public SerializableStringIntMap UpgradeLevels = new SerializableStringIntMap();
+
+        /// <summary>해금된 캐릭터 ID 목록. 기본값에 무당 포함.</summary>
+        public List<string> UnlockedCharacters = new List<string>();
+
+        /// <summary>영혼으로 해금한 신규 스킬 ID 목록(기본 11종 제외).</summary>
+        public List<string> UnlockedSkills = new List<string>();
+
+        /// <summary>튜토리얼 완료 여부(#39가 기록).</summary>
+        public bool TutorialCompleted;
+
+        /// <summary>신규 저장 파일의 초기 상태를 만든다(무당 기본 해금).</summary>
+        public static SaveData CreateDefault()
+        {
+            return new SaveData
+            {
+                SaveDataVersion = CurrentVersion,
+                TotalGold = 0,
+                TotalSpirit = 0,
+                UpgradeLevels = new SerializableStringIntMap(),
+                UnlockedCharacters = new List<string> { DefaultUnlockedCharacterId },
+                UnlockedSkills = new List<string>(),
+                TutorialCompleted = false,
+            };
+        }
+    }
+}

--- a/project1/Assets/Scripts/Persistence/SaveData.cs.meta
+++ b/project1/Assets/Scripts/Persistence/SaveData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b37dc6a7b70caae4cb58b7425d64b2f3

--- a/project1/Assets/Scripts/Persistence/SaveMigration.cs
+++ b/project1/Assets/Scripts/Persistence/SaveMigration.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+
+namespace Mukseon.Core.Persistence
+{
+    /// <summary>
+    /// 로드된 세이브 데이터를 현재 스키마 버전으로 승격/정규화한다(#33).
+    /// 구버전 필드 보강, null 컬렉션 방어, 기본 해금 캐릭터 보장을 담당한다.
+    /// 향후 필드 구조가 바뀌면 버전별 단계 마이그레이션을 이곳에 추가한다.
+    /// </summary>
+    public static class SaveMigration
+    {
+        public static SaveData Migrate(SaveData data)
+        {
+            if (data == null)
+            {
+                return SaveData.CreateDefault();
+            }
+
+            // JsonUtility 역직렬화나 구버전 파일에서 누락될 수 있는 컬렉션을 방어적으로 초기화한다.
+            if (data.UpgradeLevels == null)
+            {
+                data.UpgradeLevels = new SerializableStringIntMap();
+            }
+            if (data.UnlockedCharacters == null)
+            {
+                data.UnlockedCharacters = new List<string>();
+            }
+            if (data.UnlockedSkills == null)
+            {
+                data.UnlockedSkills = new List<string>();
+            }
+
+            // 버전별 단계 마이그레이션 지점. 현재는 v1이 최신이라 버전 승격만 수행한다.
+            if (data.SaveDataVersion < SaveData.CurrentVersion)
+            {
+                // 예: if (data.SaveDataVersion < 2) { /* v1 → v2 필드 변환 */ }
+                data.SaveDataVersion = SaveData.CurrentVersion;
+            }
+
+            // 무당은 항상 기본 해금 상태를 보장한다.
+            if (!data.UnlockedCharacters.Contains(SaveData.DefaultUnlockedCharacterId))
+            {
+                data.UnlockedCharacters.Add(SaveData.DefaultUnlockedCharacterId);
+            }
+
+            return data;
+        }
+    }
+}

--- a/project1/Assets/Scripts/Persistence/SaveMigration.cs.meta
+++ b/project1/Assets/Scripts/Persistence/SaveMigration.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ffc6f3eb01cfa95439bed7d5b4d5df02

--- a/project1/Assets/Scripts/Persistence/SaveService.cs
+++ b/project1/Assets/Scripts/Persistence/SaveService.cs
@@ -34,16 +34,22 @@ namespace Mukseon.Core.Persistence
             return Current;
         }
 
-        /// <summary>Current를 저장소에 영속화하고 OnChanged를 발행한다.</summary>
-        public void Save()
+        /// <summary>Current를 저장소에 영속화한다. 저장에 성공한 경우에만 OnChanged를 발행하고, 성공 여부를 반환한다.</summary>
+        public bool Save()
         {
             if (Current == null)
             {
                 Current = SaveData.CreateDefault();
             }
 
-            _storage.Save(Current);
-            OnChanged?.Invoke(Current);
+            // 저장 실패 시 OnChanged를 발행하지 않아, UI/구독자가 저장 성공으로 오인하지 않게 한다.
+            bool success = _storage.Save(Current);
+            if (success)
+            {
+                OnChanged?.Invoke(Current);
+            }
+
+            return success;
         }
     }
 }

--- a/project1/Assets/Scripts/Persistence/SaveService.cs
+++ b/project1/Assets/Scripts/Persistence/SaveService.cs
@@ -1,0 +1,49 @@
+using System;
+
+namespace Mukseon.Core.Persistence
+{
+    /// <summary>
+    /// 세이브 데이터의 로드/저장 및 현재 인스턴스 보관을 담당하는 서비스(#33).
+    /// 순수 C# 클래스로, 저장소(ISaveStorage)를 주입받아 테스트 가능하게 한다.
+    /// 실제 데이터 변경(재화 적립/해금/업그레이드)은 각 소유 이슈의 시스템이 Current를 수정한 뒤 Save()를 호출한다.
+    /// </summary>
+    public class SaveService
+    {
+        private readonly ISaveStorage _storage;
+
+        /// <summary>현재 메모리에 로드된 세이브 데이터. Load() 호출 전에는 null일 수 있다.</summary>
+        public SaveData Current { get; private set; }
+
+        /// <summary>Current가 (재)로드되거나 저장될 때 발행된다. UI 갱신 구독용.</summary>
+        public event Action<SaveData> OnChanged;
+
+        public SaveService(ISaveStorage storage)
+        {
+            _storage = storage ?? new JsonSaveStorage();
+        }
+
+        /// <summary>
+        /// 저장소에서 데이터를 로드한다. 파일이 없으면 기본값을,
+        /// 있으면 마이그레이션된 데이터를 Current로 설정한다.
+        /// </summary>
+        public SaveData Load()
+        {
+            SaveData loaded = _storage.Load();
+            Current = loaded == null ? SaveData.CreateDefault() : SaveMigration.Migrate(loaded);
+            OnChanged?.Invoke(Current);
+            return Current;
+        }
+
+        /// <summary>Current를 저장소에 영속화하고 OnChanged를 발행한다.</summary>
+        public void Save()
+        {
+            if (Current == null)
+            {
+                Current = SaveData.CreateDefault();
+            }
+
+            _storage.Save(Current);
+            OnChanged?.Invoke(Current);
+        }
+    }
+}

--- a/project1/Assets/Scripts/Persistence/SaveService.cs.meta
+++ b/project1/Assets/Scripts/Persistence/SaveService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8527380254a0fde439a29a7372371d40

--- a/project1/Assets/Scripts/Persistence/SerializableStringIntMap.cs
+++ b/project1/Assets/Scripts/Persistence/SerializableStringIntMap.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Mukseon.Core.Persistence
+{
+    /// <summary>
+    /// JsonUtility는 Dictionary를 직렬화하지 못하므로, 문자열 키 → 정수 값 매핑을
+    /// 직렬화 가능한 엔트리 리스트로 감싼다(#33). 신당 업그레이드 레벨 등 키-값 저장에 사용한다.
+    /// </summary>
+    [Serializable]
+    public class SerializableStringIntMap
+    {
+        [Serializable]
+        private struct Entry
+        {
+            public string Key;
+            public int Value;
+        }
+
+        [SerializeField]
+        private List<Entry> _entries = new List<Entry>();
+
+        public int Count => _entries != null ? _entries.Count : 0;
+
+        public bool ContainsKey(string key) => IndexOf(key) >= 0;
+
+        public bool TryGetValue(string key, out int value)
+        {
+            int index = IndexOf(key);
+            if (index < 0)
+            {
+                value = 0;
+                return false;
+            }
+
+            value = _entries[index].Value;
+            return true;
+        }
+
+        public int GetValueOrDefault(string key, int fallback = 0)
+            => TryGetValue(key, out int value) ? value : fallback;
+
+        /// <summary>키가 있으면 값을 갱신하고, 없으면 새 엔트리를 추가한다.</summary>
+        public void Set(string key, int value)
+        {
+            if (string.IsNullOrEmpty(key))
+            {
+                return;
+            }
+
+            EnsureList();
+            int index = IndexOf(key);
+            if (index >= 0)
+            {
+                // 구조체는 값 복사이므로 수정 후 다시 대입한다.
+                Entry entry = _entries[index];
+                entry.Value = value;
+                _entries[index] = entry;
+            }
+            else
+            {
+                _entries.Add(new Entry { Key = key, Value = value });
+            }
+        }
+
+        public bool Remove(string key)
+        {
+            int index = IndexOf(key);
+            if (index < 0)
+            {
+                return false;
+            }
+
+            _entries.RemoveAt(index);
+            return true;
+        }
+
+        public void Clear() => _entries?.Clear();
+
+        public IEnumerable<string> Keys
+        {
+            get
+            {
+                if (_entries == null)
+                {
+                    yield break;
+                }
+
+                for (int i = 0; i < _entries.Count; i++)
+                {
+                    yield return _entries[i].Key;
+                }
+            }
+        }
+
+        private void EnsureList()
+        {
+            if (_entries == null)
+            {
+                _entries = new List<Entry>();
+            }
+        }
+
+        private int IndexOf(string key)
+        {
+            if (_entries == null || string.IsNullOrEmpty(key))
+            {
+                return -1;
+            }
+
+            for (int i = 0; i < _entries.Count; i++)
+            {
+                if (_entries[i].Key == key)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+    }
+}

--- a/project1/Assets/Scripts/Persistence/SerializableStringIntMap.cs.meta
+++ b/project1/Assets/Scripts/Persistence/SerializableStringIntMap.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cb391e8256f651a449e0c384dbf23c88

--- a/project1/Assets/Tests/EditMode/SaveSystemTests.cs
+++ b/project1/Assets/Tests/EditMode/SaveSystemTests.cs
@@ -166,11 +166,18 @@ namespace Mukseon.Tests.EditMode
 
             SaveData second = SaveData.CreateDefault();
             second.TotalGold = 999;
-            _storage.Save(second); // 기존 파일 위에 다시 저장 → File.Replace 경로
+            bool saved = _storage.Save(second); // 기존 파일 위에 다시 저장 → File.Replace 경로
 
             SaveData loaded = _storage.Load();
+            Assert.That(saved, Is.True);
             Assert.That(loaded.TotalGold, Is.EqualTo(999));
             Assert.That(File.Exists(_tempPath + ".tmp"), Is.False, "임시 파일이 남아있으면 안 된다.");
+        }
+
+        [Test]
+        public void Storage_Save_ReturnsFalse_ForNullData()
+        {
+            Assert.That(_storage.Save(null), Is.False);
         }
 
         // ---- 서비스 저장/로드 통합 + OnChanged ----
@@ -186,14 +193,45 @@ namespace Mukseon.Tests.EditMode
 
             service.Current.TotalSpirit = 7;
             service.Current.UnlockedSkills.Add("skill.unlocked");
-            service.Save();
+            bool saved = service.Save();
 
             var reloaded = new SaveService(_storage);
             reloaded.Load();
 
-            Assert.That(changedCount, Is.EqualTo(1), "Save() 시 OnChanged가 1회 발행돼야 한다.");
+            Assert.That(saved, Is.True);
+            Assert.That(changedCount, Is.EqualTo(1), "Save() 성공 시 OnChanged가 1회 발행돼야 한다.");
             Assert.That(reloaded.Current.TotalSpirit, Is.EqualTo(7));
             Assert.That(reloaded.Current.UnlockedSkills, Does.Contain("skill.unlocked"));
+        }
+
+        [Test]
+        public void Service_Save_DoesNotRaiseOnChanged_WhenStorageFails()
+        {
+            var failing = new FailingStorage();
+            var service = new SaveService(failing);
+            service.Load();
+
+            int changedCount = 0;
+            service.OnChanged += _ => changedCount++;
+
+            bool saved = service.Save();
+
+            Assert.That(saved, Is.False, "저장소가 실패하면 Save()는 false를 반환해야 한다.");
+            Assert.That(changedCount, Is.EqualTo(0), "저장 실패 시 OnChanged가 발행되면 안 된다.");
+        }
+
+        /// <summary>저장이 항상 실패하는 테스트용 저장소.</summary>
+        private sealed class FailingStorage : ISaveStorage
+        {
+            public bool Exists() => false;
+
+            public SaveData Load() => null;
+
+            public bool Save(SaveData data) => false;
+
+            public void Delete()
+            {
+            }
         }
     }
 }

--- a/project1/Assets/Tests/EditMode/SaveSystemTests.cs
+++ b/project1/Assets/Tests/EditMode/SaveSystemTests.cs
@@ -1,0 +1,199 @@
+using System.Collections.Generic;
+using System.IO;
+using Mukseon.Core.Persistence;
+using NUnit.Framework;
+
+namespace Mukseon.Tests.EditMode
+{
+    public class SaveSystemTests
+    {
+        private string _tempPath;
+        private JsonSaveStorage _storage;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // 각 테스트마다 고유한 임시 파일을 사용해 상호 간섭과 실제 세이브 오염을 막는다.
+            _tempPath = Path.Combine(Path.GetTempPath(), $"mukseon_save_test_{System.Guid.NewGuid():N}.json");
+            _storage = new JsonSaveStorage(_tempPath);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (File.Exists(_tempPath))
+            {
+                File.Delete(_tempPath);
+            }
+
+            string temp = _tempPath + ".tmp";
+            if (File.Exists(temp))
+            {
+                File.Delete(temp);
+            }
+        }
+
+        // ---- SaveData 기본값 ----
+
+        [Test]
+        public void CreateDefault_UnlocksMudang_AndSetsCurrentVersion()
+        {
+            SaveData data = SaveData.CreateDefault();
+
+            Assert.That(data.SaveDataVersion, Is.EqualTo(SaveData.CurrentVersion));
+            Assert.That(data.TotalGold, Is.EqualTo(0));
+            Assert.That(data.TotalSpirit, Is.EqualTo(0));
+            Assert.That(data.UnlockedCharacters, Does.Contain(SaveData.DefaultUnlockedCharacterId));
+            Assert.That(data.UnlockedSkills, Is.Empty);
+            Assert.That(data.UpgradeLevels.Count, Is.EqualTo(0));
+            Assert.That(data.TutorialCompleted, Is.False);
+        }
+
+        // ---- 라운드트립: 모든 필드 보존 ----
+
+        [Test]
+        public void RoundTrip_PreservesAllFields()
+        {
+            SaveData original = new SaveData
+            {
+                SaveDataVersion = SaveData.CurrentVersion,
+                TotalGold = 123456789,
+                TotalSpirit = 42,
+                UnlockedCharacters = new List<string> { "character.mudang", "character.baksu" },
+                UnlockedSkills = new List<string> { "skill.new_a", "skill.new_b" },
+                TutorialCompleted = true,
+            };
+            original.UpgradeLevels.Set("MaxHP", 3);
+            original.UpgradeLevels.Set("MagnetRadius", 1);
+
+            _storage.Save(original);
+            SaveData loaded = _storage.Load();
+
+            Assert.That(loaded, Is.Not.Null);
+            Assert.That(loaded.SaveDataVersion, Is.EqualTo(original.SaveDataVersion));
+            Assert.That(loaded.TotalGold, Is.EqualTo(123456789));
+            Assert.That(loaded.TotalSpirit, Is.EqualTo(42));
+            Assert.That(loaded.UnlockedCharacters, Is.EquivalentTo(original.UnlockedCharacters));
+            Assert.That(loaded.UnlockedSkills, Is.EquivalentTo(original.UnlockedSkills));
+            Assert.That(loaded.TutorialCompleted, Is.True);
+            Assert.That(loaded.UpgradeLevels.GetValueOrDefault("MaxHP"), Is.EqualTo(3));
+            Assert.That(loaded.UpgradeLevels.GetValueOrDefault("MagnetRadius"), Is.EqualTo(1));
+        }
+
+        // ---- Dictionary(맵) 직렬화 왕복 ----
+
+        [Test]
+        public void UpgradeLevels_SerializationRoundTrip_PreservesEntries()
+        {
+            var map = new SerializableStringIntMap();
+            map.Set("a", 10);
+            map.Set("b", 20);
+            map.Set("a", 15); // 덮어쓰기 확인
+
+            SaveData data = SaveData.CreateDefault();
+            data.UpgradeLevels = map;
+
+            _storage.Save(data);
+            SaveData loaded = _storage.Load();
+
+            Assert.That(loaded.UpgradeLevels.Count, Is.EqualTo(2));
+            Assert.That(loaded.UpgradeLevels.GetValueOrDefault("a"), Is.EqualTo(15));
+            Assert.That(loaded.UpgradeLevels.GetValueOrDefault("b"), Is.EqualTo(20));
+            Assert.That(loaded.UpgradeLevels.ContainsKey("missing"), Is.False);
+        }
+
+        // ---- 파일 부재 시 동작 ----
+
+        [Test]
+        public void Storage_Load_ReturnsNull_WhenFileMissing()
+        {
+            Assert.That(_storage.Exists(), Is.False);
+            Assert.That(_storage.Load(), Is.Null);
+        }
+
+        [Test]
+        public void Service_Load_ReturnsDefault_WhenFileMissing()
+        {
+            var service = new SaveService(_storage);
+
+            SaveData data = service.Load();
+
+            Assert.That(data, Is.Not.Null);
+            Assert.That(data.SaveDataVersion, Is.EqualTo(SaveData.CurrentVersion));
+            Assert.That(data.UnlockedCharacters, Does.Contain(SaveData.DefaultUnlockedCharacterId));
+            Assert.That(service.Current, Is.SameAs(data));
+        }
+
+        // ---- 마이그레이션 ----
+
+        [Test]
+        public void Migrate_UpgradesOldVersion_AndNormalizesNulls()
+        {
+            SaveData legacy = new SaveData
+            {
+                SaveDataVersion = 0,
+                UpgradeLevels = null,
+                UnlockedCharacters = null,
+                UnlockedSkills = null,
+            };
+
+            SaveData migrated = SaveMigration.Migrate(legacy);
+
+            Assert.That(migrated.SaveDataVersion, Is.EqualTo(SaveData.CurrentVersion));
+            Assert.That(migrated.UpgradeLevels, Is.Not.Null);
+            Assert.That(migrated.UnlockedCharacters, Is.Not.Null);
+            Assert.That(migrated.UnlockedSkills, Is.Not.Null);
+            Assert.That(migrated.UnlockedCharacters, Does.Contain(SaveData.DefaultUnlockedCharacterId));
+        }
+
+        [Test]
+        public void Migrate_Null_ReturnsDefault()
+        {
+            SaveData migrated = SaveMigration.Migrate(null);
+
+            Assert.That(migrated, Is.Not.Null);
+            Assert.That(migrated.SaveDataVersion, Is.EqualTo(SaveData.CurrentVersion));
+        }
+
+        // ---- 저장 안정성: 원자적 교체 / 임시 파일 잔존 없음 ----
+
+        [Test]
+        public void Save_OverwritesExistingFile_AndLeavesNoTempFile()
+        {
+            SaveData first = SaveData.CreateDefault();
+            first.TotalGold = 100;
+            _storage.Save(first);
+
+            SaveData second = SaveData.CreateDefault();
+            second.TotalGold = 999;
+            _storage.Save(second); // 기존 파일 위에 다시 저장 → File.Replace 경로
+
+            SaveData loaded = _storage.Load();
+            Assert.That(loaded.TotalGold, Is.EqualTo(999));
+            Assert.That(File.Exists(_tempPath + ".tmp"), Is.False, "임시 파일이 남아있으면 안 된다.");
+        }
+
+        // ---- 서비스 저장/로드 통합 + OnChanged ----
+
+        [Test]
+        public void Service_SaveThenReload_PersistsChanges_AndRaisesOnChanged()
+        {
+            var service = new SaveService(_storage);
+            service.Load();
+
+            int changedCount = 0;
+            service.OnChanged += _ => changedCount++;
+
+            service.Current.TotalSpirit = 7;
+            service.Current.UnlockedSkills.Add("skill.unlocked");
+            service.Save();
+
+            var reloaded = new SaveService(_storage);
+            reloaded.Load();
+
+            Assert.That(changedCount, Is.EqualTo(1), "Save() 시 OnChanged가 1회 발행돼야 한다.");
+            Assert.That(reloaded.Current.TotalSpirit, Is.EqualTo(7));
+            Assert.That(reloaded.Current.UnlockedSkills, Does.Contain("skill.unlocked"));
+        }
+    }
+}

--- a/project1/Assets/Tests/EditMode/SaveSystemTests.cs.meta
+++ b/project1/Assets/Tests/EditMode/SaveSystemTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1a1c20510868d4e4d91cdce4520d123b


### PR DESCRIPTION
## 개요

메타 진행(골드/영혼, 신당 업그레이드, 해금, 튜토리얼) 영구 저장을 위한 **순수 저장 레이어**를 구현합니다. Closes #33.

> 착수 전 검토로 이슈를 재정의했습니다: 본 PR은 저장 레이어(모델 + 직렬화 + 서비스)까지만 담당하고, 실제 저장 **트리거 배선**은 각 소유 이슈(#34/#36/#61/#39)로 이관했습니다. 덕분에 아직 없는 시스템에 의존하지 않고 단독으로 검증됩니다.

## 변경 내용

`Assets/Scripts/Persistence/` (`Mukseon.Core.Persistence`)

| 파일 | 역할 |
|---|---|
| `SaveData.cs` | 직렬화 POCO + `CreateDefault()` (무당 기본 해금, 스키마 version=1) |
| `SerializableStringIntMap.cs` | `JsonUtility`가 `Dictionary`를 직렬화하지 못하는 문제 우회 래퍼 |
| `ISaveStorage.cs` / `JsonSaveStorage.cs` | 파일 IO. `persistentDataPath`, **원자적 쓰기**(tmp → `File.Replace`/`Move`) |
| `SaveMigration.cs` | 버전 승격 · null 컬렉션 방어 · 무당 기본 해금 보장 |
| `SaveService.cs` | `Current` 보관, `Load()`/`Save()`, `OnChanged` 이벤트 |
| `Tests/EditMode/SaveSystemTests.cs` | EditMode 테스트 9종 |
| `docs/06_ArchitectureAndData.md` | §6.3 저장 모델을 실제 필드로 갱신 |

## 데이터 모델

`SaveDataVersion` / `TotalGold` / `TotalSpirit` / `UpgradeLevels`(맵) / `UnlockedCharacters` / `UnlockedSkills` / `TutorialCompleted`

### 네이밍 규약
메타 재화 **영혼**은 인런 EXP **혼불**(기존 코드 토큰 `Soul*`)과 충돌하므로 **`Spirit`** 토큰으로 분리했습니다(`TotalSpirit`).

## 검증

Unity 런타임에서 직접 실행하여 확인 (컴파일 에러 0):
- ✅ 라운드트립: 모든 필드 보존
- ✅ `UpgradeLevels` 맵 직렬화 왕복(덮어쓰기 포함) — `JsonUtility` 우회 래퍼 정상 동작
- ✅ 원자적 쓰기 후 `.tmp` 잔존 없음 / 파일 부재 시 기본값 / 구버전→v1 마이그레이션

> EditMode 테스트 9종 작성 완료(컴파일 확인). Test Runner 실행은 리뷰어 환경에서 함께 확인 부탁드립니다.

## 범위 밖 (후속 이슈)

신당 구매 저장 → #34 · 결과화면 적립 → #36/#61 · 캐릭터·스킬 해금 → #61 · 튜토리얼 플래그 → #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)
