### PR TITLE
feat: 적 첫 등장 연출 — 이름표 배너 + 대상 화살표 (#70)

### DIFF
--- a/project1/Assets/Scripts/Combat/EnemyIntroductionTracker.cs
+++ b/project1/Assets/Scripts/Combat/EnemyIntroductionTracker.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 런(run) 안에서 적 종류별 '첫 등장'을 한 번만 통과시키는 기록기(#70).
+    ///
+    /// 등장 연출은 "새 적이 나왔다"를 알리는 장치라 두 번째부터는 소음이다. 스폰은 초당 여러 번
+    /// 일어나므로 판정은 호출부가 아니라 여기서 원자적으로 끝낸다 —
+    /// <see cref="TryMarkIntroduced"/>는 '조회 후 기록'을 한 번에 처리해 같은 종류가 같은 프레임에
+    /// 두 마리 스폰돼도 연출이 두 번 뜨지 않는다.
+    ///
+    /// MonoBehaviour에 의존하지 않는 순수 C# 클래스다(CLAUDE.md 테스트 용이성 규칙).
+    /// </summary>
+    public sealed class EnemyIntroductionTracker
+    {
+        // 종류 식별 키(보통 MonsterData 에셋). 인스턴스가 아니라 종류 단위로 기록해야
+        // 풀에서 재사용된 같은 종류의 적이 다시 연출을 띄우지 않는다.
+        private readonly HashSet<object> _introduced = new HashSet<object>();
+
+        /// <summary>이번 런에서 지금까지 소개된 적 종류 수.</summary>
+        public int IntroducedCount => _introduced.Count;
+
+        /// <summary>
+        /// 이 종류가 이번 런에서 처음이면 기록하고 true를 반환한다(= 연출을 재생해야 한다).
+        /// 이미 소개했거나 키가 null이면 false.
+        /// </summary>
+        public bool TryMarkIntroduced(object speciesKey)
+        {
+            if (speciesKey == null)
+            {
+                return false;
+            }
+
+            return _introduced.Add(speciesKey);
+        }
+
+        /// <summary>이 종류가 이미 소개되었는지 조회한다(기록하지 않음).</summary>
+        public bool IsIntroduced(object speciesKey)
+        {
+            return speciesKey != null && _introduced.Contains(speciesKey);
+        }
+
+        /// <summary>새 런 시작 시 호출해 기록을 비운다. 다음 런에서는 모든 적이 다시 처음이 된다.</summary>
+        public void Reset()
+        {
+            _introduced.Clear();
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/EnemyIntroductionTracker.cs.meta
+++ b/project1/Assets/Scripts/Combat/EnemyIntroductionTracker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5e5adffb723a4f24a9300627efbdcb66
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/project1/Assets/Scripts/Combat/WaveCombatDirector.cs
+++ b/project1/Assets/Scripts/Combat/WaveCombatDirector.cs
@@ -107,6 +107,13 @@ namespace Mukseon.Gameplay.Combat
         /// <summary>지정 분 마크 도달 시 1회 발행. 인자는 도달한 분(mark) 값. 미니 보스 시스템(#71)이 구독.</summary>
         public event Action<float> OnMiniBossMarkReached;
 
+        /// <summary>
+        /// 일반 적 1마리를 스폰한 직후 발행. 인자: (스폰된 적, 종류 데이터 — 없으면 null).
+        /// 적 첫 등장 연출(#70)이 구독해 '이 종류가 이번 런에서 처음인가'를 판정한다.
+        /// 미니 보스(#71)·보스(#37)는 각자의 스포너가 소환하므로 여기서는 발행되지 않는다.
+        /// </summary>
+        public event Action<EnemyHealth, MonsterData> OnEnemySpawned;
+
         /// <summary>보스 마크 도달 시 1회 발행. 일반 스포닝은 이 시점에 중단된다. 보스 시스템(#37)이 구독.</summary>
         public event Action OnBossPhaseStarted;
 
@@ -555,6 +562,9 @@ namespace Mukseon.Gameplay.Combat
             _aliveEnemies.Add(spawnedEnemy);
             _enemySpeciesKey[spawnedEnemy] = runtimeEntry.SpeciesKey;
             IncrementAliveCount(runtimeEntry.SpeciesKey);
+
+            // 추적 등록을 모두 끝낸 뒤에 알린다 — 구독자가 이 적을 즉시 조회해도 상태가 일관되도록.
+            OnEnemySpawned?.Invoke(spawnedEnemy, runtimeEntry.Entry.MonsterData);
 
             NotifyRemainingEnemyCountChanged();
         }

--- a/project1/Assets/Scripts/Combat/WaveCombatDirector.cs
+++ b/project1/Assets/Scripts/Combat/WaveCombatDirector.cs
@@ -108,11 +108,15 @@ namespace Mukseon.Gameplay.Combat
         public event Action<float> OnMiniBossMarkReached;
 
         /// <summary>
-        /// 일반 적 1마리를 스폰한 직후 발행. 인자: (스폰된 적, 종류 데이터 — 없으면 null).
+        /// 일반 적 1마리를 스폰한 직후 발행. 인자: (스폰된 적, 이 적을 소환한 웨이브 엔트리).
         /// 적 첫 등장 연출(#70)이 구독해 '이 종류가 이번 런에서 처음인가'를 판정한다.
         /// 미니 보스(#71)·보스(#37)는 각자의 스포너가 소환하므로 여기서는 발행되지 않는다.
+        ///
+        /// 종류 판별 키·표시 이름은 반드시 엔트리(<see cref="WaveEnemySpawnEntry.SpeciesKey"/>,
+        /// <see cref="WaveEnemySpawnEntry.DisplayName"/>)에서 읽는다 — 적 인스턴스에서 다시 유추하면
+        /// 풀에서 재사용된 개체가 들고 있는 이전 종류의 MonsterData를 읽어 스포너의 판단과 어긋난다.
         /// </summary>
-        public event Action<EnemyHealth, MonsterData> OnEnemySpawned;
+        public event Action<EnemyHealth, WaveEnemySpawnEntry> OnEnemySpawned;
 
         /// <summary>보스 마크 도달 시 1회 발행. 일반 스포닝은 이 시점에 중단된다. 보스 시스템(#37)이 구독.</summary>
         public event Action OnBossPhaseStarted;
@@ -564,7 +568,7 @@ namespace Mukseon.Gameplay.Combat
             IncrementAliveCount(runtimeEntry.SpeciesKey);
 
             // 추적 등록을 모두 끝낸 뒤에 알린다 — 구독자가 이 적을 즉시 조회해도 상태가 일관되도록.
-            OnEnemySpawned?.Invoke(spawnedEnemy, runtimeEntry.Entry.MonsterData);
+            OnEnemySpawned?.Invoke(spawnedEnemy, runtimeEntry.Entry);
 
             NotifyRemainingEnemyCountChanged();
         }
@@ -732,6 +736,26 @@ namespace Mukseon.Gameplay.Combat
             }
 
             NotifyRemainingEnemyCountChanged();
+        }
+
+        /// <summary>
+        /// 살아있는 적에게 <b>현재 배정된</b> 종류 판별 키를 조회한다(#70).
+        ///
+        /// 스폰 시 <see cref="WaveEnemySpawnEntry.SpeciesKey"/>로 등록되고 사망·정리 시 제거되므로,
+        /// 풀에서 다른 종류로 재사용된 개체는 자동으로 새 키를 돌려준다. 적 인스턴스에서 종류를 유추하는
+        /// 방식(MonsterData/표시 이름)과 달리 스포너의 판단과 항상 일치한다.
+        /// </summary>
+        /// <returns>등록되어 있으면 true. 이미 죽었거나 이 디렉터가 소환하지 않은 적이면 false.</returns>
+        public bool TryGetSpeciesKey(EnemyHealth enemy, out object speciesKey)
+        {
+            // Dictionary는 null 키를 허용하지 않는다. 파괴된 오브젝트도 == null 이 true라 여기서 걸러진다.
+            if (enemy == null)
+            {
+                speciesKey = null;
+                return false;
+            }
+
+            return _enemySpeciesKey.TryGetValue(enemy, out speciesKey);
         }
 
         private int GetAliveCount(object speciesKey)

