### PR TITLE
fix: 적 접촉 데미지 미연결 해소 — 매초 지속 접촉 데미지 + 게임오버 배선 (#103)

### DIFF
--- a/project1/Assets/Prefabs/Enemies/Boss_Dureoksini.prefab
+++ b/project1/Assets/Prefabs/Enemies/Boss_Dureoksini.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 110446678007002424}
   - component: {fileID: 6676783505557286248}
   - component: {fileID: 8970587817756802101}
+  - component: {fileID: 6384410719192656890}
   m_Layer: 0
   m_Name: Boss_Dureoksini
   m_TagString: Untagged
@@ -193,6 +194,7 @@ MonoBehaviour:
   _movePattern: 0
   _playerTarget: {fileID: 0}
   _riseHeight: 10
+  _keepDistance: 5
 --- !u!114 &6676783505557286248
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -222,3 +224,21 @@ MonoBehaviour:
   _spriteRenderer: {fileID: 5588491822506949314}
   _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
   _glowColorProperty: _GlowColor
+  _imminentBlinkSpeed: 9
+  _imminentBlinkAmount: 0.7
+  _convertFlashDuration: 0.25
+--- !u!114 &6384410719192656890
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5516339678559892061}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c05d2c5a591c5d646907c7fd1e1f8d0c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyContactDamage
+  _contactRadius: 0.6
+  _tickInterval: 1
+  _damagePerTick: 10

--- a/project1/Assets/Prefabs/Enemies/Dummy_Down.prefab
+++ b/project1/Assets/Prefabs/Enemies/Dummy_Down.prefab
@@ -17,6 +17,7 @@ GameObject:
   - component: {fileID: 902457377154407016}
   - component: {fileID: 2164090938067278628}
   - component: {fileID: 1050207443342037178}
+  - component: {fileID: 2447229560178975562}
   m_Layer: 0
   m_Name: Dummy_Down
   m_TagString: Untagged
@@ -194,6 +195,7 @@ MonoBehaviour:
   _movePattern: 0
   _playerTarget: {fileID: 0}
   _riseHeight: 10
+  _keepDistance: 5
 --- !u!114 &902457377154407016
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -223,6 +225,9 @@ MonoBehaviour:
   _spriteRenderer: {fileID: 5073888473262603188}
   _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
   _glowColorProperty: _GlowColor
+  _imminentBlinkSpeed: 9
+  _imminentBlinkAmount: 0.7
+  _convertFlashDuration: 0.25
 --- !u!114 &1050207443342037178
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -237,3 +242,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionConverter
   _enemyHealth: {fileID: 4234627494100266546}
   _config: {fileID: 11400000, guid: f1a9553ab329986408b9f0c2d2067df3, type: 2}
+--- !u!114 &2447229560178975562
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6892844264584007441}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c05d2c5a591c5d646907c7fd1e1f8d0c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyContactDamage
+  _contactRadius: 0.6
+  _tickInterval: 1
+  _damagePerTick: 10

--- a/project1/Assets/Prefabs/Enemies/Dummy_Left.prefab
+++ b/project1/Assets/Prefabs/Enemies/Dummy_Left.prefab
@@ -17,6 +17,7 @@ GameObject:
   - component: {fileID: 2776196048433973373}
   - component: {fileID: 7387759474708353289}
   - component: {fileID: 4611500699197383874}
+  - component: {fileID: 3617912292246258249}
   m_Layer: 0
   m_Name: Dummy_Left
   m_TagString: Untagged
@@ -194,6 +195,7 @@ MonoBehaviour:
   _movePattern: 0
   _playerTarget: {fileID: 0}
   _riseHeight: 10
+  _keepDistance: 5
 --- !u!114 &2776196048433973373
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -223,6 +225,9 @@ MonoBehaviour:
   _spriteRenderer: {fileID: 2472191227068787534}
   _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
   _glowColorProperty: _GlowColor
+  _imminentBlinkSpeed: 9
+  _imminentBlinkAmount: 0.7
+  _convertFlashDuration: 0.25
 --- !u!114 &4611500699197383874
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -237,3 +242,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionConverter
   _enemyHealth: {fileID: 4368540737326870438}
   _config: {fileID: 11400000, guid: f1a9553ab329986408b9f0c2d2067df3, type: 2}
