### PR TITLE
feat: 시연용 디버그 치트 — 무적 / 즉시 레벨업 / 보스 구간 점프 (#111)

### DIFF
--- a/project1/Assets/Scripts/Combat/WaveCombatDirector.cs
+++ b/project1/Assets/Scripts/Combat/WaveCombatDirector.cs
@@ -96,6 +96,9 @@ namespace Mukseon.Gameplay.Combat
         public float TimelineElapsedSeconds => _timelineElapsedSeconds;
         public bool IsBossPhase => _bossPhaseStarted;
 
+        /// <summary>보스 진입 분 마크. 0 이하이면 보스 마크가 없다.</summary>
+        public float BossMinuteMark => _bossMinuteMark;
+
         public event Action<int, WaveDefinition> OnWaveStarted;
         public event Action<int, WaveEndReason> OnWaveEnded;
         public event Action<int, int> OnRemainingEnemyCountChanged;
@@ -181,6 +184,69 @@ namespace Mukseon.Gameplay.Combat
         {
             CleanupAliveEnemies(true);
             NotifyRemainingEnemyCountChanged();
+        }
+
+        /// <summary>
+        /// 타임라인을 지정 시각으로 즉시 진행시킨다(시연/디버그용 #111).
+        ///
+        /// 되감기는 지원하지 않는다 — 이미 발행된 마크 이벤트를 취소할 방법이 없어 되감으면
+        /// 같은 마크가 두 번 발행되거나 보스 페이즈가 어긋난 상태로 남는다. 과거 시각을 넘기면 무시한다.
+        ///
+        /// <paramref name="fireSkippedMarks"/>가 false(기본)면 건너뛴 미니 보스 마크를 발행 없이 소진 처리한다.
+        /// 챕터 1 기준 미니 보스 마크가 3·6·9분이고 보스가 10분이라, 0분에서 보스로 점프하면 그대로
+        /// 세 마크가 같은 프레임에 발행되어 미니 보스 3마리가 한꺼번에 쏟아진다. 시연에서 필요한 건
+        /// 깨끗한 보스전이므로 억제가 기본이고, 미니 보스 자체를 확인하려면 true로 부른다.
+        ///
+        /// 주의: 웨이브 진행(스폰 구성)은 앞당기지 않고 타임라인 마크만 처리한다. 보스 점프는
+        /// <see cref="EnterBossPhase"/>가 웨이브를 종료시키므로 문제되지 않지만, 중간 시각으로
+        /// 점프하면 웨이브 인덱스가 타임라인보다 뒤처진 상태로 남는다.
+        /// </summary>
+        public void SkipTimelineTo(float targetSeconds, bool fireSkippedMarks = false)
+        {
+            if (!_isRunning || targetSeconds <= _timelineElapsedSeconds)
+            {
+                return;
+            }
+
+            _timelineElapsedSeconds = targetSeconds;
+
+            if (!fireSkippedMarks)
+            {
+                SuppressMiniBossMarksBefore(targetSeconds);
+            }
+
+            CheckTimelineMarks();
+        }
+
+        /// <summary>
+        /// 보스 구간으로 즉시 점프한다(시연/디버그용 #111). 보스 마크가 없거나 이미 보스 페이즈면 false.
+        /// </summary>
+        public bool SkipToBossPhase()
+        {
+            if (!_isRunning || _bossPhaseStarted || _bossMinuteMark <= 0f)
+            {
+                return false;
+            }
+
+            SkipTimelineTo(_bossMinuteMark * 60f);
+            return _bossPhaseStarted;
+        }
+
+        // 지정 시각 이하의 미니 보스 마크를 '발행하지 않고' 소진 처리한다.
+        private void SuppressMiniBossMarksBefore(float seconds)
+        {
+            if (_miniBossMinuteMarks == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < _miniBossMinuteMarks.Count && i < _miniBossMarkFired.Count; i++)
+            {
+                if (_miniBossMinuteMarks[i] * 60f <= seconds)
+                {
+                    _miniBossMarkFired[i] = true;
+                }
+            }
         }
 
         internal void Tick(float deltaTime)

--- a/project1/Assets/Scripts/Dev.meta
+++ b/project1/Assets/Scripts/Dev.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bfe65716341ffe64591d69255d29f141
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/project1/Assets/Scripts/Dev/DemoCheatAction.cs
+++ b/project1/Assets/Scripts/Dev/DemoCheatAction.cs
@@ -1,0 +1,32 @@
+namespace Mukseon.Dev
+{
+    /// <summary>
+    /// 시연용 치트 종류(#111). 실제 실행은 <c>DemoCheatController</c>가, 키 매핑은
+    /// <see cref="DemoCheatBindings"/>가 담당한다.
+    /// </summary>
+    public enum DemoCheatAction
+    {
+        None = 0,
+
+        /// <summary>무적 토글. 시연 도중 사망으로 흐름이 끊기는 것을 막는다.</summary>
+        ToggleInvincible = 1,
+
+        /// <summary>즉시 레벨업. 레벨업 스킬 선택 UI를 바로 보여주기 위한 것.</summary>
+        LevelUp = 2,
+
+        /// <summary>화면 내 적 일괄 제거.</summary>
+        KillEnemies = 3,
+
+        /// <summary>강신 게이지를 채우고 즉시 발동.</summary>
+        ActivateGangshin = 4,
+
+        /// <summary>미장착 강신을 슬롯에 지급. 슬롯 교체 시연용.</summary>
+        GrantGangshinSlot = 5,
+
+        /// <summary>보스 구간으로 타임라인 점프. 10분 런을 기다리지 않기 위한 핵심 치트.</summary>
+        SkipToBoss = 6,
+
+        /// <summary>치트 안내 오버레이 표시 토글.</summary>
+        ToggleOverlay = 7,
+    }
+}

--- a/project1/Assets/Scripts/Dev/DemoCheatAction.cs.meta
+++ b/project1/Assets/Scripts/Dev/DemoCheatAction.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 763bf7a0d682f4f4eac5145768a24235

--- a/project1/Assets/Scripts/Dev/DemoCheatBindings.cs
+++ b/project1/Assets/Scripts/Dev/DemoCheatBindings.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Mukseon.Dev
+{
+    /// <summary>
+    /// 시연용 치트의 키 매핑과 표시 라벨(#111).
+    ///
+    /// MonoBehaviour에 의존하지 않는 순수 자료구조로 분리했다. 실행부(<c>DemoCheatController</c>)는
+    /// 조건부 컴파일로 출시 빌드에서 통째로 빠지지만, 매핑 자체는 테스트에서 중복/누락을 검증할 수 있어야 한다.
+    /// </summary>
+    public static class DemoCheatBindings
+    {
+        /// <summary>키 하나에 대응하는 치트 한 개.</summary>
+        public readonly struct Binding
+        {
+            public readonly KeyCode Key;
+            public readonly DemoCheatAction Action;
+
+            /// <summary>화면 오버레이에 표시할 설명.</summary>
+            public readonly string Label;
+
+            public Binding(KeyCode key, DemoCheatAction action, string label)
+            {
+                Key = key;
+                Action = action;
+                Label = label;
+            }
+
+            /// <summary>오버레이 한 줄 표기(예: "F1  무적").</summary>
+            public string DisplayText => $"{KeyText}  {Label}";
+
+            /// <summary>KeyCode의 기본 ToString은 "F1"처럼 그대로 쓸 만하므로 그대로 사용한다.</summary>
+            public string KeyText => Key.ToString();
+        }
+
+        // 기능 키를 쓰는 이유: 시연은 PC 키보드 기준이고, 숫자/문자 키는 향후 다른 디버그 입력과
+        // 충돌하기 쉽다. F1~F7은 게임 입력(스와이프/더블탭)과 겹치지 않는다.
+        private static readonly Binding[] _bindings =
+        {
+            new Binding(KeyCode.F1, DemoCheatAction.ToggleInvincible, "무적 토글"),
+            new Binding(KeyCode.F2, DemoCheatAction.LevelUp, "즉시 레벨업"),
+            new Binding(KeyCode.F3, DemoCheatAction.KillEnemies, "적 일괄 제거"),
+            new Binding(KeyCode.F4, DemoCheatAction.ActivateGangshin, "강신 즉시 발동"),
+            new Binding(KeyCode.F5, DemoCheatAction.GrantGangshinSlot, "강신 슬롯 지급"),
+            new Binding(KeyCode.F6, DemoCheatAction.SkipToBoss, "보스 구간 점프"),
+            new Binding(KeyCode.F7, DemoCheatAction.ToggleOverlay, "안내 표시 토글"),
+        };
+
+        public static IReadOnlyList<Binding> All => _bindings;
+
+        /// <summary>지정 키에 매핑된 치트를 찾는다. 없으면 <see cref="DemoCheatAction.None"/>.</summary>
+        public static DemoCheatAction Resolve(KeyCode key)
+        {
+            for (int i = 0; i < _bindings.Length; i++)
+            {
+                if (_bindings[i].Key == key)
+                {
+                    return _bindings[i].Action;
+                }
+            }
+
+            return DemoCheatAction.None;
+        }
+
+        /// <summary>지정 치트의 키를 찾는다. 없으면 <see cref="KeyCode.None"/>.</summary>
+        public static KeyCode ResolveKey(DemoCheatAction action)
+        {
+            for (int i = 0; i < _bindings.Length; i++)
+            {
+                if (_bindings[i].Action == action)
+                {
+                    return _bindings[i].Key;
+                }
+            }
+
+            return KeyCode.None;
+        }
+    }
+}

--- a/project1/Assets/Scripts/Dev/DemoCheatBindings.cs.meta
+++ b/project1/Assets/Scripts/Dev/DemoCheatBindings.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3f4a09dbdc142b248b325e8941bc3d1c

--- a/project1/Assets/Scripts/Dev/DemoCheatController.cs
+++ b/project1/Assets/Scripts/Dev/DemoCheatController.cs
@@ -1,0 +1,253 @@
+// 시연/개발 전용(#111). 출시 빌드에는 이 파일의 내용이 통째로 빠진다.
+// 파일 전체를 감싸는 이유: 클래스 선언까지 제외해야 다른 코드가 실수로 참조해 출시 빌드를 깨뜨리는 일이 없다.
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+
+using System.Collections.Generic;
+using Mukseon.Core;
+using Mukseon.Gameplay.Combat;
+using Mukseon.Gameplay.Progression;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace Mukseon.Dev
+{
+    /// <summary>
+    /// 시연용 디버그 치트 실행부(#111).
+    ///
+    /// 10분 런 + 보스라는 설계를 시연 부스에서 그대로 굴릴 수 없어서 존재한다. 대부분의 치트는
+    /// 이미 있는 public API를 키에 연결한 것뿐이고, 보스 점프만 <see cref="WaveCombatDirector.SkipToBossPhase"/>를
+    /// 새로 필요로 했다.
+    ///
+    /// GameplayInputGate/GameplayHudBootstrapper와 같은 자가 부트스트랩 패턴을 쓴다 — 씬을 편집하지 않으므로
+    /// 씬 파일에 시연용 오브젝트가 커밋되는 일이 없다.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public sealed class DemoCheatController : MonoBehaviour
+    {
+        private const string RootObjectName = "DemoCheatRuntime";
+
+        /// <summary>즉시 레벨업 시 임계치를 확실히 넘기기 위한 여유분.</summary>
+        private const float LevelUpExperienceMargin = 1f;
+
+        private static DemoCheatController _instance;
+
+        private PlayerHealth _playerHealth;
+        private PlayerLevelSystem _playerLevelSystem;
+        private GangshinController _gangshinController;
+        private WaveCombatDirector _waveCombatDirector;
+
+        private readonly List<EnemyHealth> _killBuffer = new List<EnemyHealth>(64);
+
+        private DemoCheatOverlay _overlay;
+        private bool _isInvincible;
+
+        /// <summary>무적 치트가 켜져 있는지. 오버레이 표시에 사용.</summary>
+        public bool IsInvincible => _isInvincible;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void EnsureController()
+        {
+            if (SceneObjectFinder.Find<DemoCheatController>() != null)
+            {
+                return;
+            }
+
+            var root = new GameObject(RootObjectName);
+            root.AddComponent<DemoCheatController>();
+        }
+
+        private void Awake()
+        {
+            if (_instance != null && _instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            _instance = this;
+            DontDestroyOnLoad(gameObject);
+            SceneManager.sceneLoaded += HandleSceneLoaded;
+
+            _overlay = new DemoCheatOverlay(this);
+            ResolveSources();
+        }
+
+        private void OnDestroy()
+        {
+            if (_instance == this)
+            {
+                _instance = null;
+            }
+
+            SceneManager.sceneLoaded -= HandleSceneLoaded;
+            _overlay?.Dispose();
+            _overlay = null;
+        }
+
+        // 씬이 바뀌면 이전 씬의 참조가 전부 무효해지므로 다시 해석한다.
+        // 무적 상태도 새 런에 자동으로 따라가지 않게 해제한다 — 시연자가 껐다고 착각하는 편이 위험하다.
+        private void HandleSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            _playerHealth = null;
+            _playerLevelSystem = null;
+            _gangshinController = null;
+            _waveCombatDirector = null;
+            _isInvincible = false;
+            ResolveSources();
+        }
+
+        private void ResolveSources()
+        {
+            _playerHealth = SceneObjectFinder.Find<PlayerHealth>();
+            _playerLevelSystem = SceneObjectFinder.Find<PlayerLevelSystem>();
+            _gangshinController = SceneObjectFinder.Find<GangshinController>();
+            _waveCombatDirector = SceneObjectFinder.Find<WaveCombatDirector>();
+        }
+
+        // 게임이 정지(timeScale 0)돼 있어도 치트는 먹어야 하므로 Update에서 직접 키를 읽는다.
+        private void Update()
+        {
+            IReadOnlyList<DemoCheatBindings.Binding> bindings = DemoCheatBindings.All;
+            for (int i = 0; i < bindings.Count; i++)
+            {
+                if (Input.GetKeyDown(bindings[i].Key))
+                {
+                    Execute(bindings[i].Action);
+                }
+            }
+
+            _overlay?.Update();
+        }
+
+        private void Execute(DemoCheatAction action)
+        {
+            switch (action)
+            {
+                case DemoCheatAction.ToggleInvincible:
+                    ToggleInvincible();
+                    break;
+                case DemoCheatAction.LevelUp:
+                    LevelUp();
+                    break;
+                case DemoCheatAction.KillEnemies:
+                    KillEnemies();
+                    break;
+                case DemoCheatAction.ActivateGangshin:
+                    ActivateGangshin();
+                    break;
+                case DemoCheatAction.GrantGangshinSlot:
+                    GrantGangshinSlot();
+                    break;
+                case DemoCheatAction.SkipToBoss:
+                    SkipToBoss();
+                    break;
+                case DemoCheatAction.ToggleOverlay:
+                    _overlay?.ToggleVisible();
+                    break;
+            }
+        }
+
+        private void ToggleInvincible()
+        {
+            if (_playerHealth == null)
+            {
+                return;
+            }
+
+            _isInvincible = !_isInvincible;
+            _playerHealth.SetInvincible(_isInvincible);
+        }
+
+        private void LevelUp()
+        {
+            if (_playerLevelSystem == null)
+            {
+                return;
+            }
+
+            // 임계치까지 남은 만큼만 넣어 정확히 1레벨만 오르게 한다(큰 값을 넣으면 여러 번 겹쳐 오른다).
+            float remaining = _playerLevelSystem.CurrentThreshold - _playerLevelSystem.CurrentExperience;
+            _playerLevelSystem.AddExperience(Mathf.Max(0f, remaining) + LevelUpExperienceMargin);
+        }
+
+        private void KillEnemies()
+        {
+            // ActiveEnemies는 사망 처리 중 변경되므로 버퍼에 복사한 뒤 순회한다.
+            _killBuffer.Clear();
+            _killBuffer.AddRange(EnemyHealth.ActiveEnemies);
+
+            for (int i = 0; i < _killBuffer.Count; i++)
+            {
+                EnemyHealth enemy = _killBuffer[i];
+                if (enemy != null && enemy.IsAlive)
+                {
+                    enemy.Kill();
+                }
+            }
+
+            _killBuffer.Clear();
+        }
+
+        private void ActivateGangshin()
+        {
+            if (_gangshinController == null)
+            {
+                return;
+            }
+
+            _gangshinController.AddGauge(_gangshinController.MaxGauge);
+            _gangshinController.TryActivate();
+        }
+
+        // 강신 어빌리티는 SO가 아니라 씬에 배치된 MonoBehaviour라, 씬에서 찾아 미장착인 것을 슬롯에 넣는다.
+        private void GrantGangshinSlot()
+        {
+            if (_gangshinController == null || !_gangshinController.HasFreeSlot)
+            {
+                return;
+            }
+
+            GangshinAbilityBase[] abilities =
+                Object.FindObjectsByType<GangshinAbilityBase>(FindObjectsInactive.Include, FindObjectsSortMode.None);
+
+            for (int i = 0; i < abilities.Length; i++)
+            {
+                if (IsEquipped(abilities[i]))
+                {
+                    continue;
+                }
+
+                if (_gangshinController.TryAddAbility(abilities[i]) >= 0)
+                {
+                    return;
+                }
+            }
+        }
+
+        private bool IsEquipped(GangshinAbilityBase ability)
+        {
+            IReadOnlyList<GangshinSlot> slots = _gangshinController.Slots;
+            if (slots == null)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < slots.Count; i++)
+            {
+                if (slots[i] != null && slots[i].Ability == ability)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private void SkipToBoss()
+        {
+            _waveCombatDirector?.SkipToBossPhase();
+        }
+    }
+}
+
+#endif

--- a/project1/Assets/Scripts/Dev/DemoCheatController.cs
+++ b/project1/Assets/Scripts/Dev/DemoCheatController.cs
@@ -39,10 +39,15 @@ namespace Mukseon.Dev
         private readonly List<EnemyHealth> _killBuffer = new List<EnemyHealth>(64);
 
         private DemoCheatOverlay _overlay;
-        private bool _isInvincible;
 
-        /// <summary>무적 치트가 켜져 있는지. 오버레이 표시에 사용.</summary>
-        public bool IsInvincible => _isInvincible;
+        /// <summary>
+        /// 무적 치트가 켜져 있는지. 오버레이 표시에 사용.
+        ///
+        /// 별도 bool을 캐시하지 않고 <see cref="PlayerHealth.IsInvincible"/>을 그대로 읽는다 —
+        /// 상태를 두 곳에 두면 어긋날 수 있고, 실제 무적 여부의 소유자는 PlayerHealth다.
+        /// 여기서는 지연 해석을 하지 않는다(오버레이가 매 프레임 호출하므로 씬 탐색이 반복되면 안 된다).
+        /// </summary>
+        public bool IsInvincible => _playerHealth != null && _playerHealth.IsInvincible;
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         private static void EnsureController()
@@ -85,14 +90,17 @@ namespace Mukseon.Dev
         }
 
         // 씬이 바뀌면 이전 씬의 참조가 전부 무효해지므로 다시 해석한다.
-        // 무적 상태도 새 런에 자동으로 따라가지 않게 해제한다 — 시연자가 껐다고 착각하는 편이 위험하다.
+        //
+        // 무적 상태를 여기서 따로 끄지 않는 이유: 무적 여부의 소유자가 PlayerHealth이고 이 컨트롤러는
+        // 캐시를 두지 않으므로, 새 씬의 PlayerHealth는 애초에 무적이 아닌 상태로 시작한다.
+        // 애디티브 로드로 이전 플레이어가 살아남는 경우에도 IsInvincible이 실제 상태를 그대로 보고하므로
+        // 표시와 실제가 어긋나지 않는다.
         private void HandleSceneLoaded(Scene scene, LoadSceneMode mode)
         {
             _playerHealth = null;
             _playerLevelSystem = null;
             _gangshinController = null;
             _waveCombatDirector = null;
-            _isInvincible = false;
             ResolveSources();
         }
 
@@ -102,6 +110,28 @@ namespace Mukseon.Dev
             _playerLevelSystem = SceneObjectFinder.Find<PlayerLevelSystem>();
             _gangshinController = SceneObjectFinder.Find<GangshinController>();
             _waveCombatDirector = SceneObjectFinder.Find<WaveCombatDirector>();
+        }
+
+        // 치트 실행 시점의 지연 재해석용 접근자(PR #113 리뷰 반영).
+        //
+        // 씬 로드 직후에 해석해 캐시하지만, 플레이어나 디렉터가 씬 로드 이후에 동적으로 생성되면
+        // 캐시가 비어 있는 채로 남아 치트가 조용히 먹지 않는다. 실제로 눌렀을 때 한 번 더 찾아본다.
+        //
+        // Unity의 == 오버로드가 파괴된 오브젝트도 null로 판정하므로, 이전 참조가 파괴된 경우에도
+        // 자동으로 다시 해석된다. 비용은 캐시가 비었을 때(=어차피 no-op이었을 때)만 발생한다.
+        private PlayerHealth Health => ResolveLazily(ref _playerHealth);
+        private PlayerLevelSystem Levels => ResolveLazily(ref _playerLevelSystem);
+        private GangshinController Gangshin => ResolveLazily(ref _gangshinController);
+        private WaveCombatDirector Waves => ResolveLazily(ref _waveCombatDirector);
+
+        private static T ResolveLazily<T>(ref T cached) where T : Object
+        {
+            if (cached == null)
+            {
+                cached = SceneObjectFinder.Find<T>();
+            }
+
+            return cached;
         }
 
         // 게임이 정지(timeScale 0)돼 있어도 치트는 먹어야 하므로 Update에서 직접 키를 읽는다.