--- a/project1/Assets/Scripts/Combat/WaveDatabase.cs
+++ b/project1/Assets/Scripts/Combat/WaveDatabase.cs
@@ -49,6 +49,27 @@ namespace Mukseon.Gameplay.Combat
             }
         }
 
+        /// <summary>
+        /// UI 표시용 종류 이름. <see cref="SpeciesKey"/>와 <b>같은 우선순위</b>(MonsterData → EnemyPrefab → EnemyType)로
+        /// 결정해, 키가 가리키는 종류와 화면에 뜨는 이름이 어긋나지 않게 한다.
+        ///
+        /// 적 인스턴스(<see cref="EnemyHealth.DisplayName"/>)에서 읽지 않는 이유:
+        /// <see cref="EnemyHealth.ApplyMonsterData"/>는 인자가 null이면 기존 값을 유지하므로,
+        /// MonsterData가 없는 엔트리에 풀에서 재사용된 개체가 배정되면 이전 종류의 이름을 그대로 반환한다.
+        /// </summary>
+        public string DisplayName
+        {
+            get
+            {
+                if (_monsterData != null)
+                {
+                    return _monsterData.DisplayName;
+                }
+
+                return _enemyPrefab != null ? _enemyPrefab.name : EnemyType;
+            }
+        }
+
         public bool IsValid(out string reason)
         {
             if (_monsterData != null)

--- a/project1/Assets/Scripts/UI/EnemyIntroductionPresenter.cs
+++ b/project1/Assets/Scripts/UI/EnemyIntroductionPresenter.cs
@@ -1,0 +1,286 @@
+using System.Collections.Generic;
+using Mukseon.Core;
+using Mukseon.Gameplay.Combat;
+using Mukseon.UI;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UIElements;
+
+namespace Mukseon.Gameplay.UI
+{
+    /// <summary>
+    /// 적 종류가 이번 런에서 처음 등장할 때 이름표를 띄우고, 그 개체를 화살표로 가리키는 연출(#70).
+    ///
+    /// 챕터 1은 10분 동안 9종이 순차 투입되는데, 새 적이 조용히 섞여 들어오면 플레이어는 죽고 나서야
+    /// "저건 뭐였지"를 알게 된다. 이름표만으로는 화면의 수십 마리 중 누가 새 적인지 못 찾으므로
+    /// 상단 배너와 해당 개체 위 화살표를 <b>함께</b> 띄운다(표시는 <see cref="EnemyIntroductionView"/>).
+    ///
+    /// <see cref="GameplayHudBootstrapper"/>와 같은 자가 부트스트랩 방식이다 — 씬에 배치할 필요 없이
+    /// 스스로 생성되고, <see cref="WaveCombatDirector"/>를 런타임에 찾아 구독한다.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public sealed class EnemyIntroductionPresenter : MonoBehaviour
+    {
+        private sealed class PendingIntroduction
+        {
+            public string DisplayName;
+            public EnemyHealth Enemy;
+            public object SpeciesKey;
+        }
+
+        private const string RootObjectName = "EnemyIntroductionRuntime";
+
+        // 인게임 HUD(500) 위, 결과(600)·조작 안내(700) 아래. 배너는 상단 중앙이라
+        // 화면 중앙에 뜨는 레벨업 카드와 시각적으로 겹치지 않는다.
+        private const int BannerSortingOrder = 550;
+
+        private const float HoldSeconds = 1.8f;
+        private const float FadeSeconds = 0.5f;
+        private const float TotalSeconds = HoldSeconds + FadeSeconds;
+
+        // 폴링 상한은 HUD와 같은 이유 — 비게임플레이 씬(타이틀/캐릭터선택)에는 웨이브 디렉터가 없어
+        // 상한이 없으면 0.5초마다 Find를 영원히 반복한다.
+        private const int MaxResolveRetries = 6;
+        private const float ResolveIntervalSeconds = 0.5f;
+
+        private readonly EnemyIntroductionTracker _tracker = new EnemyIntroductionTracker();
+        private readonly List<PendingIntroduction> _queue = new List<PendingIntroduction>(4);
+
+        private WaveCombatDirector _director;
+        private Camera _cachedCamera;
+        private float _resolveRetryTimer;
+        private int _resolveRetryCount;
+        private bool _stopPolling;
+
+        private UIDocument _document;
+        private PanelSettings _panelSettings;
+        private EnemyIntroductionView _view;
+
+        private PendingIntroduction _current;
+        private float _remainingSeconds;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void EnsurePresenter()
+        {
+            if (SceneObjectFinder.Find<EnemyIntroductionPresenter>() != null)
+            {
+                return;
+            }
+
+            var root = new GameObject(RootObjectName);
+            root.AddComponent<EnemyIntroductionPresenter>();
+        }
+
+        private void Awake()
+        {
+            DontDestroyOnLoad(gameObject);
+            SceneManager.sceneLoaded += HandleSceneLoaded;
+            EnsureUi();
+            HandleSceneLoaded();
+        }
+
+        private void OnDestroy()
+        {
+            SceneManager.sceneLoaded -= HandleSceneLoaded;
+            Unsubscribe();
+
+            // PanelSettings는 에셋이 아니라 런타임 인스턴스라 직접 파기해야 누수되지 않는다.
+            if (_panelSettings != null)
+            {
+                Destroy(_panelSettings);
+                _panelSettings = null;
+            }
+        }
+
+        private void Update()
+        {
+            if (!_stopPolling && _director == null)
+            {
+                _resolveRetryTimer -= Time.unscaledDeltaTime;
+                if (_resolveRetryTimer <= 0f)
+                {
+                    _resolveRetryTimer = ResolveIntervalSeconds;
+                    TryResolveDirector();
+
+                    _resolveRetryCount++;
+                    if (_resolveRetryCount >= MaxResolveRetries)
+                    {
+                        _stopPolling = true;
+                    }
+                }
+            }
+
+            // 레벨업 정지 중에도 배너가 흘러가도록 unscaled를 쓴다(HUD 플로팅 텍스트와 동일).
+            TickPresentation(Time.unscaledDeltaTime);
+        }
+
+        private void HandleSceneLoaded(Scene scene, LoadSceneMode mode)
+        {
+            HandleSceneLoaded();
+        }
+
+        private void HandleSceneLoaded()
+        {
+            Unsubscribe();
+            _director = null;
+            _cachedCamera = Camera.main;
+            _resolveRetryTimer = 0f;
+            _resolveRetryCount = 0;
+            _stopPolling = false;
+
+            // ResetRun이 배너를 숨기므로 UI가 먼저 존재해야 한다.
+            EnsureUi();
+            // 씬이 바뀌면 새 런이다 — 이전 런의 등장 기록과 대기열을 모두 버린다.
+            ResetRun();
+            TryResolveDirector();
+        }
+
+        private void TryResolveDirector()
+        {
+            if (_cachedCamera == null)
+            {
+                _cachedCamera = Camera.main;
+            }
+
+            if (_director != null)
+            {
+                return;
+            }
+
+            _director = SceneObjectFinder.Find<WaveCombatDirector>();
+            if (_director == null)
+            {
+                return;
+            }
+
+            _director.OnEnemySpawned += HandleEnemySpawned;
+            _director.OnWaveStarted += HandleWaveStarted;
+        }
+
+        private void Unsubscribe()
+        {
+            if (_director == null)
+            {
+                return;
+            }
+
+            _director.OnEnemySpawned -= HandleEnemySpawned;
+            _director.OnWaveStarted -= HandleWaveStarted;
+        }
+
+        // 1번 웨이브 시작 = 타임라인이 처음부터 다시 도는 것(StartWaves)이므로 등장 기록을 초기화한다.
+        private void HandleWaveStarted(int waveNumber, WaveDefinition wave)
+        {
+            if (waveNumber <= 1)
+            {
+                ResetRun();
+            }
+        }
+
+        private void HandleEnemySpawned(EnemyHealth enemy, MonsterData monsterData)
+        {
+            if (enemy == null)
+            {
+                return;
+            }
+
+            object speciesKey = ResolveSpeciesKey(enemy, monsterData);
+            if (!_tracker.TryMarkIntroduced(speciesKey))
+            {
+                return;
+            }
+
+            _queue.Add(new PendingIntroduction
+            {
+                DisplayName = monsterData != null ? monsterData.DisplayName : enemy.DisplayName,
+                Enemy = enemy,
+                SpeciesKey = speciesKey
+            });
+        }
+
+        private void ResetRun()
+        {
+            _tracker.Reset();
+            _queue.Clear();
+            _current = null;
+            _remainingSeconds = 0f;
+            _view?.Hide();
+        }
+
+        private void TickPresentation(float deltaTime)
+        {
+            if (_current == null)
+            {
+                if (_queue.Count == 0)
+                {
+                    return;
+                }
+
+                _current = _queue[0];
+                _queue.RemoveAt(0);
+                _remainingSeconds = TotalSeconds;
+                _view.ShowBanner(_current.DisplayName);
+            }
+
+            _remainingSeconds -= deltaTime;
+            if (_remainingSeconds <= 0f)
+            {
+                _current = null;
+                _view.Hide();
+                return;
+            }
+
+            // 마지막 FadeSeconds 구간에서만 서서히 사라진다.
+            _view.SetOpacity(_remainingSeconds / FadeSeconds);
+            UpdateMarker();
+        }
+
+        /// <summary>
+        /// 소개 중인 개체 머리 위로 화살표를 옮긴다. 개체가 죽었거나 풀에서 다른 종류로 재사용됐으면
+        /// (SpeciesKey 불일치) 화살표만 감추고 배너는 그대로 둔다.
+        /// </summary>
+        private void UpdateMarker()
+        {
+            EnemyHealth enemy = _current.Enemy;
+
+            // 키 비교는 Equals — 폴백 키가 문자열이면 매번 새 인스턴스라 참조 비교로는 항상 어긋난다.
+            bool trackable = enemy != null && enemy.IsAlive &&
+                             Equals(ResolveSpeciesKey(enemy, enemy.MonsterData), _current.SpeciesKey);
+            if (!trackable)
+            {
+                _view.HideMarker();
+                return;
+            }
+
+            _view.UpdateMarker(_cachedCamera, enemy.transform.position);
+        }
+
+        /// <summary>
+        /// 종류 식별 키. MonsterData가 원칙이고, 없는 엔트리(프리팹만 지정)는 표시 이름으로 대체한다 —
+        /// 인스턴스를 키로 쓰면 풀에서 재사용될 때마다 '처음'이 되어 연출이 반복된다.
+        /// </summary>
+        private static object ResolveSpeciesKey(EnemyHealth enemy, MonsterData monsterData)
+        {
+            return monsterData != null ? monsterData : (object)enemy.DisplayName;
+        }
+
+        private void EnsureUi()
+        {
+            if (_document != null)
+            {
+                return;
+            }
+
+            _panelSettings = ScreenUiFactory.CreatePanelSettings(BannerSortingOrder);
+            _document = gameObject.AddComponent<UIDocument>();
+            _document.panelSettings = _panelSettings;
+
+            VisualElement root = _document.rootVisualElement;
+            root.style.flexGrow = 1f;
+            // 루트가 입력을 먹으면 그 아래 전투 스와이프가 막힌다. 연출은 표시 전용이다.
+            root.pickingMode = PickingMode.Ignore;
+
+            _view = new EnemyIntroductionView(root);
+        }
+    }
+}

--- a/project1/Assets/Scripts/UI/EnemyIntroductionPresenter.cs
+++ b/project1/Assets/Scripts/UI/EnemyIntroductionPresenter.cs
@@ -177,14 +177,16 @@ namespace Mukseon.Gameplay.UI
             }
         }
 