+--- !u!114 &3617912292246258249
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6848363840087502861}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c05d2c5a591c5d646907c7fd1e1f8d0c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyContactDamage
+  _contactRadius: 0.6
+  _tickInterval: 1
+  _damagePerTick: 10

--- a/project1/Assets/Prefabs/Enemies/Dummy_Right.prefab
+++ b/project1/Assets/Prefabs/Enemies/Dummy_Right.prefab
@@ -17,6 +17,7 @@ GameObject:
   - component: {fileID: 8797208339621773822}
   - component: {fileID: 3917159128010735540}
   - component: {fileID: 2685217770002757526}
+  - component: {fileID: 4187899176103390245}
   m_Layer: 0
   m_Name: Dummy_Right
   m_TagString: Untagged
@@ -194,6 +195,7 @@ MonoBehaviour:
   _movePattern: 0
   _playerTarget: {fileID: 0}
   _riseHeight: 10
+  _keepDistance: 5
 --- !u!114 &8797208339621773822
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -223,6 +225,9 @@ MonoBehaviour:
   _spriteRenderer: {fileID: 5588491822506949314}
   _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
   _glowColorProperty: _GlowColor
+  _imminentBlinkSpeed: 9
+  _imminentBlinkAmount: 0.7
+  _convertFlashDuration: 0.25
 --- !u!114 &2685217770002757526
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -237,3 +242,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionConverter
   _enemyHealth: {fileID: 1475677598667535634}
   _config: {fileID: 11400000, guid: f1a9553ab329986408b9f0c2d2067df3, type: 2}
+--- !u!114 &4187899176103390245
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5516339678559892061}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c05d2c5a591c5d646907c7fd1e1f8d0c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyContactDamage
+  _contactRadius: 0.6
+  _tickInterval: 1
+  _damagePerTick: 10

--- a/project1/Assets/Prefabs/Enemies/Dummy_Up.prefab
+++ b/project1/Assets/Prefabs/Enemies/Dummy_Up.prefab
@@ -17,6 +17,7 @@ GameObject:
   - component: {fileID: 8489735811375365995}
   - component: {fileID: 2372149767770650528}
   - component: {fileID: 7355930812239250675}
+  - component: {fileID: 3993136036044180358}
   m_Layer: 0
   m_Name: Dummy_Up
   m_TagString: Untagged
@@ -194,6 +195,7 @@ MonoBehaviour:
   _movePattern: 0
   _playerTarget: {fileID: 0}
   _riseHeight: 10
+  _keepDistance: 5
 --- !u!114 &8489735811375365995
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -223,6 +225,9 @@ MonoBehaviour:
   _spriteRenderer: {fileID: 5162172495293148243}
   _palette: {fileID: 11400000, guid: da07367ae5ae2a340ac99c70977e6437, type: 2}
   _glowColorProperty: _GlowColor
+  _imminentBlinkSpeed: 9
+  _imminentBlinkAmount: 0.7
+  _convertFlashDuration: 0.25
 --- !u!114 &7355930812239250675
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -237,3 +242,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyDirectionConverter
   _enemyHealth: {fileID: 3535088139439741544}
   _config: {fileID: 11400000, guid: f1a9553ab329986408b9f0c2d2067df3, type: 2}
+--- !u!114 &3993136036044180358
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7248748341038818817}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c05d2c5a591c5d646907c7fd1e1f8d0c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyContactDamage
+  _contactRadius: 0.6
+  _tickInterval: 1
+  _damagePerTick: 10

--- a/project1/Assets/Prefabs/Enemies/Minion_CorruptedTiger.prefab
+++ b/project1/Assets/Prefabs/Enemies/Minion_CorruptedTiger.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 6774789542255169904}
   - component: {fileID: 4023560501918882999}
   - component: {fileID: 598596981575195040}
+  - component: {fileID: 7422338194335434088}
   m_Layer: 0
   m_Name: Minion_CorruptedTiger
   m_TagString: Untagged
@@ -194,3 +195,18 @@ MonoBehaviour:
   _imminentBlinkSpeed: 9
   _imminentBlinkAmount: 0.7
   _convertFlashDuration: 0.25