@@ -149,25 +179,27 @@ namespace Mukseon.Dev
 
         private void ToggleInvincible()
         {
-            if (_playerHealth == null)
+            PlayerHealth health = Health;
+            if (health == null)
             {
                 return;
             }
 
-            _isInvincible = !_isInvincible;
-            _playerHealth.SetInvincible(_isInvincible);
+            // 현재 값을 PlayerHealth에서 직접 읽어 뒤집는다 — 별도 캐시를 두지 않으므로 어긋날 여지가 없다.
+            health.SetInvincible(!health.IsInvincible);
         }
 
         private void LevelUp()
         {
-            if (_playerLevelSystem == null)
+            PlayerLevelSystem levels = Levels;
+            if (levels == null)
             {
                 return;
             }
 
             // 임계치까지 남은 만큼만 넣어 정확히 1레벨만 오르게 한다(큰 값을 넣으면 여러 번 겹쳐 오른다).
-            float remaining = _playerLevelSystem.CurrentThreshold - _playerLevelSystem.CurrentExperience;
-            _playerLevelSystem.AddExperience(Mathf.Max(0f, remaining) + LevelUpExperienceMargin);
+            float remaining = levels.CurrentThreshold - levels.CurrentExperience;
+            levels.AddExperience(Mathf.Max(0f, remaining) + LevelUpExperienceMargin);
         }
 
         private void KillEnemies()