-        private void HandleEnemySpawned(EnemyHealth enemy, MonsterData monsterData)
+        private void HandleEnemySpawned(EnemyHealth enemy, WaveEnemySpawnEntry entry)
         {
-            if (enemy == null)
+            if (enemy == null || entry == null)
             {
                 return;
             }
 
-            object speciesKey = ResolveSpeciesKey(enemy, monsterData);
+            // 키와 이름은 스포너와 같은 기준(엔트리)에서만 읽는다 — 적 인스턴스에서 유추하면
+            // 풀에서 재사용된 개체가 들고 있는 이전 종류의 MonsterData를 읽어 판정이 어긋난다.
+            object speciesKey = entry.SpeciesKey;
             if (!_tracker.TryMarkIntroduced(speciesKey))
             {
                 return;
@@ -192,7 +194,7 @@ namespace Mukseon.Gameplay.UI
 
             _queue.Add(new PendingIntroduction
             {
-                DisplayName = monsterData != null ? monsterData.DisplayName : enemy.DisplayName,
+                DisplayName = entry.DisplayName,
                 Enemy = enemy,
                 SpeciesKey = speciesKey
             });
@@ -243,9 +245,12 @@ namespace Mukseon.Gameplay.UI
         {
             EnemyHealth enemy = _current.Enemy;
 
+            // 지금 이 개체에 배정된 종류는 디렉터의 등록부에서 읽는다 — 사망·정리 시 등록이 지워지고
+            // 재사용 시 새 키로 덮이므로, 인스턴스에서 유추하는 것과 달리 스포너의 판단과 항상 일치한다.
             // 키 비교는 Equals — 폴백 키가 문자열이면 매번 새 인스턴스라 참조 비교로는 항상 어긋난다.
-            bool trackable = enemy != null && enemy.IsAlive &&
-                             Equals(ResolveSpeciesKey(enemy, enemy.MonsterData), _current.SpeciesKey);
+            bool trackable = enemy != null && enemy.IsAlive && _director != null &&
+                             _director.TryGetSpeciesKey(enemy, out object currentKey) &&
+                             Equals(currentKey, _current.SpeciesKey);
             if (!trackable)
             {
                 _view.HideMarker();
@@ -253,15 +258,6 @@ namespace Mukseon.Gameplay.UI
             }
 
             _view.UpdateMarker(_cachedCamera, enemy.transform.position);
-        }
-
-        /// <summary>
-        /// 종류 식별 키. MonsterData가 원칙이고, 없는 엔트리(프리팹만 지정)는 표시 이름으로 대체한다 —
-        /// 인스턴스를 키로 쓰면 풀에서 재사용될 때마다 '처음'이 되어 연출이 반복된다.
-        /// </summary>
-        private static object ResolveSpeciesKey(EnemyHealth enemy, MonsterData monsterData)
-        {
-            return monsterData != null ? monsterData : (object)enemy.DisplayName;
         }
 
         private void EnsureUi()

--- a/project1/Assets/Scripts/UI/EnemyIntroductionPresenter.cs.meta
+++ b/project1/Assets/Scripts/UI/EnemyIntroductionPresenter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6754a31d92cb4810a3fde96508e91704
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/project1/Assets/Scripts/UI/EnemyIntroductionView.cs
+++ b/project1/Assets/Scripts/UI/EnemyIntroductionView.cs
@@ -1,0 +1,137 @@
+using Mukseon.UI;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Mukseon.Gameplay.UI
+{
+    /// <summary>
+    /// 적 첫 등장 연출의 표시 담당(#70). 상단 이름표 배너와 대상 개체를 가리키는 화살표를 소유한다.
+    ///
+    /// 언제 무엇을 띄울지는 <see cref="EnemyIntroductionPresenter"/>가 정하고, 이 클래스는
+    /// '어떻게 보이는가'만 안다. MonoBehaviour가 아니므로 UIDocument 수명은 프레젠터가 관리한다.
+    /// </summary>
+    internal sealed class EnemyIntroductionView
+    {
+        private static class Strings
+        {
+            public const string Caption = "새로운 적";
+            public const string Marker = "▼";
+        }
+
+        // 화살표를 적 머리 위로 띄우는 월드 오프셋. HUD 방향 오브(1.6)보다 위에 둬서 겹치지 않게 한다.
+        private const float MarkerWorldYOffset = 2.3f;
+
+        private readonly VisualElement _root;
+        private readonly VisualElement _banner;
+        private readonly Label _nameLabel;
+        private readonly Label _marker;
+
+        public EnemyIntroductionView(VisualElement root)
+        {
+            _root = root;
+            _banner = BuildBanner(root, out _nameLabel);
+            _marker = BuildMarker(root);
+        }
+
+        /// <summary>배너에 적 이름을 넣고 표시한다. 화살표는 위치가 정해질 때까지 감춰 둔다.</summary>
+        public void ShowBanner(string displayName)
+        {
+            _nameLabel.text = displayName;
+            _banner.style.display = DisplayStyle.Flex;
+            _banner.style.opacity = 1f;
+            _marker.style.display = DisplayStyle.None;
+        }
+
+        /// <summary>배너와 화살표를 모두 감춘다.</summary>
+        public void Hide()
+        {
+            _banner.style.display = DisplayStyle.None;
+            _marker.style.display = DisplayStyle.None;
+        }
+
+        /// <summary>페이드용 불투명도(0~1)를 배너와 화살표에 함께 적용한다.</summary>
+        public void SetOpacity(float opacity)
+        {
+            float clamped = Mathf.Clamp01(opacity);
+            _banner.style.opacity = clamped;
+            _marker.style.opacity = clamped;
+        }
+
+        public void HideMarker()
+        {
+            _marker.style.display = DisplayStyle.None;
+        }
+
+        /// <summary>
+        /// 화살표를 월드 좌표 위(<see cref="MarkerWorldYOffset"/>만큼 상단)로 옮긴다.
+        /// 카메라 뒤로 넘어가면 감춘다.
+        /// </summary>
+        public void UpdateMarker(Camera camera, Vector3 worldPosition)
+        {
+            if (camera == null)
+            {
+                HideMarker();
+                return;
+            }
+
+            Vector3 screenPoint = camera.WorldToScreenPoint(worldPosition + Vector3.up * MarkerWorldYOffset);
+            if (screenPoint.z <= 0f)
+            {
+                HideMarker();
+                return;
+            }
+
+            // UI Toolkit 패널 좌표는 좌상단 원점이라 스크린 y를 뒤집는다(HUD 월드 요소와 동일한 변환).
+            var flipped = new Vector2(screenPoint.x, Screen.height - screenPoint.y);
+            IPanel panel = _root?.panel;
+            Vector2 panelPos = panel != null ? RuntimePanelUtils.ScreenToPanel(panel, flipped) : flipped;
+
+            _marker.style.display = DisplayStyle.Flex;
+            _marker.style.left = panelPos.x;
+            _marker.style.top = panelPos.y;
+            _marker.style.translate = new Translate(Length.Percent(-50f), Length.Percent(-50f));
+        }
+
+        private static VisualElement BuildBanner(VisualElement root, out Label nameLabel)
+        {
+            var banner = new VisualElement();
+            banner.style.position = Position.Absolute;
+            banner.style.top = 96f;
+            banner.style.left = Length.Percent(50f);
+            banner.style.translate = new Translate(Length.Percent(-50f), 0f);
+            banner.style.paddingTop = 10f;
+            banner.style.paddingBottom = 12f;
+            banner.style.paddingLeft = 34f;
+            banner.style.paddingRight = 34f;
+            banner.style.alignItems = Align.Center;
+            banner.style.backgroundColor = ScreenUiFactory.CardFace;
+            banner.style.display = DisplayStyle.None;
+            banner.pickingMode = PickingMode.Ignore;
+            ScreenUiFactory.SetBorderRadius(banner, 8f);
+            root.Add(banner);
+
+            Label caption = ScreenUiFactory.Text(banner, Strings.Caption, 18, ScreenUiFactory.Seal);
+            caption.style.marginBottom = 2f;
+            caption.pickingMode = PickingMode.Ignore;
+
+            nameLabel = ScreenUiFactory.Text(banner, string.Empty, 34, ScreenUiFactory.Ink);
+            nameLabel.style.unityFontStyleAndWeight = FontStyle.Bold;
+            nameLabel.pickingMode = PickingMode.Ignore;
+
+            return banner;
+        }
+
+        private static Label BuildMarker(VisualElement root)
+        {
+            var marker = new Label(Strings.Marker);
+            marker.style.position = Position.Absolute;
+            marker.style.fontSize = 30f;
+            marker.style.color = ScreenUiFactory.Seal;
+            marker.style.unityTextAlign = TextAnchor.MiddleCenter;
+            marker.style.display = DisplayStyle.None;
+            marker.pickingMode = PickingMode.Ignore;
+            root.Add(marker);
+            return marker;
+        }
+    }
+}

--- a/project1/Assets/Scripts/UI/EnemyIntroductionView.cs.meta
+++ b/project1/Assets/Scripts/UI/EnemyIntroductionView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ec5990ab688e496bb0739ee3beb0c950
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/project1/Assets/Tests/EditMode/EnemyIntroductionTrackerTests.cs
+++ b/project1/Assets/Tests/EditMode/EnemyIntroductionTrackerTests.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using Mukseon.Gameplay.Combat;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Mukseon.Tests.EditMode
+{
+    /// <summary>
+    /// 적 첫 등장 기록기 검증(#70).
+    ///
+    /// 스폰은 초당 여러 번 일어나므로 '한 런에 한 번'이 깨지면 배너가 연달아 뜬다.
+    /// 특히 최소 유지 수를 채우는 라운드에서는 같은 종류가 연속으로 소환되므로,
+    /// 조회와 기록이 한 호출로 끝나는지가 핵심이다.
+    /// </summary>
+    public class EnemyIntroductionTrackerTests
+    {
+        private readonly List<MonsterData> _created = new List<MonsterData>();
+        private EnemyIntroductionTracker _tracker;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _tracker = new EnemyIntroductionTracker();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            for (int i = 0; i < _created.Count; i++)
+            {
+                Object.DestroyImmediate(_created[i]);
+            }
+
+            _created.Clear();
+        }
+
+        [Test]
+        public void FirstMark_ReturnsTrue()
+        {
+            MonsterData species = CreateSpecies();
+
+            Assert.That(_tracker.TryMarkIntroduced(species), Is.True);
+            Assert.That(_tracker.IntroducedCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void RepeatedMarks_SameSpecies_OnlyFirstPasses()
+        {
+            MonsterData species = CreateSpecies();
+
+            int passes = 0;
+            for (int i = 0; i < 10; i++)
+            {
+                if (_tracker.TryMarkIntroduced(species))
+                {
+                    passes++;
+                }
+            }
+
+            Assert.That(passes, Is.EqualTo(1), "같은 종류는 런 내 한 번만 통과해야 한다.");
+            Assert.That(_tracker.IntroducedCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void DifferentSpecies_AreTrackedIndependently()
+        {
+            MonsterData sonakssi = CreateSpecies();
+            MonsterData mangryang = CreateSpecies();
+
+            Assert.That(_tracker.TryMarkIntroduced(sonakssi), Is.True);
+            Assert.That(_tracker.TryMarkIntroduced(mangryang), Is.True, "다른 종류는 별개로 소개되어야 한다.");
+            Assert.That(_tracker.TryMarkIntroduced(sonakssi), Is.False);
+            Assert.That(_tracker.IntroducedCount, Is.EqualTo(2));
+        }
+
+        // MonsterData가 없는 엔트리는 표시 이름 문자열이 키가 된다(프리팹만 지정한 경우).
+        [Test]
+        public void StringKey_BehavesByValue()
+        {
+            Assert.That(_tracker.TryMarkIntroduced("Dokkaebibul"), Is.True);
+
+            // 매 호출마다 새 인스턴스가 되는 상황을 흉내낸다 — 값이 같으면 같은 종류로 봐야 한다.
+            string sameValue = string.Concat("Dokkaebi", "bul");
+            Assert.That(_tracker.TryMarkIntroduced(sameValue), Is.False);
+        }
+
+        [Test]
+        public void NullKey_IsIgnored()
+        {
+            Assert.That(_tracker.TryMarkIntroduced(null), Is.False);
+            Assert.That(_tracker.IsIntroduced(null), Is.False);
+            Assert.That(_tracker.IntroducedCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void IsIntroduced_DoesNotRecord()
+        {
+            MonsterData species = CreateSpecies();
+
+            Assert.That(_tracker.IsIntroduced(species), Is.False);
+            Assert.That(_tracker.IntroducedCount, Is.EqualTo(0), "조회만으로 기록되면 안 된다.");
+            Assert.That(_tracker.TryMarkIntroduced(species), Is.True);
+            Assert.That(_tracker.IsIntroduced(species), Is.True);
+        }
+
+        // 새 런(타이틀 → 재시작)에서는 모든 적이 다시 '처음'이어야 한다.
+        [Test]
+        public void Reset_ClearsRecord()
+        {
+            MonsterData species = CreateSpecies();
+            _tracker.TryMarkIntroduced(species);
+
+            _tracker.Reset();
+
+            Assert.That(_tracker.IntroducedCount, Is.EqualTo(0));
+            Assert.That(_tracker.TryMarkIntroduced(species), Is.True);
+        }
+
+        private MonsterData CreateSpecies()
+        {
+            MonsterData species = ScriptableObject.CreateInstance<MonsterData>();
+            _created.Add(species);
+            return species;
+        }
+    }
+}

--- a/project1/Assets/Tests/EditMode/EnemyIntroductionTrackerTests.cs.meta
+++ b/project1/Assets/Tests/EditMode/EnemyIntroductionTrackerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c513d5d6d8264c02b22d90015d0fc004
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/project1/Assets/Tests/EditMode/WaveDefinitionTests.cs
+++ b/project1/Assets/Tests/EditMode/WaveDefinitionTests.cs
@@ -2,11 +2,25 @@
 using System.Reflection;
 using Mukseon.Gameplay.Combat;
 using NUnit.Framework;
+using UnityEngine;
 
 namespace Mukseon.Tests.EditMode
 {
     public class WaveDefinitionTests
     {
+        private readonly List<Object> _created = new List<Object>();
+
+        [TearDown]
+        public void TearDown()
+        {
+            for (int i = 0; i < _created.Count; i++)
+            {
+                Object.DestroyImmediate(_created[i]);
+            }
+
+            _created.Clear();
+        }
+
         [Test]
         public void GetTotalMinAliveCount_SumsOnlyValidEntriesAndClampsNegatives()
         {
@@ -29,6 +43,75 @@ namespace Mukseon.Tests.EditMode
 
             // 음수는 0으로 클램프되고 null 항목은 무시되므로 3만 합산된다.
             Assert.That(wave.GetTotalMinAliveCount(), Is.EqualTo(3));
+        }
+
+        // 종류 판별 키와 표시 이름은 같은 우선순위(MonsterData → EnemyPrefab → EnemyType)로 결정되어야 한다.
+        // 둘이 어긋나면 '처음 보는 종류'로 판정한 적과 배너에 뜨는 이름이 서로 다른 적을 가리키게 된다(#70).
+        [Test]
+        public void SpeciesKeyAndDisplayName_PreferMonsterData()
+        {
+            var entry = new WaveEnemySpawnEntry();
+            MonsterData species = CreateMonsterData("Sonakssi_MonsterData", "손각시");
+            EnemyHealth prefab = CreatePrefab("Sonakssi_Prefab");
+
+            SetPrivateField(entry, "_monsterData", species);
+            SetPrivateField(entry, "_enemyPrefab", prefab);
+            SetPrivateField(entry, "_enemyType", "Sonakssi");
+
+            Assert.That(entry.SpeciesKey, Is.SameAs(species));
+            Assert.That(entry.DisplayName, Is.EqualTo("손각시"), "MonsterData가 있으면 그 표시 이름을 쓴다.");
+        }
+
+        [Test]
+        public void SpeciesKeyAndDisplayName_FallBackToPrefab_WhenMonsterDataMissing()
+        {
+            var entry = new WaveEnemySpawnEntry();
+            EnemyHealth prefab = CreatePrefab("Dokkaebibul");
+
+            SetPrivateField(entry, "_enemyPrefab", prefab);
+            SetPrivateField(entry, "_enemyType", "Dokkaebi");
+
+            // 인스턴스가 아니라 프리팹이 키다 — 풀에서 재사용된 개체가 이전 종류의 MonsterData를
+            // 들고 있어도 이 엔트리로 스폰된 적은 항상 같은 종류로 묶인다.
+            Assert.That(entry.SpeciesKey, Is.SameAs(prefab));
+            Assert.That(entry.DisplayName, Is.EqualTo("Dokkaebibul"));
+        }
+
+        [Test]
+        public void SpeciesKeyAndDisplayName_FallBackToEnemyType_WhenPrefabMissing()
+        {
+            var entry = new WaveEnemySpawnEntry();
+            SetPrivateField(entry, "_enemyType", "Mangryang");
+
+            Assert.That(entry.SpeciesKey, Is.EqualTo("Mangryang"));
+            Assert.That(entry.DisplayName, Is.EqualTo("Mangryang"));
+        }
+
+        [Test]
+        public void SpeciesKey_DiffersPerPrefab_WhenMonsterDataMissing()
+        {
+            var first = new WaveEnemySpawnEntry();
+            var second = new WaveEnemySpawnEntry();
+            SetPrivateField(first, "_enemyPrefab", CreatePrefab("Dokkaebibul"));
+            SetPrivateField(second, "_enemyPrefab", CreatePrefab("Mokgwi"));
+
+            Assert.That(first.SpeciesKey, Is.Not.EqualTo(second.SpeciesKey), "프리팹이 다르면 다른 종류다.");
+        }
+
+        private MonsterData CreateMonsterData(string assetName, string displayName)
+        {
+            MonsterData species = ScriptableObject.CreateInstance<MonsterData>();
+            species.name = assetName;
+            SetPrivateField(species, "_displayName", displayName);
+            _created.Add(species);
+            return species;
+        }
+
+        private EnemyHealth CreatePrefab(string objectName)
+        {
+            var go = new GameObject(objectName);
+            _created.Add(go);
+            return go.AddComponent<EnemyHealth>();
         }
 
         private static void SetPrivateField<T>(object target, string fieldName, T value)


### PR DESCRIPTION
챕터 1 타임라인(#70)의 마지막 미구현 항목인 **적 첫 등장 연출**을 구현했다.

## 먼저 — 이슈 체크리스트 대조 결과

이슈에 적힌 항목 대부분은 이미 끝나 있었다. 코멘트에 "남은 작업"으로 적혀 있던 선행 이슈 3개(#29 특수 적 · #71 미니보스 · #37 보스 기반)가 닫히면서, 후속 PR들이 해당 항목을 처리한 상태다.

| 항목 | 상태 |
|---|---|
| 분 단위 WaveData 10개 | 완료 — `Chapter1_WaveDatabase.asset` |
| 도깨비불 · 매구 배치 | 완료 — PR #107 (#104) |
| 미니보스 마크 3/6/9분 | 완료 — 씬의 `WaveCombatDirector` + `MiniBossSpawner` 배선 |
| 10:00 스포닝 중단 / 잔여 적 처리 | 완료 — `EnterBossPhase` + `BossEncounterDirector.DespawnTrackedEnemies` |
| **적 첫 등장 연출** | **이 PR** |

## 문제

챕터 1은 10분 동안 9종이 순차 투입된다. 새 적이 조용히 섞여 들어오면 플레이어는 죽고 나서야 "저건 뭐였지"를 알게 된다. 이름표만 띄워서는 화면의 수십 마리 중 누가 그 적인지 못 찾으므로, **상단 배너와 대상 개체 위 화살표(▼)를 함께** 띄운다.

## 구성

| 파일 | 줄 수 | 책임 |
|---|---|---|
| `Combat/EnemyIntroductionTracker.cs` | 50 | 종류별 첫 등장을 런 내 1회만 통과 (순수 C#) |
| `UI/EnemyIntroductionPresenter.cs` | 286 | 구독 · 대기열 · 타이밍 |
| `UI/EnemyIntroductionView.cs` | 137 | 배너 · 화살표 표시 |
| `Combat/WaveCombatDirector.cs` | +10 | `OnEnemySpawned` 이벤트 추가 |

`TryMarkIntroduced`가 조회와 기록을 한 호출로 끝내는 게 핵심이다. 최소 유지 수를 채우는 소환 라운드에서는 같은 종류가 한 프레임에 여러 마리 나오므로, 판정을 호출부에 맡기면 배너가 중복된다.

프레젠터는 자가 부트스트랩(`GameplayHudBootstrapper`와 동일 방식)이라 **씬 파일을 건드리지 않는다.**

## 설계상 짚어둘 것

- **종류 키는 MonsterData 에셋.** 인스턴스를 키로 쓰면 풀에서 재사용될 때마다 '처음'이 되어 연출이 반복된다. MonsterData가 없는 엔트리는 표시 이름 문자열로 폴백하며, 이 경우 참조가 매번 새로 생기므로 키 비교는 `Equals`로 한다.
- **배너 타이머는 `unscaledDeltaTime`.** 레벨업으로 timeScale이 0이 돼도 연출이 갇히지 않는다.
- **sortingOrder 550** — HUD(500) 위, 결과(600)·조작 안내(700) 아래. 배너가 상단 중앙이라 화면 중앙의 레벨업 카드와 겹치지 않는다.
- **모든 요소 `PickingMode.Ignore`.** 연출이 입력을 먹으면 전투 스와이프가 막힌다.
- 대상이 죽거나 풀에서 다른 종류로 재사용되면(SpeciesKey 불일치) 화살표만 감추고 배너는 유지한다.

## 검증

- **EditMode 270개 통과 / 실패 0** (신규 7개 포함), 컴파일 에러 없음.
- 테스트는 `같은 종류 10회 호출 중 1회만 통과`, 문자열 폴백 키의 값 비교, `Reset` 후 재소개를 덮는다.
- 실기 플레이 확인은 아직 하지 않았다 — 리뷰어가 확인해주면 좋겠다.

## 범위 밖

- **`ChapterData` ScriptableObject 생성은 #64 소유**라 손대지 않았다. 지금 타임라인은 `WaveDatabase`로 동작하며, #64에서 `ChapterData`가 생기면 참조를 옮기면 된다. 여기서 미리 만들면 #64와 설계가 충돌한다.
- 등장 효과음은 `AudioCue` 추가 + `AudioLibrary` 배선이 필요해 #38 범위로 남긴다.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)