+--- !u!114 &7422338194335434088
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2361037789781864666}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c05d2c5a591c5d646907c7fd1e1f8d0c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.EnemyContactDamage
+  _contactRadius: 0.6
+  _tickInterval: 1
+  _damagePerTick: 10

--- a/project1/Assets/SampleScene.unity
+++ b/project1/Assets/SampleScene.unity
@@ -1651,6 +1651,7 @@ GameObject:
   - component: {fileID: 1453966977}
   - component: {fileID: 1453966979}
   - component: {fileID: 1453966980}
+  - component: {fileID: 1453966981}
   m_Layer: 0
   m_Name: WaveSystem
   m_TagString: Untagged
@@ -1792,6 +1793,22 @@ MonoBehaviour:
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Progression.GuaranteedSkillSelector
   _miniBossSpawner: {fileID: 1453966979}
   _playerLevelSystem: {fileID: 187285035}
+--- !u!114 &1453966981
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1453966975}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b3a2b7b5cb3c3664192a950edb76caf3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.GameOverHandler
+  _playerHealth: {fileID: 187285038}
+  _waveCombatDirector: {fileID: 1453966977}
+  _pauseTimeOnGameOver: 1
+  _showDebugLogs: 0
 --- !u!1 &1477472083
 GameObject:
   m_ObjectHideFlags: 0

--- a/project1/Assets/Scripts/Combat/EnemyContactDamage.cs
+++ b/project1/Assets/Scripts/Combat/EnemyContactDamage.cs
@@ -39,13 +39,16 @@ namespace Mukseon.Gameplay.Combat
 
         private void OnEnable()
         {
-            // 풀 재사용 가드: 이전 생애의 틱 타이머가 남지 않도록 초기화한다.
-            _tickTimer = 0f;
+            ResetForReuse();
+        }
 
-            if (_playerHealth == null)
-            {
-                _playerHealth = FindAnyObjectByType<PlayerHealth>();
-            }
+        /// <summary>
+        /// 풀 재사용 가드: 이전 생애의 틱 타이머가 남지 않도록 초기화한다.
+        /// OnEnable에서 호출되며, EditMode 테스트에서는 SetActive로 OnEnable이 불리지 않으므로 직접 호출한다.
+        /// </summary>
+        internal void ResetForReuse()
+        {
+            _tickTimer = 0f;
         }
 
         private void Update()
@@ -69,13 +72,27 @@ namespace Mukseon.Gameplay.Combat
             // 닿았다 떨어졌다를 반복해도 최대 초당 1틱을 넘지 않게 하기 위함이다.
             _tickTimer = Mathf.Max(0f, _tickTimer - Mathf.Max(0f, deltaTime));
 
-            if (_playerHealth == null || !_playerHealth.IsAlive)
+            // 플레이어 참조는 매 틱 지연 해석한다. 파괴된 참조는 유니티 pseudo-null로 걸러지므로,
+            // 플레이어가 적보다 늦게 생성되거나 재생성되는 경우에도 새 인스턴스를 다시 찾는다.
+            if (_playerHealth == null)
+            {
+                _playerHealth = FindAnyObjectByType<PlayerHealth>();
+                if (_playerHealth == null)
+                {
+                    return;
+                }
+            }
+
+            if (!_playerHealth.IsAlive)
             {
                 return;
             }
 
             // 거리 판정: 플레이어 고정(중앙) 전제이므로 sqrMagnitude 비교면 충분하다.
-            float sqrDistance = (transform.position - _playerHealth.transform.position).sqrMagnitude;
+            // 스프라이트 정렬 등으로 Z 오프셋이 생겨도 판정이 틀어지지 않도록 2D(XY) 거리만 사용한다.
+            Vector2 enemyPosition = transform.position;
+            Vector2 playerPosition = _playerHealth.transform.position;
+            float sqrDistance = (enemyPosition - playerPosition).sqrMagnitude;
             bool inContact = sqrDistance <= _contactRadius * _contactRadius;
 
             if (inContact && _tickTimer <= 0f)