@@ -190,19 +222,21 @@ namespace Mukseon.Dev
 
         private void ActivateGangshin()
         {
-            if (_gangshinController == null)
+            GangshinController gangshin = Gangshin;
+            if (gangshin == null)
             {
                 return;
             }
 
-            _gangshinController.AddGauge(_gangshinController.MaxGauge);
-            _gangshinController.TryActivate();
+            gangshin.AddGauge(gangshin.MaxGauge);
+            gangshin.TryActivate();
         }
 
         // 강신 어빌리티는 SO가 아니라 씬에 배치된 MonoBehaviour라, 씬에서 찾아 미장착인 것을 슬롯에 넣는다.
         private void GrantGangshinSlot()
         {
-            if (_gangshinController == null || !_gangshinController.HasFreeSlot)
+            GangshinController gangshin = Gangshin;
+            if (gangshin == null || !gangshin.HasFreeSlot)
             {
                 return;
             }
@@ -212,21 +246,22 @@ namespace Mukseon.Dev
 
             for (int i = 0; i < abilities.Length; i++)
             {
-                if (IsEquipped(abilities[i]))
+                // 같은 프레임에 파괴된 오브젝트가 섞여 올 수 있어 null 판정을 먼저 한다.
+                if (abilities[i] == null || IsEquipped(gangshin, abilities[i]))
                 {
                     continue;
                 }
 
-                if (_gangshinController.TryAddAbility(abilities[i]) >= 0)
+                if (gangshin.TryAddAbility(abilities[i]) >= 0)
                 {
                     return;
                 }
             }
         }
 
