### PR TITLE
feat: 도깨비불·매구 챕터1 웨이브 타임라인 편입 (#104)

### DIFF
--- a/project1/Assets/Settings/Chapter1_WaveDatabase.asset
+++ b/project1/Assets/Settings/Chapter1_WaveDatabase.asset
@@ -128,7 +128,7 @@ MonoBehaviour:
       _enemyPrefab: {fileID: 0}
       _minAliveCount: 2
       _moveSpeed: 1.5
-  - _waveName: 6:00-7:00 +Dureoksini (TODO Dokkaebi-bul)
+  - _waveName: 6:00-7:00 +Dureoksini/Dokkaebibul
     _durationSeconds: 60
     _spawnIntervalSeconds: 1.5
     _maxAliveEnemies: 16
@@ -148,7 +148,12 @@ MonoBehaviour:
       _enemyPrefab: {fileID: 0}
       _minAliveCount: 2
       _moveSpeed: 0.7
-  - _waveName: 7:00-8:00 +BrambleIdol (TODO Dokkaebi-bul)
+    - _enemyType: Dokkaebibul
+      _monsterData: {fileID: 11400000, guid: 6871f23fb6aa420f8bcc706b3f6c6cfd, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 1.6
+  - _waveName: 7:00-8:00 +BrambleIdol/Dokkaebibul
     _durationSeconds: 60
     _spawnIntervalSeconds: 1.5
     _maxAliveEnemies: 18
@@ -168,7 +173,12 @@ MonoBehaviour:
       _enemyPrefab: {fileID: 0}
       _minAliveCount: 2
       _moveSpeed: 0.85
-  - _waveName: 8:00-9:00 Dureoksini/BrambleIdol (TODO Dokkaebi-bul, Maegu)
+    - _enemyType: Dokkaebibul
+      _monsterData: {fileID: 11400000, guid: 6871f23fb6aa420f8bcc706b3f6c6cfd, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 1.6
+  - _waveName: 8:00-9:00 +Maegu
     _durationSeconds: 60
     _spawnIntervalSeconds: 1
     _maxAliveEnemies: 18
@@ -183,7 +193,17 @@ MonoBehaviour:
       _enemyPrefab: {fileID: 0}
       _minAliveCount: 2
       _moveSpeed: 0.85
-  - _waveName: 9:00-10:00 All enemies (TODO Dokkaebi-bul, Maegu)
+    - _enemyType: Dokkaebibul
+      _monsterData: {fileID: 11400000, guid: 6871f23fb6aa420f8bcc706b3f6c6cfd, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 2
+      _moveSpeed: 1.6
+    - _enemyType: Maegu
+      _monsterData: {fileID: 11400000, guid: bd890c0541c5445d8225e7789bea10b2, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 1
+      _moveSpeed: 1.1
+  - _waveName: 9:00-10:00 All enemies
     _durationSeconds: 60
     _spawnIntervalSeconds: 1
     _maxAliveEnemies: 24
@@ -223,3 +243,13 @@ MonoBehaviour:
       _enemyPrefab: {fileID: 0}
       _minAliveCount: 1
       _moveSpeed: 0.85
+    - _enemyType: Dokkaebibul
+      _monsterData: {fileID: 11400000, guid: 6871f23fb6aa420f8bcc706b3f6c6cfd, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 1
+      _moveSpeed: 1.6
+    - _enemyType: Maegu
+      _monsterData: {fileID: 11400000, guid: bd890c0541c5445d8225e7789bea10b2, type: 2}
+      _enemyPrefab: {fileID: 0}
+      _minAliveCount: 1
+      _moveSpeed: 1.1

--- a/project1/Assets/Settings/Chapter1_WaveDatabase.asset
+++ b/project1/Assets/Settings/Chapter1_WaveDatabase.asset
@@ -178,7 +178,7 @@ MonoBehaviour:
       _enemyPrefab: {fileID: 0}
       _minAliveCount: 2
       _moveSpeed: 1.6
-  - _waveName: 8:00-9:00 +Maegu
+  - _waveName: 8:00-9:00 Dureoksini/BrambleIdol/Dokkaebibul/Maegu
     _durationSeconds: 60
     _spawnIntervalSeconds: 1
     _maxAliveEnemies: 18

--- a/project1/Assets/Settings/Data/Monsters/Monster_Dokkaebibul.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_Dokkaebibul.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dad141cadcb6cef41a0c485253bfb68b, type: 3}
+  m_Name: Monster_Dokkaebibul
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.MonsterData
+  _monsterId: monster.dokkaebibul
+  _displayName: Dokkaebibul
+  _isBoss: 0
+  _enemyPrefab: {fileID: 2996619713416633372, guid: 6aef2084f48bebf46beae76621a92515, type: 3}
+  _swipeDirectionSequence:
+  _randomizeSequence: 0
+  _maxHealth: 3
+  _moveSpeed: 1.6
+  _contactDamagePerSecond: 0
+  _soulDropCount: 2
+  _experiencePerOrb: 2

--- a/project1/Assets/Settings/Data/Monsters/Monster_Dokkaebibul.asset.meta
+++ b/project1/Assets/Settings/Data/Monsters/Monster_Dokkaebibul.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6871f23fb6aa420f8bcc706b3f6c6cfd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/project1/Assets/Settings/Data/Monsters/Monster_Maegu.asset
+++ b/project1/Assets/Settings/Data/Monsters/Monster_Maegu.asset
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dad141cadcb6cef41a0c485253bfb68b, type: 3}
+  m_Name: Monster_Maegu
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.MonsterData
+  _monsterId: monster.maegu
+  _displayName: Maegu
+  _isBoss: 0
+  _enemyPrefab: {fileID: 2073897433596552694, guid: 48b14ef3869f0144cbe60c46bc4a935a, type: 3}
+  _swipeDirectionSequence:
+  _randomizeSequence: 0
+  _maxHealth: 6
+  _moveSpeed: 1.1
+  _contactDamagePerSecond: 0
+  _soulDropCount: 3
+  _experiencePerOrb: 2

--- a/project1/Assets/Settings/Data/Monsters/Monster_Maegu.asset.meta
+++ b/project1/Assets/Settings/Data/Monsters/Monster_Maegu.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bd890c0541c5445d8225e7789bea10b2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 개요

`Chapter1_WaveDatabase`에 TODO로 빠져 있던 도깨비불(6:00~)·매구(8:00~) 웨이브 엔트리를 편입합니다. 적 코드·프리팹(#29)은 이미 구현돼 있어 **데이터 에셋만 추가/수정**하는 변경입니다.

Closes #104

## 변경 내용

### 신규 MonsterData 에셋 (`Assets/Settings/Data/Monsters/`)
| 에셋 | 프리팹 | HP | 속도 | 접촉 DPS | 혼불 |
|------|--------|----|------|---------|------|
| Monster_Dokkaebibul | Dokkaebibul.prefab | 3 | 1.6 | 0 | 2×2exp |
| Monster_Maegu | Maegu.prefab | 6 | 1.1 | 0 | 3×2exp |

- 접촉 데미지 0은 enemy_design.md의 '특수 공격' 분류 기준 (데미지는 자폭/투사체로만) — 두 프리팹 모두 EnemyContactDamage 미부착과 일치
- 수치는 초안 — 밸런스 패스에서 조정 예정

### Chapter1_WaveDatabase 웨이브 엔트리 (chapter1_content.md 타임라인 기준)
- 6:00~7:00, 7:00~8:00, 8:00~9:00: 도깨비불 각 최소 2마리
- 8:00~9:00: 매구 최소 1마리
- 9:00~10:00 (전 적 복합): 도깨비불·매구 각 1마리
- 웨이브 이름의 TODO 표기 제거

## 검증

Unity 에디터에서 스크립트 실행으로 확인:
- 전체 10개 웨이브의 모든 엔트리 `IsValid` 통과
- 도깨비불 → `Dokkaebibul.prefab`, 매구 → `Maegu.prefab` 전용 프리팹으로 해석 (Dummy 폴백 없음)
- 스폰 경로 배선 확인: `WaveCombatDirector.SpawnEnemy` → `ApplyMonsterData`/`SetMoveSpeed` → `DokkaebibulEnemy`(자체 이동+자폭), `MaeguEnemy`+`EnemyMover(KeepDistance)`(투사체) 모두 `EnemyHealth.MoveSpeed` 기반으로 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)