--- a/project1/Assets/Scripts/Combat/EnemyContactDamage.cs
+++ b/project1/Assets/Scripts/Combat/EnemyContactDamage.cs
@@ -2,47 +2,107 @@ using UnityEngine;
 
 namespace Mukseon.Gameplay.Combat
 {
+    /// <summary>
+    /// 기본 접촉 데미지(enemy_design.md): 플레이어와 닿아있는 동안 매초 지속 데미지를 입힌다.
+    /// 물리 콜백 대신 거리 판정을 사용한다 — 플레이어는 화면 중앙에 고정이므로
+    /// 적 자신과 플레이어 사이의 거리만 비교하면 되고, Rigidbody2D 동적 충돌이 필요 없다.
+    /// </summary>
     [DisallowMultipleComponent]
     [RequireComponent(typeof(EnemyHealth))]
     public class EnemyContactDamage : MonoBehaviour
     {
-        [SerializeField, Min(0.1f)]
-        private float _contactDamage = 10f;
+        [Tooltip("이 거리 이내면 '닿아있음'으로 판정한다.")]
+        [SerializeField, Min(0.05f)]
+        private float _contactRadius = 0.6f;
 
-        [SerializeField]
-        private bool _destroyOnContact = true;
+        [Tooltip("접촉 데미지 틱 간격(초). 기획 기준 1초.")]
+        [SerializeField, Min(0.1f)]
+        private float _tickInterval = 1f;
+
+        [Tooltip("틱당 데미지. MonsterData의 초당 접촉 데미지로 덮어써진다. 0이면 데미지를 주지 않는다(기믹 적).")]
+        [SerializeField, Min(0f)]
+        private float _damagePerTick = 10f;
 
         private EnemyHealth _enemyHealth;
+        private PlayerHealth _playerHealth;
+
+        // 다음 틱까지 남은 시간. 0 이하이면 접촉 즉시 데미지가 들어간다(첫 접촉 프레임 포함).
+        private float _tickTimer;
+
+        public float ContactRadius => _contactRadius;
+        public float DamagePerTick => _damagePerTick;
 
         private void Awake()
         {
             _enemyHealth = GetComponent<EnemyHealth>();
         }
 
-        private void OnTriggerEnter2D(Collider2D other)
+        private void OnEnable()
         {
-            if (_enemyHealth != null && !_enemyHealth.IsAlive)
+            // 풀 재사용 가드: 이전 생애의 틱 타이머가 남지 않도록 초기화한다.
+            _tickTimer = 0f;
+
+            if (_playerHealth == null)
+            {
+                _playerHealth = FindAnyObjectByType<PlayerHealth>();
+            }
+        }
+
+        private void Update()
+        {
+            Tick(Time.deltaTime);
+        }
+
+        internal void Tick(float deltaTime)
+        {
+            if (_enemyHealth == null)
+            {
+                _enemyHealth = GetComponent<EnemyHealth>();
+            }
+
+            if (_damagePerTick <= 0f || _enemyHealth == null || !_enemyHealth.IsAlive)
             {
                 return;
             }
 
-            PlayerHealth playerHealth = other.GetComponent<PlayerHealth>();
-            if (playerHealth == null)
-            {
-                playerHealth = other.GetComponentInParent<PlayerHealth>();
-            }
+            // 틱 타이머는 접촉 여부와 무관하게 감소시킨다.
+            // 닿았다 떨어졌다를 반복해도 최대 초당 1틱을 넘지 않게 하기 위함이다.
+            _tickTimer = Mathf.Max(0f, _tickTimer - Mathf.Max(0f, deltaTime));
 
-            if (playerHealth == null || !playerHealth.IsAlive)
+            if (_playerHealth == null || !_playerHealth.IsAlive)
             {
                 return;
             }
 
-            playerHealth.TakeDamage(_contactDamage, _enemyHealth);
+            // 거리 판정: 플레이어 고정(중앙) 전제이므로 sqrMagnitude 비교면 충분하다.
+            float sqrDistance = (transform.position - _playerHealth.transform.position).sqrMagnitude;
+            bool inContact = sqrDistance <= _contactRadius * _contactRadius;
 
-            if (_destroyOnContact && _enemyHealth != null && _enemyHealth.IsAlive)
+            if (inContact && _tickTimer <= 0f)
             {
-                _enemyHealth.Kill(countAsKill: false);
+                _playerHealth.TakeDamage(_damagePerTick, _enemyHealth);
+                _tickTimer = _tickInterval;
             }
+        }
+
+        /// <summary>
+        /// MonsterData의 초당 접촉 데미지를 반영한다. 스폰 시 WaveCombatDirector가 호출한다.
+        /// </summary>
+        public void ApplyMonsterData(MonsterData data)
+        {
+            if (data == null)
+            {
+                return;
+            }
+
+            // 틱 간격이 1초 기준이므로 '초당 데미지 × 간격 = 틱당 데미지'로 환산한다.
+            _damagePerTick = data.ContactDamagePerSecond * _tickInterval;
+        }
+
+        /// <summary>테스트/외부 배선용 플레이어 타겟 주입.</summary>
+        public void SetPlayerTarget(PlayerHealth playerHealth)
+        {
+            _playerHealth = playerHealth;
         }
     }
 }