-        private bool IsEquipped(GangshinAbilityBase ability)
+        private static bool IsEquipped(GangshinController gangshin, GangshinAbilityBase ability)
         {
-            IReadOnlyList<GangshinSlot> slots = _gangshinController.Slots;
+            IReadOnlyList<GangshinSlot> slots = gangshin.Slots;
             if (slots == null)
             {
                 return false;
@@ -245,7 +280,11 @@ namespace Mukseon.Dev
 
         private void SkipToBoss()
         {
-            _waveCombatDirector?.SkipToBossPhase();
+            WaveCombatDirector waves = Waves;
+            if (waves != null)
+            {
+                waves.SkipToBossPhase();
+            }
         }
     }
 }

--- a/project1/Assets/Scripts/Dev/DemoCheatController.cs.meta
+++ b/project1/Assets/Scripts/Dev/DemoCheatController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ad38f4d9a816b15448abd1bff9102dd8

--- a/project1/Assets/Scripts/Dev/DemoCheatOverlay.cs
+++ b/project1/Assets/Scripts/Dev/DemoCheatOverlay.cs
@@ -1,0 +1,173 @@
+// 시연/개발 전용(#111). DemoCheatController와 함께 출시 빌드에서 제외된다.
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+
+using System;
+using System.Collections.Generic;
+using Mukseon.UI;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Mukseon.Dev
+{
+    /// <summary>
+    /// 치트 키 목록과 활성 상태를 화면에 표시한다(#111).
+    ///
+    /// 무적 표시가 핵심이다 — 발표자가 무적을 켜둔 걸 잊고 "이 정도 난이도입니다"라고 설명하면
+    /// 시연 자체가 거짓이 된다. 켜져 있는 동안은 눈에 띄게 보여야 한다.
+    ///
+    /// MonoBehaviour가 아니라 <see cref="DemoCheatController"/>가 소유하는 일반 클래스다.
+    /// 치트 오브젝트 하나에 컴포넌트를 더 붙일 이유가 없고, 수명이 컨트롤러와 정확히 같다.
+    /// </summary>
+    internal sealed class DemoCheatOverlay : IDisposable
+    {
+        // 페이드 오버레이(1000)보다도 위. 화면 전환 중에도 치트 상태는 보여야 한다.
+        private const int SortingOrder = 1100;
+
+        private static readonly Color PanelBackground = new Color(0f, 0f, 0f, 0.55f);
+        private static readonly Color WarningColor = new Color(0.95f, 0.35f, 0.30f, 1f);
+
+        private readonly DemoCheatController _controller;
+
+        private GameObject _root;
+        private UIDocument _document;
+        private PanelSettings _panelSettings;
+        private Label _invincibleLabel;
+
+        private bool _isVisible = true;
+        private bool _lastInvincible;
+
+        public DemoCheatOverlay(DemoCheatController controller)
+        {
+            _controller = controller;
+            Build();
+        }
+
+        public void ToggleVisible()
+        {
+            _isVisible = !_isVisible;
+            ApplyVisibility();
+        }
+
+        /// <summary>무적 상태가 바뀌었을 때만 표시를 갱신한다(매 프레임 스타일 대입 방지).</summary>
+        public void Update()
+        {
+            if (_controller == null || _invincibleLabel == null)
+            {
+                return;
+            }
+
+            bool invincible = _controller.IsInvincible;
+            if (invincible == _lastInvincible)
+            {
+                return;
+            }
+
+            _lastInvincible = invincible;
+            _invincibleLabel.style.display = invincible ? DisplayStyle.Flex : DisplayStyle.None;
+        }
+
+        public void Dispose()
+        {
+            // PanelSettings는 에셋이 아니라 런타임 인스턴스라 직접 파기하지 않으면 누수된다(#36과 동일).
+            if (_panelSettings != null)
+            {
+                UnityEngine.Object.Destroy(_panelSettings);
+                _panelSettings = null;
+            }
+
+            if (_root != null)
+            {
+                UnityEngine.Object.Destroy(_root);
+                _root = null;
+            }
+
+            _document = null;
+            _invincibleLabel = null;
+        }
+
+        private void Build()
+        {
+            _root = new GameObject("DemoCheatOverlay");
+            _root.transform.SetParent(_controller.transform, false);
+
+            _panelSettings = ScreenUiFactory.CreatePanelSettings(SortingOrder);
+            _document = _root.AddComponent<UIDocument>();
+            _document.panelSettings = _panelSettings;
+
+            VisualElement root = _document.rootVisualElement;
+            root.pickingMode = PickingMode.Ignore;
+
+            VisualElement panel = CreatePanel(root);
+            _invincibleLabel = CreateInvincibleLabel(panel);
+
+            CreateTitle(panel);
+            CreateBindingList(panel);
+
+            ApplyVisibility();
+        }
+
+        // 좌상단 고정. 전투는 화면 중앙에서 일어나므로 구석이 시연 화면을 가장 덜 가린다.
+        private static VisualElement CreatePanel(VisualElement parent)
+        {
+            var panel = new VisualElement();
+            panel.style.position = Position.Absolute;
+            panel.style.left = 16f;
+            panel.style.top = 16f;
+            panel.style.paddingLeft = 12f;
+            panel.style.paddingRight = 12f;
+            panel.style.paddingTop = 8f;
+            panel.style.paddingBottom = 8f;
+            panel.style.backgroundColor = PanelBackground;
+            panel.style.flexDirection = FlexDirection.Column;
+            panel.pickingMode = PickingMode.Ignore;
+            parent.Add(panel);
+            return panel;
+        }
+
+        private static Label CreateInvincibleLabel(VisualElement parent)
+        {
+            var label = new Label("● 무적 ON — 시연용 치트");
+            label.style.color = WarningColor;
+            label.style.fontSize = 22f;
+            label.style.unityFontStyleAndWeight = FontStyle.Bold;
+            label.style.marginBottom = 6f;
+            label.style.display = DisplayStyle.None;
+            label.pickingMode = PickingMode.Ignore;
+            parent.Add(label);
+            return label;
+        }
+
+        private static void CreateTitle(VisualElement parent)
+        {
+            var title = new Label("시연용 치트");
+            title.style.color = ScreenUiFactory.InkDim;
+            title.style.fontSize = 16f;
+            title.style.marginBottom = 4f;
+            title.pickingMode = PickingMode.Ignore;
+            parent.Add(title);
+        }
+
+        private static void CreateBindingList(VisualElement parent)
+        {
+            IReadOnlyList<DemoCheatBindings.Binding> bindings = DemoCheatBindings.All;
+            for (int i = 0; i < bindings.Count; i++)
+            {
+                var line = new Label(bindings[i].DisplayText);
+                line.style.color = ScreenUiFactory.Ink;
+                line.style.fontSize = 14f;
+                line.pickingMode = PickingMode.Ignore;
+                parent.Add(line);
+            }
+        }
+
+        private void ApplyVisibility()
+        {
+            if (_document != null && _document.rootVisualElement != null)
+            {
+                _document.rootVisualElement.style.display = _isVisible ? DisplayStyle.Flex : DisplayStyle.None;
+            }
+        }
+    }
+}
+
+#endif