--- a/project1/Assets/Scripts/Combat/MonsterData.cs
+++ b/project1/Assets/Scripts/Combat/MonsterData.cs
@@ -33,6 +33,11 @@ namespace Mukseon.Gameplay.Combat
         [SerializeField, Min(0f)]
         private float _moveSpeed = 1f;
 
+        // 접촉 데미지는 '닿아있는 동안 매초 지속 데미지' 방식(enemy_design.md).
+        // 0이면 접촉 데미지를 주지 않는 기믹 적(어둑시니/목귀 등)이다.
+        [SerializeField, Min(0f)]
+        private float _contactDamagePerSecond = 10f;
+
         [SerializeField, Min(1)]
         private int _soulDropCount = 1;
 
@@ -47,6 +52,7 @@ namespace Mukseon.Gameplay.Combat
         public bool RandomizeSequence => _randomizeSequence;
         public float MaxHealth => Mathf.Max(1f, _maxHealth);
         public float MoveSpeed => Mathf.Max(0f, _moveSpeed);
+        public float ContactDamagePerSecond => Mathf.Max(0f, _contactDamagePerSecond);
         public int SoulDropCount => Mathf.Max(1, _soulDropCount);
         public int ExperiencePerOrb => Mathf.Max(1, _experiencePerOrb);
 

--- a/project1/Assets/Scripts/Combat/MountainKingMinionSpawner.cs
+++ b/project1/Assets/Scripts/Combat/MountainKingMinionSpawner.cs
@@ -184,6 +184,12 @@ namespace Mukseon.Gameplay.Combat
             {
                 soulDropper.ApplyMonsterData(_minionMonsterData);
             }
+
+            EnemyContactDamage contactDamage = go.GetComponent<EnemyContactDamage>();
+            if (contactDamage != null)
+            {
+                contactDamage.ApplyMonsterData(_minionMonsterData);
+            }
         }
 
         /// <summary>생존 부하로 추적하고 사망 시 전멸 감지를 위해 구독한다. (테스트에서도 사용)</summary>

--- a/project1/Assets/Scripts/Combat/WaveCombatDirector.cs
+++ b/project1/Assets/Scripts/Combat/WaveCombatDirector.cs
@@ -479,6 +479,12 @@ namespace Mukseon.Gameplay.Combat
                 soulDropper.ApplyMonsterData(runtimeEntry.Entry.MonsterData);
             }
 
+            EnemyContactDamage contactDamage = spawnedEnemy.GetComponent<EnemyContactDamage>();
+            if (contactDamage != null)
+            {
+                contactDamage.ApplyMonsterData(runtimeEntry.Entry.MonsterData);
+            }
+
             spawnedEnemy.OnDeath += HandleSpawnedEnemyDeath;
             _aliveEnemies.Add(spawnedEnemy);
             _enemySpeciesKey[spawnedEnemy] = runtimeEntry.SpeciesKey;

--- a/project1/Assets/Settings/Data/Monsters/Monster_AshenClaw.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_AshenClaw.asset
@@ -20,5 +20,6 @@ MonoBehaviour:
   _randomizeSequence: 0
   _maxHealth: 3
   _moveSpeed: 1.2
+  _contactDamagePerSecond: 5
   _soulDropCount: 1
   _experiencePerOrb: 1

--- a/project1/Assets/Settings/Data/Monsters/Monster_BrambleIdol.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_BrambleIdol.asset
@@ -19,5 +19,6 @@ MonoBehaviour:
   _randomizeSequence: 0
   _maxHealth: 5
   _moveSpeed: 0.85
+  _contactDamagePerSecond: 0
   _soulDropCount: 3
   _experiencePerOrb: 2

--- a/project1/Assets/Settings/Data/Monsters/Monster_CorruptedMountainKing.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_CorruptedMountainKing.asset
@@ -20,5 +20,6 @@ MonoBehaviour:
   _randomizeSequence: 0
   _maxHealth: 10
   _moveSpeed: 1
+  _contactDamagePerSecond: 12
   _soulDropCount: 1
   _experiencePerOrb: 1

--- a/project1/Assets/Settings/Data/Monsters/Monster_CorruptedTiger.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_CorruptedTiger.asset
@@ -20,5 +20,6 @@ MonoBehaviour:
   _randomizeSequence: 0
   _maxHealth: 3
   _moveSpeed: 1
+  _contactDamagePerSecond: 5
   _soulDropCount: 1
   _experiencePerOrb: 1

--- a/project1/Assets/Settings/Data/Monsters/Monster_Dureoksini.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_Dureoksini.asset
@@ -20,5 +20,6 @@ MonoBehaviour:
   _randomizeSequence: 0
   _maxHealth: 20
   _moveSpeed: 0.7
+  _contactDamagePerSecond: 15
   _soulDropCount: 8
   _experiencePerOrb: 5

--- a/project1/Assets/Settings/Data/Monsters/Monster_DuskShade.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_DuskShade.asset
@@ -19,5 +19,6 @@ MonoBehaviour:
   _randomizeSequence: 0
   _maxHealth: 4
   _moveSpeed: 1.5
+  _contactDamagePerSecond: 0
   _soulDropCount: 2
   _experiencePerOrb: 1

--- a/project1/Assets/Settings/Data/Monsters/Monster_Mangryang.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_Mangryang.asset
@@ -20,5 +20,6 @@ MonoBehaviour:
   _randomizeSequence: 0
   _maxHealth: 6
   _moveSpeed: 1
+  _contactDamagePerSecond: 8
   _soulDropCount: 2
   _experiencePerOrb: 2

--- a/project1/Assets/Settings/Data/Monsters/Monster_Sangwi.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_Sangwi.asset
@@ -20,5 +20,6 @@ MonoBehaviour:
   _randomizeSequence: 0
   _maxHealth: 7
   _moveSpeed: 0.95
+  _contactDamagePerSecond: 8
   _soulDropCount: 2
   _experiencePerOrb: 2

--- a/project1/Assets/Settings/Data/Monsters/Monster_Sonakssi.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_Sonakssi.asset
@@ -20,5 +20,6 @@ MonoBehaviour:
   _randomizeSequence: 0
   _maxHealth: 2
   _moveSpeed: 1.3
+  _contactDamagePerSecond: 5
   _soulDropCount: 1
   _experiencePerOrb: 1