--- a/project1/Assets/Scripts/Dev/DemoCheatOverlay.cs.meta
+++ b/project1/Assets/Scripts/Dev/DemoCheatOverlay.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c8ee59e5ef82a2a4196b0b83f641fffd

--- a/project1/Assets/Tests/EditMode/DemoCheatBindingsTests.cs
+++ b/project1/Assets/Tests/EditMode/DemoCheatBindingsTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using Mukseon.Dev;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Mukseon.Tests.EditMode
+{
+    /// <summary>시연용 치트 키 매핑 검증(#111).</summary>
+    public class DemoCheatBindingsTests
+    {
+        [Test]
+        public void Bindings_HaveNoDuplicateKeys()
+        {
+            var seen = new HashSet<KeyCode>();
+
+            foreach (DemoCheatBindings.Binding binding in DemoCheatBindings.All)
+            {
+                Assert.That(seen.Add(binding.Key), Is.True, $"키 {binding.Key}가 중복 매핑되었습니다.");
+            }
+        }
+
+        [Test]
+        public void Bindings_HaveNoDuplicateActions()
+        {
+            var seen = new HashSet<DemoCheatAction>();
+
+            foreach (DemoCheatBindings.Binding binding in DemoCheatBindings.All)
+            {
+                Assert.That(seen.Add(binding.Action), Is.True, $"치트 {binding.Action}가 중복 매핑되었습니다.");
+            }
+        }
+
+        // None은 '매핑 없음'을 뜻하는 센티널이므로 바인딩에 들어가면 Resolve 결과와 구분할 수 없게 된다.
+        [Test]
+        public void Bindings_DoNotContainNoneAction()
+        {
+            foreach (DemoCheatBindings.Binding binding in DemoCheatBindings.All)
+            {
+                Assert.That(binding.Action, Is.Not.EqualTo(DemoCheatAction.None));
+            }
+        }
+
+        [Test]
+        public void Bindings_CoverEveryDeclaredAction()
+        {
+            foreach (DemoCheatAction action in Enum.GetValues(typeof(DemoCheatAction)))
+            {
+                if (action == DemoCheatAction.None)
+                {
+                    continue;
+                }
+
+                Assert.That(
+                    DemoCheatBindings.ResolveKey(action),
+                    Is.Not.EqualTo(KeyCode.None),
+                    $"치트 {action}에 키가 매핑되지 않았습니다.");
+            }
+        }
+
+        [Test]
+        public void Bindings_HaveLabels()
+        {
+            foreach (DemoCheatBindings.Binding binding in DemoCheatBindings.All)
+            {
+                Assert.That(string.IsNullOrWhiteSpace(binding.Label), Is.False, $"{binding.Action}에 라벨이 없습니다.");
+            }
+        }
+
+        [Test]
+        public void Resolve_ReturnsMappedAction()
+        {
+            KeyCode key = DemoCheatBindings.ResolveKey(DemoCheatAction.SkipToBoss);
+
+            Assert.That(DemoCheatBindings.Resolve(key), Is.EqualTo(DemoCheatAction.SkipToBoss));
+        }
+
+        [Test]
+        public void Resolve_UnmappedKey_ReturnsNone()
+        {
+            Assert.That(DemoCheatBindings.Resolve(KeyCode.Escape), Is.EqualTo(DemoCheatAction.None));
+        }
+
+        [Test]
+        public void DisplayText_ContainsKeyAndLabel()
+        {
+            DemoCheatBindings.Binding binding = DemoCheatBindings.All[0];
+
+            Assert.That(binding.DisplayText, Does.Contain(binding.KeyText));
+            Assert.That(binding.DisplayText, Does.Contain(binding.Label));
+        }
+    }
+}

--- a/project1/Assets/Tests/EditMode/DemoCheatBindingsTests.cs.meta
+++ b/project1/Assets/Tests/EditMode/DemoCheatBindingsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b7ff8793f4216ad45a8c9dc6fd7bf5e7

--- a/project1/Assets/Tests/EditMode/WaveTimelineSkipTests.cs
+++ b/project1/Assets/Tests/EditMode/WaveTimelineSkipTests.cs
@@ -1,0 +1,146 @@
+using System.Collections.Generic;
+using System.Reflection;
+using Mukseon.Gameplay.Combat;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Mukseon.Tests.EditMode
+{
+    /// <summary>
+    /// 타임라인 시간 점프와 미니 보스 마크 억제 검증(#111).
+    ///
+    /// 억제(SuppressMiniBossMarksBefore)와 검사(CheckTimelineMarks)의 호출 순서가 뒤바뀌면
+    /// 건너뛴 마크가 전부 발행되어 미니 보스가 한꺼번에 쏟아진다. 순서에 민감한 로직이라
+    /// 회귀를 잡을 테스트가 필요하다(PR #113 리뷰 지적).
+    /// </summary>
+    public class WaveTimelineSkipTests
+    {
+        private const float BossMinuteMark = 10f;
+
+        private GameObject _directorGo;
+        private WaveCombatDirector _director;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _directorGo = new GameObject("WaveCombatDirector");
+            // AddComponent는 EditMode에서 Awake/OnEnable을 태우지 않으므로 private 필드를 직접 세팅한다.
+            _director = _directorGo.AddComponent<WaveCombatDirector>();
+
+            SetPrivateField(_director, "_bossMinuteMark", BossMinuteMark);
+            SetPrivateField(_director, "_miniBossMinuteMarks", new List<float> { 3f, 6f, 9f });
+
+            // StartWaves는 WaveDatabase를 요구하므로, 점프 로직 검증에 필요한 런타임 상태만 직접 만든다.
+            SetPrivateField(_director, "_isRunning", true);
+            SetPrivateField(_director, "_timelineElapsedSeconds", 0f);
+
+            var fired = GetPrivateField<List<bool>>(_director, "_miniBossMarkFired");
+            fired.Clear();
+            fired.AddRange(new[] { false, false, false });
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(_directorGo);
+        }
+
+        [Test]
+        public void SkipToBoss_SuppressesSkippedMiniBossMarks()
+        {
+            int markCount = 0;
+            _director.OnMiniBossMarkReached += _ => markCount++;
+
+            bool entered = _director.SkipToBossPhase();
+
+            Assert.That(entered, Is.True, "보스 페이즈에 진입해야 한다.");
+            Assert.That(markCount, Is.EqualTo(0), "건너뛴 미니 보스 마크는 발행되지 않아야 한다.");
+            Assert.That(_director.IsBossPhase, Is.True);
+            Assert.That(_director.TimelineElapsedSeconds, Is.EqualTo(BossMinuteMark * 60f).Within(0.01f));
+        }
+
+        // 억제가 '실제로 무언가를 막고 있는지' 확인하는 대조 테스트.
+        // 이게 없으면 마크가 애초에 발행되지 않는 경우와 구분할 수 없다.
+        [Test]
+        public void SkipWithFireSkippedMarks_FiresEveryPassedMark()
+        {
+            var fired = new List<float>();
+            _director.OnMiniBossMarkReached += minutes => fired.Add(minutes);
+
+            _director.SkipTimelineTo(BossMinuteMark * 60f, fireSkippedMarks: true);
+
+            Assert.That(fired, Is.EqualTo(new[] { 3f, 6f, 9f }));
+        }
+
+        [Test]
+        public void SkipTimelineTo_DoesNotRewind()
+        {
+            _director.SkipTimelineTo(300f);
+
+            _director.SkipTimelineTo(100f);
+
+            Assert.That(_director.TimelineElapsedSeconds, Is.EqualTo(300f).Within(0.01f));
+        }
+
+        [Test]
+        public void SkipTimelineTo_BeforeBossMark_DoesNotEnterBossPhase()
+        {
+            _director.SkipTimelineTo(5f * 60f);
+
+            Assert.That(_director.IsBossPhase, Is.False);
+            Assert.That(_director.TimelineElapsedSeconds, Is.EqualTo(300f).Within(0.01f));
+        }
+
+        // 5분으로 점프하면 3분 마크만 소진되고, 6·9분은 남아 있어야 한다.
+        [Test]
+        public void PartialSkip_OnlySuppressesMarksBeforeTarget()
+        {
+            _director.SkipTimelineTo(5f * 60f);
+
+            var fired = GetPrivateField<List<bool>>(_director, "_miniBossMarkFired");
+            Assert.That(fired[0], Is.True, "3분 마크는 소진되어야 한다.");
+            Assert.That(fired[1], Is.False, "6분 마크는 남아 있어야 한다.");
+            Assert.That(fired[2], Is.False, "9분 마크는 남아 있어야 한다.");
+        }
+
+        [Test]
+        public void SkipToBoss_WhenNotRunning_DoesNothing()
+        {
+            SetPrivateField(_director, "_isRunning", false);
+
+            Assert.That(_director.SkipToBossPhase(), Is.False);
+            Assert.That(_director.IsBossPhase, Is.False);
+        }
+
+        [Test]
+        public void SkipToBoss_Twice_SecondCallIsNoOp()
+        {
+            Assert.That(_director.SkipToBossPhase(), Is.True);
+
+            Assert.That(_director.SkipToBossPhase(), Is.False, "이미 보스 페이즈면 다시 진입하지 않아야 한다.");
+        }
+
+        [Test]
+        public void SkipToBoss_WithoutBossMark_DoesNothing()
+        {
+            SetPrivateField(_director, "_bossMinuteMark", 0f);
+
+            Assert.That(_director.SkipToBossPhase(), Is.False);
+            Assert.That(_director.IsBossPhase, Is.False);
+        }
+
+        private static void SetPrivateField(object target, string fieldName, object value)
+        {
+            FieldInfo field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(field, Is.Not.Null, $"필드 {fieldName}를 찾지 못했습니다.");
+            field.SetValue(target, value);
+        }
+
+        private static T GetPrivateField<T>(object target, string fieldName)
+        {
+            FieldInfo field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(field, Is.Not.Null, $"필드 {fieldName}를 찾지 못했습니다.");
+            return (T)field.GetValue(target);
+        }
+    }
+}