--- a/project1/Assets/Tests/EditMode/EnemyContactDamageTests.cs
+++ b/project1/Assets/Tests/EditMode/EnemyContactDamageTests.cs
@@ -1,0 +1,165 @@
+using System.Reflection;
+using Mukseon.Gameplay.Combat;
+using Mukseon.Gameplay.Stats;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Mukseon.Tests.EditMode
+{
+    public class EnemyContactDamageTests
+    {
+        private const float ContactRadius = 0.6f;
+        private const float TickInterval = 1f;
+        private const float DamagePerTick = 10f;
+
+        private GameObject _enemyGo;
+        private EnemyHealth _enemyHealth;
+        private EnemyContactDamage _contactDamage;
+
+        private GameObject _playerGo;
+        private PlayerHealth _playerHealth;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _playerGo = new GameObject("Player");
+            _playerGo.AddComponent<PlayerStatSystem>();
+            _playerHealth = _playerGo.AddComponent<PlayerHealth>();
+            SetPrivateField(_playerHealth, "_fallbackMaxHealth", 100f);
+            _playerHealth.ResetHealth();
+
+            _enemyGo = new GameObject("Enemy");
+            _enemyHealth = _enemyGo.AddComponent<EnemyHealth>();
+            _enemyHealth.ResetHealth();
+            _contactDamage = _enemyGo.AddComponent<EnemyContactDamage>();
+            SetPrivateField(_contactDamage, "_contactRadius", ContactRadius);
+            SetPrivateField(_contactDamage, "_tickInterval", TickInterval);
+            SetPrivateField(_contactDamage, "_damagePerTick", DamagePerTick);
+            _contactDamage.SetPlayerTarget(_playerHealth);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(_enemyGo);
+            Object.DestroyImmediate(_playerGo);
+        }
+
+        [Test]
+        public void InContact_DamagesPlayerImmediately()
+        {
+            _enemyGo.transform.position = _playerGo.transform.position;
+
+            _contactDamage.Tick(0.016f);
+
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(100f - DamagePerTick).Within(0.01f));
+        }
+
+        [Test]
+        public void InContact_DoesNotExceedOneTickPerInterval()
+        {
+            _enemyGo.transform.position = _playerGo.transform.position;
+
+            // 여러 프레임이 지나도 틱 간격(1초) 안에서는 데미지가 1회만 들어가야 한다.
+            for (int i = 0; i < 10; i++)
+            {
+                _contactDamage.Tick(0.016f);
+            }
+
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(100f - DamagePerTick).Within(0.01f));
+        }
+
+        [Test]
+        public void InContact_TicksAgainAfterInterval()
+        {
+            _enemyGo.transform.position = _playerGo.transform.position;
+
+            _contactDamage.Tick(0.016f);
+            _contactDamage.Tick(TickInterval + 0.01f);
+
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(100f - DamagePerTick * 2f).Within(0.01f));
+        }
+
+        [Test]
+        public void OutOfContact_DoesNotDamage()
+        {
+            _enemyGo.transform.position = new Vector3(ContactRadius + 1f, 0f, 0f);
+
+            _contactDamage.Tick(0.016f);
+
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(100f));
+        }
+
+        [Test]
+        public void DeadEnemy_DoesNotDamage()
+        {
+            _enemyGo.transform.position = _playerGo.transform.position;
+            _enemyHealth.Kill(countAsKill: false);
+
+            _contactDamage.Tick(0.016f);
+
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(100f));
+        }
+
+        [Test]
+        public void ZeroDamage_GimmickEnemy_DoesNotDamage()
+        {
+            // 기믹 적(어둑시니/목귀)은 접촉 데미지 0 — MonsterData 적용 후 데미지가 없어야 한다.
+            var data = ScriptableObject.CreateInstance<MonsterData>();
+            try
+            {
+                SetPrivateField(data, "_contactDamagePerSecond", 0f);
+                _contactDamage.ApplyMonsterData(data);
+
+                _enemyGo.transform.position = _playerGo.transform.position;
+                _contactDamage.Tick(0.016f);
+
+                Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(100f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(data);
+            }
+        }
+
+        [Test]
+        public void ApplyMonsterData_ConvertsPerSecondToPerTick()
+        {
+            // 초당 데미지 × 틱 간격 = 틱당 데미지 환산 검증 (간격 0.5초, 초당 10 → 틱당 5)
+            SetPrivateField(_contactDamage, "_tickInterval", 0.5f);
+
+            var data = ScriptableObject.CreateInstance<MonsterData>();
+            try
+            {
+                SetPrivateField(data, "_contactDamagePerSecond", 10f);
+                _contactDamage.ApplyMonsterData(data);
+
+                Assert.That(_contactDamage.DamagePerTick, Is.EqualTo(5f).Within(0.001f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(data);
+            }
+        }
+
+        [Test]
+        public void DeadPlayer_DoesNotReceiveDamage()
+        {
+            _enemyGo.transform.position = _playerGo.transform.position;
+            _playerHealth.TakeDamage(1000f);
+            Assert.That(_playerHealth.IsAlive, Is.False);
+
+            float healthAfterDeath = _playerHealth.CurrentHealth;
+            _contactDamage.Tick(TickInterval + 0.01f);
+
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(healthAfterDeath));
+        }
+
+        private static void SetPrivateField(object target, string fieldName, object value)
+        {
+            FieldInfo field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(field, Is.Not.Null, $"Field '{fieldName}' not found on {target.GetType().Name}");
+            field.SetValue(target, value);
+        }
+    }
+}

--- a/project1/Assets/Tests/EditMode/EnemyContactDamageTests.cs
+++ b/project1/Assets/Tests/EditMode/EnemyContactDamageTests.cs
@@ -143,6 +143,34 @@ namespace Mukseon.Tests.EditMode
         }
 
         [Test]
+        public void Reenable_ResetsTickTimer()
+        {
+            _enemyGo.transform.position = _playerGo.transform.position;
+
+            // 1틱 소모 — 다음 틱까지 아직 간격이 남아 있는 상태를 만든다.
+            _contactDamage.Tick(0.016f);
+
+            // 풀 재사용 흉내: 런타임에는 OnEnable이 ResetForReuse를 호출한다.
+            // EditMode에서는 SetActive로 OnEnable이 불리지 않으므로 직접 호출한다.
+            _contactDamage.ResetForReuse();
+
+            _contactDamage.Tick(0.016f);
+
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(100f - DamagePerTick * 2f).Within(0.01f));
+        }
+
+        [Test]
+        public void ZAxisOffset_DoesNotAffectContact()
+        {
+            // 스프라이트 정렬 등으로 Z 오프셋이 있어도 XY 평면 거리만으로 접촉을 판정해야 한다.
+            _enemyGo.transform.position = _playerGo.transform.position + new Vector3(0f, 0f, 5f);
+
+            _contactDamage.Tick(0.016f);
+
+            Assert.That(_playerHealth.CurrentHealth, Is.EqualTo(100f - DamagePerTick).Within(0.01f));
+        }
+
+        [Test]
         public void DeadPlayer_DoesNotReceiveDamage()
         {
             _enemyGo.transform.position = _playerGo.transform.position;

--- a/project1/Assets/Tests/EditMode/EnemyContactDamageTests.cs.meta
+++ b/project1/Assets/Tests/EditMode/EnemyContactDamageTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8b044e4f279e8c140848dbff65a4d70e


### PR DESCRIPTION
## 개요

Closes #103

시연 버전 Phase 0 검증에서 발견된 블로커 수정: 적이 플레이어에 닿아도 HP가 전혀 감소하지 않아 게임오버가 불가능했던 문제를 해소합니다.

## 변경 사항

### 코드
- **EnemyContactDamage 재작성**: `OnTriggerEnter2D`(1회 데미지 + 자폭) → 기획(`enemy_design.md`)대로 **닿아있는 동안 매초 지속 데미지**. 플레이어 고정(중앙) 전제이므로 물리 콜백 대신 sqrMagnitude 거리 판정 사용 (CLAUDE.md 물리 규칙 — 동적 충돌 미사용). 풀 재사용 시 OnEnable에서 틱 타이머 리셋.
- **MonsterData**: `_contactDamagePerSecond` 필드 추가 (0 = 기믹 적)
- **WaveCombatDirector / MountainKingMinionSpawner**: 스폰 시 `ApplyMonsterData`로 접촉 데미지 주입 (EnemySoulDropper와 동일 패턴)

### 에셋/씬
- Dummy 프리팹 4종 + Minion_CorruptedTiger에 `EnemyContactDamage` 부착
- 몬스터 9종 초당 접촉 데미지 차등 설정: 손각시·AshenClaw 5 / 망량·산귀 8 / 두억시니 15 / 어둑시니·목귀(기믹) 0 / 미니언 5 / 보스 12
- 씬에 `GameOverHandler` 배선 (WaveSystem 오브젝트, PlayerHealth·WaveCombatDirector 참조 연결) — 기존에는 씬 어디에도 없어 사망해도 게임오버 미발동

## 테스트

- EditMode 테스트 8종 추가 (`EnemyContactDamageTests`) — 전부 통과
  - 접촉 즉시 1틱 / 간격 내 중복 틱 방지 / 간격 경과 후 재틱
  - 비접촉·적 사망·플레이어 사망 시 미적용
  - 기믹 적(초당 0) 데미지 없음 / 초당→틱당 환산
- 에디터 플레이 검증: 적 접촉으로 HP 110→0 감소, 게임오버 발동 (웨이브 정지 + Time.timeScale=0) 확인

## 밸런스 노트

초당 데미지 수치는 기획서의 상대값(낮음/중간/높음)을 기반으로 한 MVP 초안입니다. 현재 밸런스로는 방치 시 약 15초에 사망 — Phase 5 밸런스 패스에서 조정 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)