--- a/project1/Assets/Tests/EditMode/WaveTimelineSkipTests.cs.meta
+++ b/project1/Assets/Tests/EditMode/WaveTimelineSkipTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4ff5d33f80e053545be4bd8767fb265a


### PR DESCRIPTION
## 📌 Summary

PC 시연을 위한 디버그 치트를 추가합니다. 현재 런은 기획대로 **10분 + 보스**라 시연 부스에서 그대로 굴릴 수 없고(관람자 주의는 2~3분), 시연 도중 사망하면 흐름이 끊깁니다. 밸런스 패스에서 보스 패턴을 반복 확인할 때도 같은 비용이 매번 발생합니다.

게임 기능이 아니라 **시연·개발 인프라**이며, 출시 빌드에는 포함되지 않습니다.

조사해보니 6종 중 **5종은 이미 있는 public API 배선**이었고, 실제로 새 코드가 필요한 건 보스 구간 점프 하나뿐이었습니다.

Closes #111

---

## 🔧 Changes

### 신규 구현 — 타임라인 점프 (`WaveCombatDirector`)

`TimelineElapsedSeconds`가 읽기 전용 getter라 보스 구간으로 건너뛸 방법이 없었습니다. `SkipTimelineTo(seconds, fireSkippedMarks)` / `SkipToBossPhase()` / `BossMinuteMark` 게터를 추가했습니다.

**건너뛴 미니 보스 마크는 기본적으로 발행 없이 소진 처리합니다.** 챕터 1은 미니 보스 마크가 3·6·9분이고 보스가 10분이라, 억제하지 않으면 점프 시 `CheckTimelineMarks`가 세 마크를 같은 프레임에 발행해 미니 보스 3마리가 한꺼번에 쏟아집니다. 시연에서 필요한 건 깨끗한 보스전이므로 억제가 기본이고, 미니 보스 자체를 확인하려면 `fireSkippedMarks: true`로 부릅니다.

되감기는 지원하지 않습니다 — 이미 발행된 마크를 취소할 방법이 없어 되감으면 같은 마크가 두 번 발행되거나 보스 페이즈가 어긋난 채 남습니다.

### 치트 실행부

| 키 | 치트 | 구현 |
|---|---|---|
| F1 | 무적 토글 | `PlayerHealth.SetInvincible` |
| F2 | 즉시 레벨업 | `AddExperience(임계치 - 현재 + 1)` — 정확히 1레벨만 오르게 |
| F3 | 적 일괄 제거 | `EnemyHealth.Kill` |
| F4 | 강신 즉시 발동 | `AddGauge(Max)` + `TryActivate` |
| F5 | 강신 슬롯 지급 | 씬에서 미장착 어빌리티 탐색 후 `TryAddAbility` |
| F6 | 보스 구간 점프 | `SkipToBossPhase` (신규) |
| F7 | 안내 표시 토글 | 오버레이 |

- `GameplayInputGate`와 같은 **자가 부트스트랩** 패턴이라 씬 파일에 시연용 오브젝트가 커밋되지 않습니다.
- 씬 전환 시 참조를 재해석하고 **무적을 자동 해제**합니다 — 시연자가 껐다고 착각하는 편이 더 위험하기 때문입니다.

### 상태 표시 오버레이

좌상단에 키 목록과 무적 상태를 표시합니다. 발표자가 무적을 켜둔 걸 잊고 "이 정도 난이도입니다"라고 설명하면 시연 자체가 거짓이 되므로, 켜져 있는 동안 눈에 띄게 경고합니다. `sortingOrder` 1100으로 페이드(1000)보다 위입니다.

### 출시 빌드 유출 방지

실행부 2개 파일(`DemoCheatController`, `DemoCheatOverlay`)을 `#if UNITY_EDITOR || DEVELOPMENT_BUILD`로 **파일 전체** 감쌌습니다. 클래스 선언까지 제외해야 다른 코드가 실수로 참조해 출시 빌드를 깨뜨리는 일이 없습니다.

키 매핑(`DemoCheatAction` / `DemoCheatBindings`)만 가드 밖에 둡니다 — 실행 능력이 없는 자료구조이고, EditMode 테스트가 참조해야 하기 때문입니다. 이 때문에 실행부를 문서 주석에서 언급할 때 `see cref`가 아니라 `<c>`를 썼습니다.

---

## 🧪 How to Test

1. `Assets/SampleScene.unity`를 열고 플레이합니다.
2. 좌상단에 치트 안내 오버레이가 뜨는지 확인합니다.
3. **F1** — 무적이 켜지고 상단에 붉은 `● 무적 ON` 경고가 뜨는지 확인합니다. 다시 누르면 사라집니다.
4. **F2** — 레벨이 1 오르고 스킬 선택 UI가 뜨는지 확인합니다.
5. **F6** — 타임라인이 600초로 점프하며 보스(`Boss_CorruptedMountainKing`)가 등장하고, **미니 보스가 함께 쏟아지지 않는지** 확인합니다.
6. 타이틀 씬에서 F1~F6을 눌러 아무 일도 일어나지 않는지(참조 부재로 무시) 확인합니다.

### 검증 결과

- **EditMode 228개 통과 / 0 실패** (기존 220 + 신규 8)
- 에디터 실동작: 자가 부트스트랩 OK / 무적 토글 / 레벨업 1→2(선택창 열림) / 적 4→0 / 보스 점프 8.0s→600.0s로 보스 소환 확인
- 미니 보스 억제 **대조 검증**: `fireSkippedMarks: true` → 마크 3건·씬 적 4(미니보스 3 + 보스), `false` → 마크 0건·씬 적 1(보스만)
- 오버레이: `sortingOrder` 1100, 7개 항목 렌더 + 무적 해제 시 경고가 `display=None`으로 숨는 것까지 확인
- 런타임 에러 0건

---

## ✅ Checklist

- [x] 테스트 코드 작성 (`DemoCheatBindingsTests` 8종 — 키/치트 중복, 전체 치트 매핑 커버리지, 라벨 누락, 역방향 조회)
- [x] 관련 이슈 연결 (#111)
- [x] 불필요한 코드 제거

---

## 리뷰 시 봐주셨으면 하는 점

1. **⚠️ DoD 중 "출시 빌드 미포함"은 구조적으로만 확인했고 실제 릴리즈 빌드는 뽑지 않았습니다.** 에디터에서는 `UNITY_EDITOR`가 항상 켜져 있어 에디터 안에서 검증할 방법이 없습니다. 확인한 건 ① 실행부가 파일 전체 가드 ② 가드 밖에서 실행부를 참조하는 코드 0건, 두 가지입니다. 데모 플랜의 PC 빌드 단계에서 함께 확인하면 됩니다.
2. **키 배치(F1~F7)** — 게임 입력(스와이프/더블탭)과 겹치지 않는 기능 키를 골랐는데, 시연 시 실제로 누르기 편한 배열인지 봐주세요.
3. **미니 보스 억제를 기본값으로 둔 판단** — 시연 목적에는 맞지만, 미니 보스 동작을 확인하고 싶을 때 `fireSkippedMarks: true`를 키로 노출할지는 열어뒀습니다.
4. **치트 사용 시 `RunStats` 오염** — 무적·즉사 치트를 쓰면 결과 화면의 생존 시간·처치 수가 실제 플레이를 반영하지 않습니다. 시연 목적상 허용했으나 인지가 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)