### PR TITLE
feat: 챕터 데이터 구조 — ChapterData / 챕터별 적 풀 격리 (#64)

### DIFF
--- a/project1/Assets/SampleScene.unity
+++ b/project1/Assets/SampleScene.unity
@@ -858,6 +858,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7dd05940247ffed4facbec1e8fc4d6b9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.BossEncounterDirector
+  _chapterData: {fileID: 11400000, guid: c6f2ea4d2fc04e32a642af5e9375557a, type: 2}
   _director: {fileID: 1453966977}
   _bossPrefab: {fileID: 2681383079461457332, guid: f6f5de12d7863c04ab83d3482bca5c6b, type: 3}
   _bossSpawnPoint: {fileID: 275740324}
@@ -1671,6 +1672,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7b7e2c7a47d44145ab1382f7783377fa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.WaveCombatDirector
+  _chapterData: {fileID: 11400000, guid: c6f2ea4d2fc04e32a642af5e9375557a, type: 2}
   _waveDatabase: {fileID: 11400000, guid: 761c6a7730f34dde86070de259bcccd6, type: 2}
   _spawnPoints: []
   _collectSpawnPointsFromChildren: 1
@@ -1715,6 +1717,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 83ea35bc9699e0443a3f1f4aee038309, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.MiniBossSpawner
+  _chapterData: {fileID: 11400000, guid: c6f2ea4d2fc04e32a642af5e9375557a, type: 2}
   _director: {fileID: 1453966977}
   _playerTransform: {fileID: 187285032}
   _soulOrbPrefab: {fileID: 2654722044290273375, guid: 100c6736884f69344849b68ede8dffdd, type: 3}

--- a/project1/Assets/Scripts/Combat/BossEncounterDirector.cs
+++ b/project1/Assets/Scripts/Combat/BossEncounterDirector.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using Mukseon.Core;
 using Mukseon.Core.Pool;
 using UnityEngine;
 
@@ -20,6 +21,12 @@ namespace Mukseon.Gameplay.Combat
     [DisallowMultipleComponent]
     public class BossEncounterDirector : MonoBehaviour
     {
+        [Header("Chapter")]
+        [Tooltip("이 챕터의 메인 보스를 사용한다(#64). 비우면 아래 보스 프리팹을 그대로 쓴다. " +
+                 "런타임에는 스테이지 선택 결과(RunContext.SelectedChapter)가 이 값보다 우선한다.")]
+        [SerializeField]
+        private ChapterData _chapterData;
+
         [Header("References")]
         [SerializeField]
         private WaveCombatDirector _director;
@@ -59,6 +66,33 @@ namespace Mukseon.Gameplay.Combat
 
         /// <summary>보스 처치 + 사망 연출 종료 후 발행. 결과 화면(#36)이 구독한다.</summary>
         public event Action OnChapterCleared;
+
+        /// <summary>
+        /// 보스 프리팹은 보스 마크(기본 10분)에 가서야 읽히므로 해석 시점에 여유가 있지만,
+        /// 나머지 두 디렉터와 같은 규약을 유지해 <c>Awake</c>에서 한 번에 끝낸다.
+        /// </summary>
+        private void Awake()
+        {
+            ApplyChapterData();
+        }
+
+        private void ApplyChapterData()
+        {
+            ChapterData chapter = RunContext.SelectedChapter != null ? RunContext.SelectedChapter : _chapterData;
+            if (chapter == null)
+            {
+                return;
+            }
+
+            _chapterData = chapter;
+
+            // 프리팹이 비어 있는 챕터(2·3장 골격)가 씬의 유효한 보스를 지워버리지 않도록 있을 때만 덮어쓴다.
+            // 보스가 정말 없는 챕터는 ChapterData.BossMinuteMark를 0으로 두어 보스 페이즈 자체를 막는다.
+            if (chapter.BossPrefab != null)
+            {
+                _bossPrefab = chapter.BossPrefab;
+            }
+        }
 
         private void OnEnable()
         {

--- a/project1/Assets/Scripts/Combat/BossEncounterDirector.cs
+++ b/project1/Assets/Scripts/Combat/BossEncounterDirector.cs
@@ -76,6 +76,10 @@ namespace Mukseon.Gameplay.Combat
             ApplyChapterData();
         }
 
+        /// <summary>
+        /// 반영 단위는 <b>챕터 통째로</b>다 — 프리팹만 씬 값으로 남기면 "2장인데 보스는 1장 산군"이 되므로,
+        /// 검증에 걸리는 챕터는 통째로 무시한다(<see cref="WaveCombatDirector"/>와 동일한 판정).
+        /// </summary>
         private void ApplyChapterData()
         {
             ChapterData chapter = RunContext.SelectedChapter != null ? RunContext.SelectedChapter : _chapterData;
@@ -84,14 +88,18 @@ namespace Mukseon.Gameplay.Combat
                 return;
             }
 
+            if (!chapter.IsValid(out string reason))
+            {
+                Debug.LogWarning(
+                    $"[BossEncounterDirector] 챕터 '{chapter.DisplayName}'가 유효하지 않아 씬 설정으로 진행합니다: {reason}");
+                return;
+            }
+
             _chapterData = chapter;
 
-            // 프리팹이 비어 있는 챕터(2·3장 골격)가 씬의 유효한 보스를 지워버리지 않도록 있을 때만 덮어쓴다.
-            // 보스가 정말 없는 챕터는 ChapterData.BossMinuteMark를 0으로 두어 보스 페이즈 자체를 막는다.
-            if (chapter.BossPrefab != null)
-            {
-                _bossPrefab = chapter.BossPrefab;
-            }
+            // IsValid가 "보스 마크가 있으면 프리팹도 있다"를 보장한다. 그래도 프리팹이 비어 있다면 보스 마크가 0인
+            // 보스 없는 챕터이므로, 씬 값을 남기지 않고 그대로 비운다 — 어차피 보스 페이즈 자체가 시작되지 않는다.
+            _bossPrefab = chapter.BossPrefab;
         }
 
         private void OnEnable()

--- a/project1/Assets/Scripts/Combat/ChapterData.cs
+++ b/project1/Assets/Scripts/Combat/ChapterData.cs
@@ -1,0 +1,143 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 한 챕터(스테이지)의 진행 데이터 전체(#64). <c>wave_stage_system.md</c> "필요한 데이터 항목 &gt; 챕터 데이터" 기준으로
+    /// 챕터 이름 · 분 단위 웨이브 목록 · 미니 보스 등장 설정 · 메인 보스 참조를 한 에셋에 모은다.
+    ///
+    /// 이전에는 같은 정보가 씬의 세 컴포넌트(<see cref="WaveCombatDirector"/> · <see cref="MiniBossSpawner"/> ·
+    /// <see cref="BossEncounterDirector"/>)에 나뉘어 직렬화돼 있었다. 챕터를 바꾸려면 세 곳을 동시에 고쳐야 했고,
+    /// 특히 미니 보스 분 마크는 디렉터와 스포너 양쪽에 <b>중복 입력</b>돼 어긋나면 마크만 울리고 미니 보스는
+    /// 나오지 않는 조용한 버그가 됐다. 여기서는 <see cref="MiniBossMinuteMarks"/>를 차수 목록에서 파생시켜
+    /// 그 중복 자체를 없앤다.
+    /// </summary>
+    [CreateAssetMenu(fileName = "ChapterData", menuName = "Mukseon/Data/Chapter Data")]
+    public class ChapterData : ScriptableObject
+    {
+        [SerializeField]
+        private string _chapterId = "chapter.default";
+
+        [SerializeField]
+        private string _displayName = "Chapter";
+
+        [Tooltip("이 챕터의 배경(게임플레이 씬) 이름. 비우면 ScreenFlow의 기본 게임플레이 씬을 쓴다.")]
+        [SerializeField]
+        private string _backgroundSceneName = string.Empty;
+
+        [Header("Waves")]
+        [Tooltip("분 단위 웨이브 목록. 보스 마크 전까지 시간 경과로 순차 전환된다.")]
+        [SerializeField]
+        private WaveDatabase _waveDatabase;
+
+        [Header("Chapter Enemy Pool")]
+        [Tooltip("이 챕터의 적 로스터 — 등장 가능한 적의 전체 목록. " +
+                 "웨이브에 이 풀 밖의 적이 들어 있으면 IsValid가 실패한다(챕터 간 적 혼입 방지).")]
+        [SerializeField]
+        private List<WaveEnemySpawnEntry> _enemyPool = new List<WaveEnemySpawnEntry>();
+
+        [Tooltip("미니 보스로 강화될 수 있는 적. 비워두면 로스터 전체가 후보가 된다. " +
+                 "기믹형 적(도깨비불·매구 등)처럼 크게 부풀리면 전투가 성립하지 않는 종류를 빼기 위한 목록이며, " +
+                 "반드시 로스터의 부분집합이어야 한다.")]
+        [SerializeField]
+        private List<WaveEnemySpawnEntry> _miniBossCandidates = new List<WaveEnemySpawnEntry>();
+
+        [Header("Mini Boss")]
+        [Tooltip("미니 보스 차수별 설정. 등장 분 마크는 각 차수의 SpawnMinuteMark에서 읽는다.")]
+        [SerializeField]
+        private List<MiniBossStageData> _miniBossStages = new List<MiniBossStageData>();
+
+        [Header("Main Boss")]
+        [Tooltip("메인 보스가 등장하는 분 마크. 이 시점에 일반 스포닝이 중단된다. 0 이하이면 보스 없음.")]
+        [SerializeField, Min(0f)]
+        private float _bossMinuteMark = 10f;
+
+        [SerializeField]
+        private BossData _bossData;
+
+        [Tooltip("EnemyHealth + BossHealthComponent를 포함한 보스 프리팹.")]
+        [SerializeField]
+        private EnemyHealth _bossPrefab;
+
+        // 차수 목록에서 파생되는 값이라 직렬화하지 않는다. 첫 조회 시 만들고 OnValidate에서 버린다.
+        private List<float> _miniBossMinuteMarksCache;
+
+        public string ChapterId => string.IsNullOrWhiteSpace(_chapterId) ? name : _chapterId;
+        public string DisplayName => string.IsNullOrWhiteSpace(_displayName) ? name : _displayName;
+
+        /// <summary>배경 씬 이름. 비어 있으면 null을 돌려주어 호출부가 기본 씬으로 폴백하게 한다.</summary>
+        public string BackgroundSceneName =>
+            string.IsNullOrWhiteSpace(_backgroundSceneName) ? null : _backgroundSceneName;
+
+        public WaveDatabase WaveDatabase => _waveDatabase;
+
+        /// <summary>이 챕터의 적 로스터. 웨이브가 이 밖의 적을 쓰면 <see cref="IsValid"/>가 실패한다.</summary>
+        public IReadOnlyList<WaveEnemySpawnEntry> EnemyPool => _enemyPool;
+
+        /// <summary>
+        /// 미니 보스 후보. 별도로 지정하지 않았으면 로스터 전체다 —
+        /// 대부분의 챕터는 구분할 이유가 없으므로 비워두는 쪽이 기본이다.
+        /// </summary>
+        public IReadOnlyList<WaveEnemySpawnEntry> MiniBossCandidates =>
+            _miniBossCandidates != null && _miniBossCandidates.Count > 0 ? _miniBossCandidates : _enemyPool;
+
+        public IReadOnlyList<MiniBossStageData> MiniBossStages => _miniBossStages;
+        public float BossMinuteMark => Mathf.Max(0f, _bossMinuteMark);
+        public BossData BossData => _bossData;
+        public EnemyHealth BossPrefab => _bossPrefab;
+
+        /// <summary>
+        /// 미니 보스 분 마크 목록. <see cref="MiniBossStages"/>의 <c>SpawnMinuteMark</c>에서 파생되므로
+        /// 스포너의 차수 설정과 절대 어긋나지 않는다. 0 이하인 차수는 제외한다.
+        /// </summary>
+        public IReadOnlyList<float> MiniBossMinuteMarks
+        {
+            get
+            {
+                if (_miniBossMinuteMarksCache == null)
+                {
+                    _miniBossMinuteMarksCache = BuildMiniBossMinuteMarks();
+                }
+
+                return _miniBossMinuteMarksCache;
+            }
+        }
+
+        private List<float> BuildMiniBossMinuteMarks()
+        {
+            var marks = new List<float>();
+            if (_miniBossStages == null)
+            {
+                return marks;
+            }
+
+            for (int i = 0; i < _miniBossStages.Count; i++)
+            {
+                MiniBossStageData stage = _miniBossStages[i];
+                if (stage == null || stage.SpawnMinuteMark <= 0f)
+                {
+                    continue;
+                }
+
+                marks.Add(stage.SpawnMinuteMark);
+            }
+
+            return marks;
+        }
+
+        private void OnValidate()
+        {
+            // 인스펙터에서 차수를 고치면 파생 캐시를 버려 다음 조회 때 다시 만든다.
+            _miniBossMinuteMarksCache = null;
+        }
+
+        /// <summary>
+        /// 챕터가 플레이 가능한 상태인지 검사한다. 규칙 본문은 <see cref="ChapterValidation"/>에 있다.
+        /// </summary>
+        public bool IsValid(out string reason)
+        {
+            return ChapterValidation.Validate(this, out reason);
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/ChapterData.cs.meta
+++ b/project1/Assets/Scripts/Combat/ChapterData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 330c7900de17a59499547d23ba978b16
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/project1/Assets/Scripts/Combat/ChapterDatabase.cs
+++ b/project1/Assets/Scripts/Combat/ChapterDatabase.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// 선택 가능한 챕터 목록(#64). 구조는 <c>CharacterDatabase</c>(#36)와 같다 —
+    /// 스테이지 선택 화면이 이 목록을 순회해 카드를 만들고, 세이브의 해금 정보와 대조한다.
+    /// </summary>
+    [CreateAssetMenu(fileName = "ChapterDatabase", menuName = "Mukseon/Data/Chapter Database")]
+    public class ChapterDatabase : ScriptableObject
+    {
+        [SerializeField]
+        private List<ChapterData> _chapters = new List<ChapterData>();
+
+        /// <summary>표시 순서대로의 챕터 목록(읽기 전용). null 항목이 섞여 있을 수 있으므로 사용 측에서 걸러야 한다.</summary>
+        public IReadOnlyList<ChapterData> Chapters => _chapters;
+
+        /// <summary>이번 런의 기본 챕터(1장). 목록이 비어 있으면 null.</summary>
+        public ChapterData DefaultChapter
+        {
+            get
+            {
+                for (int i = 0; i < _chapters.Count; i++)
+                {
+                    if (_chapters[i] != null)
+                    {
+                        return _chapters[i];
+                    }
+                }
+
+                return null;
+            }
+        }
+
+        /// <summary>ID로 챕터를 찾는다. 없으면 null.</summary>
+        public ChapterData Find(string chapterId)
+        {
+            if (string.IsNullOrWhiteSpace(chapterId))
+            {
+                return null;
+            }
+
+            for (int i = 0; i < _chapters.Count; i++)
+            {
+                ChapterData chapter = _chapters[i];
+                if (chapter != null && chapter.ChapterId == chapterId)
+                {
+                    return chapter;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// 목록 자체의 무결성만 본다(빈 항목 · 중복 ID). 각 챕터 내부의 유효성은
+        /// <see cref="ChapterData.IsValid"/>가 따로 판정한다 — 2·3장처럼 아직 골격만 있는 챕터가
+        /// 목록 검증을 통째로 실패시키면, 플레이 가능한 1장까지 화면에서 사라진다.
+        /// </summary>
+        public bool IsValid(out string reason)
+        {
+            if (_chapters.Count == 0)
+            {
+                reason = "챕터 목록이 비어 있습니다.";
+                return false;
+            }
+
+            var seenIds = new HashSet<string>();
+            for (int i = 0; i < _chapters.Count; i++)
+            {
+                ChapterData chapter = _chapters[i];
+                if (chapter == null)
+                {
+                    reason = $"{i}번 항목이 비어 있습니다.";
+                    return false;
+                }
+
+                if (!seenIds.Add(chapter.ChapterId))
+                {
+                    reason = $"ChapterId가 중복됩니다: '{chapter.ChapterId}'";
+                    return false;
+                }
+            }
+
+            reason = string.Empty;
+            return true;
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/ChapterDatabase.cs.meta
+++ b/project1/Assets/Scripts/Combat/ChapterDatabase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f38e371b5df7124aad344ad40909466
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/project1/Assets/Scripts/Combat/ChapterValidation.cs
+++ b/project1/Assets/Scripts/Combat/ChapterValidation.cs
@@ -1,0 +1,230 @@
+using System.Collections.Generic;
+
+namespace Mukseon.Gameplay.Combat
+{
+    /// <summary>
+    /// <see cref="ChapterData"/>의 검증 규칙(#64). 에셋에서 분리한 순수 C# 클래스로,
+    /// 챕터의 공개 프로퍼티만 읽는다.
+    ///
+    /// 여기서 걸리는 항목은 모두 <b>런타임에 조용히 실패하는</b> 종류다 — 웨이브가 비면 적이 아예 안 나오고,
+    /// 로스터가 비면 미니 보스 마크만 울리고 끝나며, 보스 프리팹이 없으면 10분에 아무 일도 일어나지 않는다.
+    /// 어느 쪽도 예외를 던지지 않으므로 데이터 시점에 잡아야 한다.
+    /// </summary>
+    public static class ChapterValidation
+    {
+        public static bool Validate(ChapterData chapter, out string reason)
+        {
+            if (chapter == null)
+            {
+                reason = "챕터가 비어 있습니다.";
+                return false;
+            }
+
+            WaveDatabase waveDatabase = chapter.WaveDatabase;
+            if (waveDatabase == null || waveDatabase.Waves == null || waveDatabase.Waves.Count == 0)
+            {
+                reason = "웨이브 데이터베이스가 비어 있습니다.";
+                return false;
+            }
+
+            if (!ValidateEnemyPool(chapter.EnemyPool, out reason))
+            {
+                return false;
+            }
+
+            if (!ValidateMiniBossStages(chapter, out reason))
+            {
+                return false;
+            }
+
+            if (chapter.BossMinuteMark > 0f && chapter.BossPrefab == null)
+            {
+                reason = $"보스 마크({chapter.BossMinuteMark:0.#}분)가 설정됐지만 보스 프리팹이 비어 있습니다.";
+                return false;
+            }
+
+            HashSet<object> rosterKeys = BuildSpeciesKeys(chapter.EnemyPool);
+
+            if (!ValidateWavesStayInsideRoster(waveDatabase, rosterKeys, out reason))
+            {
+                return false;
+            }
+
+            return ValidateMiniBossCandidates(chapter, rosterKeys, out reason);
+        }
+
+        /// <summary>
+        /// 종류 판별 키 집합. 키가 문자열로 폴백된 경우에도 <see cref="HashSet{T}"/>의 기본 비교자가
+        /// <c>Equals</c>를 쓰므로 값 비교가 된다(#70에서 참조 비교로 깨졌던 것과 같은 이유).
+        /// </summary>
+        private static HashSet<object> BuildSpeciesKeys(IReadOnlyList<WaveEnemySpawnEntry> entries)
+        {
+            var keys = new HashSet<object>();
+            for (int i = 0; i < entries.Count; i++)
+            {
+                keys.Add(entries[i].SpeciesKey);
+            }
+
+            return keys;
+        }
+
+        private static bool ValidateEnemyPool(IReadOnlyList<WaveEnemySpawnEntry> roster, out string reason)
+        {
+            if (roster == null || roster.Count == 0)
+            {
+                reason = "챕터 적 풀이 비어 있습니다. 미니 보스가 선택할 적이 없습니다.";
+                return false;
+            }
+
+            for (int i = 0; i < roster.Count; i++)
+            {
+                WaveEnemySpawnEntry entry = roster[i];
+                if (entry == null)
+                {
+                    reason = $"적 풀 {i}번 항목이 비어 있습니다.";
+                    return false;
+                }
+
+                if (!entry.IsValid(out string entryReason))
+                {
+                    reason = $"적 풀 {i}번 항목이 유효하지 않습니다: {entryReason}";
+                    return false;
+                }
+            }
+
+            reason = string.Empty;
+            return true;
+        }
+
+        /// <summary>
+        /// 차수는 시간순으로 <b>엄격히 증가</b>해야 하고 모두 보스 마크보다 앞서야 한다.
+        /// 마크가 중복되면 <see cref="MiniBossSpawner"/>가 먼저 등록된 차수만 쓰고 나머지를 조용히 버리며,
+        /// 보스 마크 이후의 차수는 영영 발행되지 않는다.
+        /// </summary>
+        private static bool ValidateMiniBossStages(ChapterData chapter, out string reason)
+        {
+            IReadOnlyList<MiniBossStageData> stages = chapter.MiniBossStages;
+            if (stages == null || stages.Count == 0)
+            {
+                // 미니 보스 없는 챕터도 성립한다(튜토리얼 등).
+                reason = string.Empty;
+                return true;
+            }
+
+            float bossMinuteMark = chapter.BossMinuteMark;
+            float previousMark = 0f;
+
+            for (int i = 0; i < stages.Count; i++)
+            {
+                MiniBossStageData stage = stages[i];
+                if (stage == null)
+                {
+                    reason = $"미니 보스 {i}번 차수가 비어 있습니다.";
+                    return false;
+                }
+
+                float mark = stage.SpawnMinuteMark;
+                if (mark <= previousMark)
+                {
+                    reason = $"미니 보스 분 마크는 오름차순이어야 합니다. {i}번 차수={mark:0.#} <= 이전={previousMark:0.#}";
+                    return false;
+                }
+
+                if (bossMinuteMark > 0f && mark >= bossMinuteMark)
+                {
+                    reason = $"미니 보스 {i}번 차수({mark:0.#}분)가 보스 마크({bossMinuteMark:0.#}분) 이후입니다. " +
+                             "보스 진입 후에는 마크가 발행되지 않습니다.";
+                    return false;
+                }
+
+                previousMark = mark;
+            }
+
+            reason = string.Empty;
+            return true;
+        }
+
+        /// <summary>
+        /// 웨이브에 등장하는 모든 적이 챕터 로스터 안에 있는지 검사한다 —
+        /// #64 DoD "챕터 진행 중 다른 챕터의 적이 등장하지 않는다"의 실제 강제 지점.
+        /// </summary>
+        private static bool ValidateWavesStayInsideRoster(
+            WaveDatabase waveDatabase,
+            HashSet<object> rosterKeys,
+            out string reason)
+        {
+            IReadOnlyList<WaveDefinition> waves = waveDatabase.Waves;
+            for (int waveIndex = 0; waveIndex < waves.Count; waveIndex++)
+            {
+                WaveDefinition wave = waves[waveIndex];
+                if (wave == null || wave.Enemies == null)
+                {
+                    continue;
+                }
+
+                for (int entryIndex = 0; entryIndex < wave.Enemies.Count; entryIndex++)
+                {
+                    WaveEnemySpawnEntry entry = wave.Enemies[entryIndex];
+                    if (entry == null || !entry.IsValid(out _))
+                    {
+                        // 엔트리 자체의 유효성은 WaveCombatDirector가 스폰 시점에 경고한다. 여기서는 소속만 본다.
+                        continue;
+                    }
+
+                    if (!rosterKeys.Contains(entry.SpeciesKey))
+                    {
+                        reason = $"웨이브 '{wave.WaveName}'의 적 '{entry.DisplayName}'이(가) 챕터 적 풀에 없습니다.";
+                        return false;
+                    }
+                }
+            }
+
+            reason = string.Empty;
+            return true;
+        }
+
+        /// <summary>
+        /// 미니 보스 후보는 로스터의 부분집합이어야 한다. 로스터에 없는 적을 후보로 두면
+        /// 챕터에 등장하지 않던 적이 미니 보스로만 튀어나온다 — 격리 검증을 우회하는 뒷문이 된다.
+        /// </summary>
+        private static bool ValidateMiniBossCandidates(
+            ChapterData chapter,
+            HashSet<object> rosterKeys,
+            out string reason)
+        {
+            IReadOnlyList<WaveEnemySpawnEntry> candidates = chapter.MiniBossCandidates;
+
+            // 후보를 비워두면 MiniBossCandidates가 로스터 자체를 돌려주므로 검사할 게 없다.
+            if (ReferenceEquals(candidates, chapter.EnemyPool))
+            {
+                reason = string.Empty;
+                return true;
+            }
+
+            for (int i = 0; i < candidates.Count; i++)
+            {
+                WaveEnemySpawnEntry candidate = candidates[i];
+                if (candidate == null)
+                {
+                    reason = $"미니 보스 후보 {i}번 항목이 비어 있습니다.";
+                    return false;
+                }
+
+                if (!candidate.IsValid(out string candidateReason))
+                {
+                    reason = $"미니 보스 후보 {i}번 항목이 유효하지 않습니다: {candidateReason}";
+                    return false;
+                }
+
+                if (!rosterKeys.Contains(candidate.SpeciesKey))
+                {
+                    reason = $"미니 보스 후보 '{candidate.DisplayName}'이(가) 챕터 적 로스터에 없습니다.";
+                    return false;
+                }
+            }
+
+            reason = string.Empty;
+            return true;
+        }
+    }
+}

--- a/project1/Assets/Scripts/Combat/ChapterValidation.cs.meta
+++ b/project1/Assets/Scripts/Combat/ChapterValidation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7957b3f3f3ab05641a273dfb09599e88
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/project1/Assets/Scripts/Combat/MiniBossSpawner.cs
+++ b/project1/Assets/Scripts/Combat/MiniBossSpawner.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Mukseon.Core;
 using Mukseon.Core.Pool;
 using Mukseon.Gameplay.Progression;
 using UnityEngine;
@@ -14,6 +15,12 @@ namespace Mukseon.Gameplay.Combat
     [DisallowMultipleComponent]
     public class MiniBossSpawner : MonoBehaviour
     {
+        [Header("Chapter")]
+        [Tooltip("이 챕터의 적 풀과 미니 보스 차수를 사용한다(#64). 비우면 아래 값들을 그대로 쓴다. " +
+                 "런타임에는 스테이지 선택 결과(RunContext.SelectedChapter)가 이 값보다 우선한다.")]
+        [SerializeField]
+        private ChapterData _chapterData;
+
         [Header("References")]
         [SerializeField]
         private WaveCombatDirector _director;
@@ -57,6 +64,42 @@ namespace Mukseon.Gameplay.Combat
 
         /// <summary>영혼 재화 보상 발행. 인자: (차수 인덱스, 영혼량). 영혼 재화 시스템(#61)이 구독.</summary>
         public event Action<int, int> OnMiniBossSoulCurrencyDropped;
+
+        /// <summary>
+        /// 챕터 해석은 <c>Awake</c>에서 끝낸다 — <c>OnEnable</c>의 <see cref="BuildMarkIndex"/>가 차수 목록을 읽으므로
+        /// 그 전에 이 챕터의 차수가 자리잡아 있어야 한다. <see cref="WaveCombatDirector"/>에서 건네받지 않고
+        /// 각자 <see cref="RunContext"/>를 읽는 이유는 컴포넌트 간 <c>Awake</c> 순서에 기대지 않기 위해서다.
+        /// </summary>
+        private void Awake()
+        {
+            ApplyChapterData();
+        }
+
+        private void ApplyChapterData()
+        {
+            ChapterData chapter = RunContext.SelectedChapter != null ? RunContext.SelectedChapter : _chapterData;
+            if (chapter == null)
+            {
+                return;
+            }
+
+            _chapterData = chapter;
+
+            // 로스터 전체가 아니라 '미니 보스 후보'를 쓴다 — 챕터가 후보를 따로 지정하지 않았으면
+            // ChapterData가 알아서 로스터 전체를 돌려준다. 비어 있으면 미니 보스가 아예 소환되지 않으므로
+            // 챕터 쪽이 비어 있는 경우엔 씬 값을 남긴다.
+            IReadOnlyList<WaveEnemySpawnEntry> candidates = chapter.MiniBossCandidates;
+            if (candidates != null && candidates.Count > 0)
+            {
+                _enemyPool = new List<WaveEnemySpawnEntry>(candidates);
+            }
+
+            // 차수는 WaveCombatDirector가 발행하는 마크와 짝을 이뤄야 한다. 디렉터도 같은 챕터에서
+            // 마크를 파생시키므로(ChapterData.MiniBossMinuteMarks) 여기서는 그대로 반영하면 항상 일치한다.
+            _stages = chapter.MiniBossStages != null
+                ? new List<MiniBossStageData>(chapter.MiniBossStages)
+                : new List<MiniBossStageData>();
+        }
 
         private void OnEnable()
         {

--- a/project1/Assets/Scripts/Combat/MiniBossSpawner.cs
+++ b/project1/Assets/Scripts/Combat/MiniBossSpawner.cs
@@ -75,6 +75,10 @@ namespace Mukseon.Gameplay.Combat
             ApplyChapterData();
         }
 
+        /// <summary>
+        /// 반영 단위는 <b>챕터 통째로</b>다 — 미완성 챕터를 필드별로 폴백시키면 다른 챕터의 적이 섞이므로,
+        /// 검증에 걸리는 챕터는 통째로 무시하고 씬 값으로 남긴다(<see cref="WaveCombatDirector"/>와 동일한 판정).
+        /// </summary>
         private void ApplyChapterData()
         {
             ChapterData chapter = RunContext.SelectedChapter != null ? RunContext.SelectedChapter : _chapterData;
@@ -83,16 +87,19 @@ namespace Mukseon.Gameplay.Combat
                 return;
             }
 
+            if (!chapter.IsValid(out string reason))
+            {
+                Debug.LogWarning(
+                    $"[MiniBossSpawner] 챕터 '{chapter.DisplayName}'가 유효하지 않아 씬 설정으로 진행합니다: {reason}");
+                return;
+            }
+
             _chapterData = chapter;
 
             // 로스터 전체가 아니라 '미니 보스 후보'를 쓴다 — 챕터가 후보를 따로 지정하지 않았으면
-            // ChapterData가 알아서 로스터 전체를 돌려준다. 비어 있으면 미니 보스가 아예 소환되지 않으므로
-            // 챕터 쪽이 비어 있는 경우엔 씬 값을 남긴다.
-            IReadOnlyList<WaveEnemySpawnEntry> candidates = chapter.MiniBossCandidates;
-            if (candidates != null && candidates.Count > 0)
-            {
-                _enemyPool = new List<WaveEnemySpawnEntry>(candidates);
-            }
+            // ChapterData가 알아서 로스터 전체를 돌려준다. 로스터가 비어 있지 않음은 IsValid가 보장하므로
+            // 후보도 반드시 1종 이상이다.
+            _enemyPool = new List<WaveEnemySpawnEntry>(chapter.MiniBossCandidates);
 
             // 차수는 WaveCombatDirector가 발행하는 마크와 짝을 이뤄야 한다. 디렉터도 같은 챕터에서
             // 마크를 파생시키므로(ChapterData.MiniBossMinuteMarks) 여기서는 그대로 반영하면 항상 일치한다.

--- a/project1/Assets/Scripts/Combat/WaveCombatDirector.cs
+++ b/project1/Assets/Scripts/Combat/WaveCombatDirector.cs
@@ -144,6 +144,10 @@ namespace Mukseon.Gameplay.Combat
         /// <summary>
         /// 스테이지 선택에서 고른 챕터를 우선하고, 없으면 씬에 직렬화된 챕터로 폴백한다.
         /// 둘 다 없으면 아무것도 덮어쓰지 않아 종전처럼 씬 값으로 동작한다(#36의 캐릭터 해석과 같은 규약).
+        ///
+        /// 반영 단위는 <b>챕터 통째로</b>다. 필드마다 따로 폴백하면 미완성 챕터(2·3장 골격)를 골랐을 때
+        /// "웨이브·보스는 1장, 미니 보스만 없음" 같은 중간 상태가 만들어져 #64 DoD("챕터 진행 중 다른 챕터의
+        /// 적이 등장하지 않는다")가 조용히 깨진다. 세 디렉터가 각자 같은 판정을 내리므로 셋 다 함께 씬 값으로 남는다.
         /// </summary>
         private void ApplyChapterData()
         {
@@ -153,13 +157,18 @@ namespace Mukseon.Gameplay.Combat
                 return;
             }
 
-            _chapterData = chapter;
-
-            if (chapter.WaveDatabase != null)
+            if (!chapter.IsValid(out string reason))
             {
-                _waveDatabase = chapter.WaveDatabase;
+                Debug.LogWarning(
+                    $"[WaveCombatDirector] 챕터 '{chapter.DisplayName}'가 유효하지 않아 씬 설정으로 진행합니다: {reason}");
+                return;
             }
 
+            _chapterData = chapter;
+
+            // 아래 세 값은 IsValid를 통과한 챕터에서만 읽으므로 조건 없이 덮어쓴다 —
+            // 웨이브 데이터베이스가 비어 있지 않음은 검증이 보장한다.
+            _waveDatabase = chapter.WaveDatabase;
             _bossMinuteMark = chapter.BossMinuteMark;
 
             // 미니 보스 마크는 챕터의 차수 목록에서 파생된 값이다. 챕터에 차수가 없으면 마크도 없는 게 맞으므로

--- a/project1/Assets/Scripts/Combat/WaveCombatDirector.cs
+++ b/project1/Assets/Scripts/Combat/WaveCombatDirector.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Mukseon.Core;
 using Mukseon.Core.Pool;
 using Mukseon.Gameplay.Progression;
 using UnityEngine;
@@ -21,6 +22,12 @@ namespace Mukseon.Gameplay.Combat
             public WaveEnemySpawnEntry Entry;
             public object SpeciesKey;
         }
+
+        [Header("Chapter")]
+        [Tooltip("이 챕터의 웨이브 목록과 타임라인 마크를 사용한다(#64). 비우면 아래 값들을 그대로 쓴다. " +
+                 "런타임에는 스테이지 선택 결과(RunContext.SelectedChapter)가 이 값보다 우선한다.")]
+        [SerializeField]
+        private ChapterData _chapterData;
 
         [Header("References")]
         [SerializeField]
@@ -99,6 +106,9 @@ namespace Mukseon.Gameplay.Combat
         /// <summary>보스 진입 분 마크. 0 이하이면 보스 마크가 없다.</summary>
         public float BossMinuteMark => _bossMinuteMark;
 
+        /// <summary>이번 런에 적용된 챕터(#64). 선택 화면을 거쳤으면 선택된 챕터, 아니면 씬에 직렬화된 챕터다.</summary>
+        public ChapterData ActiveChapter => _chapterData;
+
         public event Action<int, WaveDefinition> OnWaveStarted;
         public event Action<int, WaveEndReason> OnWaveEnded;
         public event Action<int, int> OnRemainingEnemyCountChanged;
@@ -120,6 +130,42 @@ namespace Mukseon.Gameplay.Combat
 
         /// <summary>보스 마크 도달 시 1회 발행. 일반 스포닝은 이 시점에 중단된다. 보스 시스템(#37)이 구독.</summary>
         public event Action OnBossPhaseStarted;
+
+        /// <summary>
+        /// 챕터 해석은 반드시 <c>Awake</c>에서 끝나야 한다 — <c>OnEnable</c>이 곧바로 <see cref="StartWaves"/>를
+        /// 호출하므로, 그 시점에는 이미 이 챕터의 웨이브·마크가 자리잡아 있어야 한다.
+        /// (씬 로드 시 Unity는 모든 오브젝트의 Awake를 끝낸 뒤 OnEnable을 돌린다.)
+        /// </summary>
+        private void Awake()
+        {
+            ApplyChapterData();
+        }
+
+        /// <summary>
+        /// 스테이지 선택에서 고른 챕터를 우선하고, 없으면 씬에 직렬화된 챕터로 폴백한다.
+        /// 둘 다 없으면 아무것도 덮어쓰지 않아 종전처럼 씬 값으로 동작한다(#36의 캐릭터 해석과 같은 규약).
+        /// </summary>
+        private void ApplyChapterData()
+        {
+            ChapterData chapter = RunContext.SelectedChapter != null ? RunContext.SelectedChapter : _chapterData;
+            if (chapter == null)
+            {
+                return;
+            }
+
+            _chapterData = chapter;
+
+            if (chapter.WaveDatabase != null)
+            {
+                _waveDatabase = chapter.WaveDatabase;
+            }
+
+            _bossMinuteMark = chapter.BossMinuteMark;
+
+            // 미니 보스 마크는 챕터의 차수 목록에서 파생된 값이다. 챕터에 차수가 없으면 마크도 없는 게 맞으므로
+            // 비어 있어도 그대로 반영한다 — 여기서 씬 값을 남겨두면 스포너에 없는 차수의 마크만 울린다.
+            _miniBossMinuteMarks = new List<float>(chapter.MiniBossMinuteMarks);
+        }
 
         private void OnEnable()
         {

--- a/project1/Assets/Scripts/Core/RunContext.cs
+++ b/project1/Assets/Scripts/Core/RunContext.cs
@@ -1,3 +1,4 @@
+using Mukseon.Gameplay.Combat;
 using Mukseon.Gameplay.Stats;
 using UnityEngine;
 
@@ -17,6 +18,12 @@ namespace Mukseon.Core
         public static CharacterData SelectedCharacter { get; set; }
 
         /// <summary>
+        /// 이번 런에 선택된 챕터(#64). null이면 게임플레이 씬의 디렉터들이 각자 직렬화된 값으로 폴백한다.
+        /// 캐릭터와 같은 규약이다 — 스테이지 선택 화면이 채우고, 웨이브·미니 보스·보스 디렉터가 읽어간다.
+        /// </summary>
+        public static ChapterData SelectedChapter { get; set; }
+
+        /// <summary>
         /// Enter Play Mode 설정에서 Domain Reload가 꺼져 있으면 static이 세션 간 유지된다.
         /// 이전 세션의 선택이 남아 다음 플레이에 새어 들어가지 않도록 진입 시 비운다.
         /// </summary>
@@ -24,6 +31,7 @@ namespace Mukseon.Core
         public static void Reset()
         {
             SelectedCharacter = null;
+            SelectedChapter = null;
         }
     }
 }

--- a/project1/Assets/Settings/Data/Chapters.meta
+++ b/project1/Assets/Settings/Data/Chapters.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 84ef78f7df904de3b9c5de44b1259931
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/project1/Assets/Settings/Data/Chapters/Chapter1_Sillim.asset
+++ b/project1/Assets/Settings/Data/Chapters/Chapter1_Sillim.asset
@@ -1,0 +1,125 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 330c7900de17a59499547d23ba978b16, type: 3}
+  m_Name: Chapter1_Sillim
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.ChapterData
+  _chapterId: chapter.1.sillim
+  _displayName: Chapter 1 - Sillim
+  _backgroundSceneName:
+  _waveDatabase: {fileID: 11400000, guid: 761c6a7730f34dde86070de259bcccd6, type: 2}
+  _enemyPool:
+  - _enemyType: monster.sonakssi
+    _monsterData: {fileID: 11400000, guid: fb24fd5e38994de6a94055af52dc5df6, type: 2}
+    _enemyPrefab: {fileID: 0}
+    _minAliveCount: 1
+    _moveSpeed: 1
+  - _enemyType: monster.ashen_claw
+    _monsterData: {fileID: 11400000, guid: 77661a277270a784b8c5751d1df4503e, type: 2}
+    _enemyPrefab: {fileID: 0}
+    _minAliveCount: 1
+    _moveSpeed: 1
+  - _enemyType: monster.mangryang
+    _monsterData: {fileID: 11400000, guid: 43506e89a63343819b87c407111527e6, type: 2}
+    _enemyPrefab: {fileID: 0}
+    _minAliveCount: 1
+    _moveSpeed: 1
+  - _enemyType: monster.sangwi
+    _monsterData: {fileID: 11400000, guid: 09e5f3c235914a7a86e707991d9982ed, type: 2}
+    _enemyPrefab: {fileID: 0}
+    _minAliveCount: 1
+    _moveSpeed: 1
+  - _enemyType: monster.dusk_shade
+    _monsterData: {fileID: 11400000, guid: 0c9e73336ec6803409b3e8030695eca2, type: 2}
+    _enemyPrefab: {fileID: 0}
+    _minAliveCount: 1
+    _moveSpeed: 1
+  - _enemyType: monster.dureoksini
+    _monsterData: {fileID: 11400000, guid: 29fa4d2c3fd292642baaf7f072b8e86e, type: 2}
+    _enemyPrefab: {fileID: 0}
+    _minAliveCount: 1
+    _moveSpeed: 1
+  - _enemyType: monster.dokkaebibul
+    _monsterData: {fileID: 11400000, guid: 6871f23fb6aa420f8bcc706b3f6c6cfd, type: 2}
+    _enemyPrefab: {fileID: 0}
+    _minAliveCount: 1
+    _moveSpeed: 1
+  - _enemyType: monster.bramble_idol
+    _monsterData: {fileID: 11400000, guid: 89dfd2a29b064fa47a88cabf39d5d41b, type: 2}
+    _enemyPrefab: {fileID: 0}
+    _minAliveCount: 1
+    _moveSpeed: 1
+  - _enemyType: monster.maegu
+    _monsterData: {fileID: 11400000, guid: bd890c0541c5445d8225e7789bea10b2, type: 2}
+    _enemyPrefab: {fileID: 0}
+    _minAliveCount: 1
+    _moveSpeed: 1
+  _miniBossCandidates:
+  - _enemyType: monster.sonakssi
+    _monsterData: {fileID: 11400000, guid: fb24fd5e38994de6a94055af52dc5df6, type: 2}
+    _enemyPrefab: {fileID: 0}
+    _minAliveCount: 1
+    _moveSpeed: 1
+  - _enemyType: monster.ashen_claw
+    _monsterData: {fileID: 11400000, guid: 77661a277270a784b8c5751d1df4503e, type: 2}
+    _enemyPrefab: {fileID: 0}
+    _minAliveCount: 1
+    _moveSpeed: 1
+  - _enemyType: monster.mangryang
+    _monsterData: {fileID: 11400000, guid: 43506e89a63343819b87c407111527e6, type: 2}
+    _enemyPrefab: {fileID: 0}
+    _minAliveCount: 1
+    _moveSpeed: 1
+  - _enemyType: monster.sangwi
+    _monsterData: {fileID: 11400000, guid: 09e5f3c235914a7a86e707991d9982ed, type: 2}
+    _enemyPrefab: {fileID: 0}
+    _minAliveCount: 1
+    _moveSpeed: 1
+  - _enemyType: monster.dureoksini
+    _monsterData: {fileID: 11400000, guid: 29fa4d2c3fd292642baaf7f072b8e86e, type: 2}
+    _enemyPrefab: {fileID: 0}
+    _minAliveCount: 1
+    _moveSpeed: 1
+  - _enemyType: monster.dusk_shade
+    _monsterData: {fileID: 11400000, guid: 0c9e73336ec6803409b3e8030695eca2, type: 2}
+    _enemyPrefab: {fileID: 0}
+    _minAliveCount: 1
+    _moveSpeed: 1
+  - _enemyType: monster.bramble_idol
+    _monsterData: {fileID: 11400000, guid: 89dfd2a29b064fa47a88cabf39d5d41b, type: 2}
+    _enemyPrefab: {fileID: 0}
+    _minAliveCount: 1
+    _moveSpeed: 1
+  _miniBossStages:
+  - _spawnMinuteMark: 3
+    _healthMultiplier: 5
+    _sizeMultiplier: 1.5
+    _knockbackThresholdRatio: 0.1
+    _moveSpeed: 0.5
+    _goldReward: 100
+    _soulCurrencyReward: 1
+  - _spawnMinuteMark: 6
+    _healthMultiplier: 8
+    _sizeMultiplier: 2
+    _knockbackThresholdRatio: 0.1
+    _moveSpeed: 0.5
+    _goldReward: 150
+    _soulCurrencyReward: 2
+  - _spawnMinuteMark: 9
+    _healthMultiplier: 12
+    _sizeMultiplier: 2.5
+    _knockbackThresholdRatio: 0.1
+    _moveSpeed: 0.5
+    _goldReward: 200
+    _soulCurrencyReward: 3
+  _bossMinuteMark: 10
+  _bossData: {fileID: 11400000, guid: d5cb2b2179043284b8598eded7b33cb6, type: 2}
+  _bossPrefab: {fileID: 2681383079461457332, guid: f6f5de12d7863c04ab83d3482bca5c6b, type: 3}

--- a/project1/Assets/Settings/Data/Chapters/Chapter1_Sillim.asset.meta
+++ b/project1/Assets/Settings/Data/Chapters/Chapter1_Sillim.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c6f2ea4d2fc04e32a642af5e9375557a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/project1/Assets/Settings/Data/Chapters/Chapter2_Cheonjedan.asset
+++ b/project1/Assets/Settings/Data/Chapters/Chapter2_Cheonjedan.asset
@@ -19,6 +19,6 @@ MonoBehaviour:
   _enemyPool: []
   _miniBossCandidates: []
   _miniBossStages: []
-  _bossMinuteMark: 10
+  _bossMinuteMark: 0
   _bossData: {fileID: 0}
   _bossPrefab: {fileID: 0}

--- a/project1/Assets/Settings/Data/Chapters/Chapter2_Cheonjedan.asset
+++ b/project1/Assets/Settings/Data/Chapters/Chapter2_Cheonjedan.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 330c7900de17a59499547d23ba978b16, type: 3}
+  m_Name: Chapter2_Cheonjedan
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.ChapterData
+  _chapterId: chapter.2.cheonjedan
+  _displayName: Chapter 2 - Cheonjedan
+  _backgroundSceneName:
+  _waveDatabase: {fileID: 0}
+  _enemyPool: []
+  _miniBossCandidates: []
+  _miniBossStages: []
+  _bossMinuteMark: 10
+  _bossData: {fileID: 0}
+  _bossPrefab: {fileID: 0}

--- a/project1/Assets/Settings/Data/Chapters/Chapter2_Cheonjedan.asset.meta
+++ b/project1/Assets/Settings/Data/Chapters/Chapter2_Cheonjedan.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6ab83421eda6403d9d59c2ef8d02d570
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/project1/Assets/Settings/Data/Chapters/Chapter3_Indangsu.asset
+++ b/project1/Assets/Settings/Data/Chapters/Chapter3_Indangsu.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 330c7900de17a59499547d23ba978b16, type: 3}
+  m_Name: Chapter3_Indangsu
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.ChapterData
+  _chapterId: chapter.3.indangsu
+  _displayName: Chapter 3 - Indangsu
+  _backgroundSceneName:
+  _waveDatabase: {fileID: 0}
+  _enemyPool: []
+  _miniBossCandidates: []
+  _miniBossStages: []
+  _bossMinuteMark: 10
+  _bossData: {fileID: 0}
+  _bossPrefab: {fileID: 0}

--- a/project1/Assets/Settings/Data/Chapters/Chapter3_Indangsu.asset
+++ b/project1/Assets/Settings/Data/Chapters/Chapter3_Indangsu.asset
@@ -19,6 +19,6 @@ MonoBehaviour:
   _enemyPool: []
   _miniBossCandidates: []
   _miniBossStages: []
-  _bossMinuteMark: 10
+  _bossMinuteMark: 0
   _bossData: {fileID: 0}
   _bossPrefab: {fileID: 0}

--- a/project1/Assets/Settings/Data/Chapters/Chapter3_Indangsu.asset.meta
+++ b/project1/Assets/Settings/Data/Chapters/Chapter3_Indangsu.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b486da80f2204f888b3cead9ad3692dc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/project1/Assets/Settings/Data/Chapters/ChapterDatabase.asset
+++ b/project1/Assets/Settings/Data/Chapters/ChapterDatabase.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1f38e371b5df7124aad344ad40909466, type: 3}
+  m_Name: ChapterDatabase
+  m_EditorClassIdentifier: Mukseon.Core::Mukseon.Gameplay.Combat.ChapterDatabase
+  _chapters:
+  - {fileID: 11400000, guid: c6f2ea4d2fc04e32a642af5e9375557a, type: 2}
+  - {fileID: 11400000, guid: 6ab83421eda6403d9d59c2ef8d02d570, type: 2}
+  - {fileID: 11400000, guid: b486da80f2204f888b3cead9ad3692dc, type: 2}

--- a/project1/Assets/Settings/Data/Chapters/ChapterDatabase.asset.meta
+++ b/project1/Assets/Settings/Data/Chapters/ChapterDatabase.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9fb651c4d7114a0c8d1b3279c50af9c0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/project1/Assets/Tests/EditMode/ChapterAssetTests.cs
+++ b/project1/Assets/Tests/EditMode/ChapterAssetTests.cs
@@ -1,0 +1,80 @@
+using Mukseon.Gameplay.Combat;
+using NUnit.Framework;
+using UnityEditor;
+
+namespace Mukseon.Tests.EditMode
+{
+    /// <summary>
+    /// 저장소에 실제로 커밋된 챕터 에셋을 로드해 검사한다(#64 DoD "3개 챕터에 대한 ChapterData 에셋이 존재한다").
+    ///
+    /// 코드로 만든 인스턴스가 아니라 에셋을 읽는 게 요점이다 — 참조가 끊기거나 GUID가 어긋나면
+    /// 컴파일도 통과하고 다른 테스트도 다 통과하지만 게임만 조용히 비어 있게 된다.
+    /// </summary>
+    public class ChapterAssetTests
+    {
+        private const string ChaptersPath = "Assets/Settings/Data/Chapters";
+        private const string Chapter1Path = ChaptersPath + "/Chapter1_Sillim.asset";
+        private const string DatabasePath = ChaptersPath + "/ChapterDatabase.asset";
+
+        [Test]
+        public void Chapter1_Asset_IsFullyAuthoredAndValid()
+        {
+            ChapterData chapter = AssetDatabase.LoadAssetAtPath<ChapterData>(Chapter1Path);
+            Assert.That(chapter, Is.Not.Null, $"챕터 에셋을 찾을 수 없습니다: {Chapter1Path}");
+
+            Assert.That(chapter.IsValid(out string reason), Is.True, reason);
+            Assert.That(chapter.WaveDatabase, Is.Not.Null);
+            Assert.That(chapter.BossPrefab, Is.Not.Null);
+            Assert.That(chapter.BossData, Is.Not.Null);
+        }
+
+        [Test]
+        public void Chapter1_Asset_KeepsTheTimelineTheSceneUsedToOwn()
+        {
+            ChapterData chapter = AssetDatabase.LoadAssetAtPath<ChapterData>(Chapter1Path);
+
+            // 씬 세 컴포넌트에 흩어져 있던 값을 그대로 옮겨왔는지 — 여기가 어긋나면 챕터 1의 난이도 곡선이 바뀐다.
+            Assert.That(chapter.MiniBossMinuteMarks, Is.EqualTo(new[] { 3f, 6f, 9f }));
+            Assert.That(chapter.BossMinuteMark, Is.EqualTo(10f));
+            Assert.That(chapter.MiniBossStages.Count, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void Chapter1_Asset_RosterCoversEveryWaveEnemy_AndExcludesGimmicksFromMiniBoss()
+        {
+            ChapterData chapter = AssetDatabase.LoadAssetAtPath<ChapterData>(Chapter1Path);
+
+            // 로스터 9종 = 웨이브에 등장하는 전체 종류. IsValid의 격리 검증이 이걸 보장한다.
+            Assert.That(chapter.EnemyPool.Count, Is.EqualTo(9));
+
+            // 미니 보스 후보는 7종 — 도깨비불·매구는 씬의 기존 풀에도 없었으므로 그대로 뺀 상태를 유지한다.
+            Assert.That(chapter.MiniBossCandidates.Count, Is.EqualTo(7));
+        }
+
+        [Test]
+        public void ChapterDatabase_Asset_ListsAllThreeChapters()
+        {
+            ChapterDatabase database = AssetDatabase.LoadAssetAtPath<ChapterDatabase>(DatabasePath);
+            Assert.That(database, Is.Not.Null, $"챕터 목록 에셋을 찾을 수 없습니다: {DatabasePath}");
+
+            Assert.That(database.IsValid(out string reason), Is.True, reason);
+            Assert.That(database.Chapters.Count, Is.EqualTo(3));
+            Assert.That(database.Find("chapter.1.sillim"), Is.Not.Null);
+            Assert.That(database.Find("chapter.2.cheonjedan"), Is.Not.Null);
+            Assert.That(database.Find("chapter.3.indangsu"), Is.Not.Null);
+            Assert.That(database.DefaultChapter.ChapterId, Is.EqualTo("chapter.1.sillim"));
+        }
+
+        [Test]
+        public void SkeletonChapters_AreKnownIncomplete_ButDoNotBreakTheList()
+        {
+            ChapterDatabase database = AssetDatabase.LoadAssetAtPath<ChapterDatabase>(DatabasePath);
+
+            // 2·3장은 의도적으로 골격만 있다(적 구성은 후속 기획). 목록 검증은 통과하되
+            // 개별 챕터 검증은 실패하는 게 정상이며, 그래서 플레이 가능한 1장이 화면에서 사라지지 않는다.
+            ChapterData chapter2 = database.Find("chapter.2.cheonjedan");
+            Assert.That(chapter2.IsValid(out _), Is.False, "2장이 완성되면 이 테스트를 갱신할 것.");
+            Assert.That(database.IsValid(out _), Is.True);
+        }
+    }
+}

--- a/project1/Assets/Tests/EditMode/ChapterAssetTests.cs
+++ b/project1/Assets/Tests/EditMode/ChapterAssetTests.cs
@@ -47,7 +47,10 @@ namespace Mukseon.Tests.EditMode
             // 로스터 9종 = 웨이브에 등장하는 전체 종류. IsValid의 격리 검증이 이걸 보장한다.
             Assert.That(chapter.EnemyPool.Count, Is.EqualTo(9));
 
-            // 미니 보스 후보는 7종 — 도깨비불·매구는 씬의 기존 풀에도 없었으므로 그대로 뺀 상태를 유지한다.
+            // 미니 보스 후보는 7종 — 도깨비불·매구를 뺀 것은 누락이 아니라 의도된 제외다.
+            // 도깨비불: Explode()에서 스스로 Kill()을 불러 차수 체력 배율과 무관하게 1.5초 만에 자멸한다.
+            //           플레이어가 아무것도 안 해도 미니 보스 보상(골드·영혼·스킬 선택)이 지급된다.
+            // 매구: 거리를 벌리며 투사체를 쏘는 적이라 느려져도 스와이프 사거리로 들어오지 않는다 — 처치 기회가 안 생긴다.
             Assert.That(chapter.MiniBossCandidates.Count, Is.EqualTo(7));
         }
 
@@ -72,8 +75,20 @@ namespace Mukseon.Tests.EditMode
 
             // 2·3장은 의도적으로 골격만 있다(적 구성은 후속 기획). 목록 검증은 통과하되
             // 개별 챕터 검증은 실패하는 게 정상이며, 그래서 플레이 가능한 1장이 화면에서 사라지지 않는다.
-            ChapterData chapter2 = database.Find("chapter.2.cheonjedan");
-            Assert.That(chapter2.IsValid(out _), Is.False, "2장이 완성되면 이 테스트를 갱신할 것.");
+            //
+            // reason까지 못 박는 이유: 실패 사유가 하나씩 채워질 때 무엇이 남았는지 바로 드러나야 한다.
+            // 지금 남은 항목은 웨이브 데이터베이스이며, 이걸 채우면 다음 사유(적 풀)로 넘어간다.
+            foreach (string chapterId in new[] { "chapter.2.cheonjedan", "chapter.3.indangsu" })
+            {
+                ChapterData skeleton = database.Find(chapterId);
+                Assert.That(skeleton.IsValid(out string reason), Is.False, $"{chapterId}이 완성되면 이 테스트를 갱신할 것.");
+                Assert.That(reason, Does.Contain("웨이브"), chapterId);
+
+                // 보스 마크 0 = "보스 없음". 보스 프리팹이 없는 챕터가 마크만 들고 있으면
+                // 10분에 BossEncounterDirector가 씬(=1장)의 보스를 그대로 띄운다.
+                Assert.That(skeleton.BossMinuteMark, Is.EqualTo(0f), $"{chapterId}: 보스가 없는 챕터는 마크도 0이어야 한다.");
+            }
+
             Assert.That(database.IsValid(out _), Is.True);
         }
     }

--- a/project1/Assets/Tests/EditMode/ChapterAssetTests.cs.meta
+++ b/project1/Assets/Tests/EditMode/ChapterAssetTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0e3e55ea2daf3bd4f84e4ed74059fca1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/project1/Assets/Tests/EditMode/ChapterBindingTests.cs
+++ b/project1/Assets/Tests/EditMode/ChapterBindingTests.cs
@@ -1,9 +1,11 @@
 using System.Collections.Generic;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Mukseon.Core;
 using Mukseon.Gameplay.Combat;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace Mukseon.Tests.EditMode
 {
@@ -13,9 +15,18 @@ namespace Mukseon.Tests.EditMode
     ///
     /// EditMode에서 AddComponent는 Awake를 부르지 않으므로, 각 디렉터의 <c>ApplyChapterData</c>를
     /// 직접 호출해 검사한다 — 런타임에 이 메서드를 부르는 주체가 Awake다.
+    ///
+    /// 디렉터는 챕터를 <b>통째로</b> 받거나 통째로 무시하므로, 배선을 보는 테스트는 모두
+    /// <see cref="ChapterData.IsValid"/>를 통과하는 챕터에서 출발한다(<see cref="CreatePlayableChapter"/>).
     /// </summary>
     public class ChapterBindingTests
     {
+        /// <summary>
+        /// 미완성 챕터를 만났을 때 세 디렉터가 남기는 경고의 공통 부분.
+        /// 요점은 "조용히 다른 챕터 콘텐츠로 퇴화하지 않는다"이므로 문구가 아니라 경고의 존재를 본다.
+        /// </summary>
+        private static readonly Regex IncompleteChapterWarning = new Regex("유효하지 않아");
+
         private readonly List<Object> _created = new List<Object>();
 
         [TearDown]
@@ -67,7 +78,7 @@ namespace Mukseon.Tests.EditMode
         [Test]
         public void WaveCombatDirector_AppliesWaveDatabaseAndTimelineMarks()
         {
-            ChapterData chapter = CreateChapter("chapter.1.sillim");
+            ChapterData chapter = CreatePlayableChapter("chapter.1.sillim");
             WaveDatabase waves = CreateWaveDatabase();
             SetPrivateField(chapter, "_waveDatabase", waves);
             SetPrivateField(chapter, "_bossMinuteMark", 12f);
@@ -94,10 +105,10 @@ namespace Mukseon.Tests.EditMode
         [Test]
         public void WaveCombatDirector_PrefersSelectedChapterOverSerializedOne()
         {
-            ChapterData serialized = CreateChapter("chapter.1.sillim");
+            ChapterData serialized = CreatePlayableChapter("chapter.1.sillim");
             SetPrivateField(serialized, "_bossMinuteMark", 10f);
 
-            ChapterData selected = CreateChapter("chapter.2.cheonjedan");
+            ChapterData selected = CreatePlayableChapter("chapter.2.cheonjedan");
             SetPrivateField(selected, "_bossMinuteMark", 15f);
 
             WaveCombatDirector director = CreateComponent<WaveCombatDirector>();
@@ -126,13 +137,57 @@ namespace Mukseon.Tests.EditMode
             Assert.That(director.BossMinuteMark, Is.EqualTo(7f));
         }
 
+        /// <summary>
+        /// 미완성 챕터를 골랐을 때 필드별로 폴백하면 "2장인데 웨이브·보스는 1장"이 되고, 그 상태로도
+        /// 게임이 조용히 굴러가 2장이 미완성이라는 걸 플레이로는 알 수 없다. 통째로 무시하고 경고를 남긴다.
+        /// </summary>
+        [Test]
+        public void WaveCombatDirector_IgnoresIncompleteChapter_AndKeepsSceneTimeline()
+        {
+            WaveDatabase sceneWaves = CreateWaveDatabase();
+            WaveCombatDirector director = CreateComponent<WaveCombatDirector>();
+            SetPrivateField(director, "_waveDatabase", sceneWaves);
+            SetPrivateField(director, "_bossMinuteMark", 10f);
+
+            // 2·3장 골격처럼 아직 웨이브도 로스터도 없는 챕터.
+            RunContext.SelectedChapter = CreateChapter("chapter.2.cheonjedan");
+
+            LogAssert.Expect(LogType.Warning, IncompleteChapterWarning);
+            Invoke(director, "ApplyChapterData");
+
+            Assert.That(GetPrivateField<WaveDatabase>(director, "_waveDatabase"), Is.SameAs(sceneWaves));
+            Assert.That(director.BossMinuteMark, Is.EqualTo(10f));
+
+            // 적용되지 않은 챕터가 ActiveChapter로 남으면 결과 화면·UI가 2장을 진행 중이라고 표시한다.
+            Assert.That(director.ActiveChapter, Is.Null);
+        }
+
+        [Test]
+        public void MiniBossSpawner_IgnoresIncompleteChapter_AndKeepsSceneStages()
+        {
+            var scenePool = new List<WaveEnemySpawnEntry> { CreateEntry(CreateMonsterData("Changgwi")) };
+            var sceneStages = new List<MiniBossStageData> { CreateStage(3f) };
+
+            MiniBossSpawner spawner = CreateComponent<MiniBossSpawner>();
+            SetPrivateField(spawner, "_enemyPool", scenePool);
+            SetPrivateField(spawner, "_stages", sceneStages);
+            SetPrivateField(spawner, "_chapterData", CreateChapter("chapter.2.cheonjedan"));
+
+            LogAssert.Expect(LogType.Warning, IncompleteChapterWarning);
+            Invoke(spawner, "ApplyChapterData");
+
+            // 세 디렉터가 같은 판정을 내리므로 디렉터가 씬 값으로 남을 때 스포너도 함께 남아야 한다.
+            Assert.That(GetPrivateField<List<WaveEnemySpawnEntry>>(spawner, "_enemyPool"), Is.SameAs(scenePool));
+            Assert.That(GetPrivateField<List<MiniBossStageData>>(spawner, "_stages"), Is.SameAs(sceneStages));
+        }
+
         [Test]
         public void MiniBossSpawner_UsesCandidateList_NotFullRoster()
         {
             MonsterData wolf = CreateMonsterData("Changgwi");
             MonsterData gimmick = CreateMonsterData("Dokkaebibul");
 
-            ChapterData chapter = CreateChapter("chapter.1.sillim");
+            ChapterData chapter = CreatePlayableChapter("chapter.1.sillim");
             SetPrivateField(chapter, "_enemyPool", new List<WaveEnemySpawnEntry>
             {
                 CreateEntry(wolf),
@@ -158,7 +213,7 @@ namespace Mukseon.Tests.EditMode
         public void BossEncounterDirector_AppliesChapterBossPrefab()
         {
             EnemyHealth chapterBoss = CreatePrefab("CorruptedMountainKing");
-            ChapterData chapter = CreateChapter("chapter.1.sillim");
+            ChapterData chapter = CreatePlayableChapter("chapter.1.sillim");
             SetPrivateField(chapter, "_bossPrefab", chapterBoss);
 
             BossEncounterDirector director = CreateComponent<BossEncounterDirector>();
@@ -169,7 +224,7 @@ namespace Mukseon.Tests.EditMode
         }
 
         [Test]
-        public void BossEncounterDirector_KeepsScenePrefab_WhenChapterHasNoBoss()
+        public void BossEncounterDirector_KeepsSceneBoss_WhenChapterIsIncomplete()
         {
             EnemyHealth sceneBoss = CreatePrefab("SceneBoss");
             ChapterData skeleton = CreateChapter("chapter.2.cheonjedan");
@@ -177,10 +232,46 @@ namespace Mukseon.Tests.EditMode
             BossEncounterDirector director = CreateComponent<BossEncounterDirector>();
             SetPrivateField(director, "_bossPrefab", sceneBoss);
             SetPrivateField(director, "_chapterData", skeleton);
+
+            LogAssert.Expect(LogType.Warning, IncompleteChapterWarning);
             Invoke(director, "ApplyChapterData");
 
-            // 아직 골격만 있는 2·3장이 씬의 멀쩡한 보스를 지워버리면 안 된다.
+            // 골격 챕터는 통째로 무시되므로 씬의 멀쩡한 보스가 남는다.
+            // (이 경로가 없으면 2장 보스 자리에 1장 산군이 조용히 등장한다.)
             Assert.That(GetPrivateField<EnemyHealth>(director, "_bossPrefab"), Is.SameAs(sceneBoss));
+        }
+
+        [Test]
+        public void BossEncounterDirector_ClearsSceneBoss_WhenChapterHasNoBossByDesign()
+        {
+            ChapterData chapter = CreatePlayableChapter("chapter.tutorial");
+            SetPrivateField(chapter, "_bossMinuteMark", 0f);
+            SetPrivateField(chapter, "_bossPrefab", (EnemyHealth)null);
+
+            BossEncounterDirector director = CreateComponent<BossEncounterDirector>();
+            SetPrivateField(director, "_bossPrefab", CreatePrefab("SceneBoss"));
+            SetPrivateField(director, "_chapterData", chapter);
+            Invoke(director, "ApplyChapterData");
+
+            // 유효하지만 보스가 없는 챕터(마크 0)는 씬 보스를 물려받지 않는다 — 절반만 갈아끼우면
+            // 나중에 마크가 생겼을 때 다른 챕터의 보스가 튀어나온다. 마크가 0이라 어차피 보스 페이즈는 없다.
+            Assert.That(GetPrivateField<EnemyHealth>(director, "_bossPrefab"), Is.Null);
+        }
+
+        /// <summary>
+        /// <see cref="ChapterData.IsValid"/>를 통과하는 최소 챕터 — 로스터 1종 + 웨이브 + 보스 프리팹.
+        /// 디렉터가 챕터를 통째로 검사하므로, 배선 테스트도 유효한 챕터에서 출발해야 한다.
+        /// </summary>
+        private ChapterData CreatePlayableChapter(string chapterId)
+        {
+            ChapterData chapter = CreateChapter(chapterId);
+            SetPrivateField(chapter, "_enemyPool", new List<WaveEnemySpawnEntry>
+            {
+                CreateEntry(CreateMonsterData("Changgwi"))
+            });
+            SetPrivateField(chapter, "_waveDatabase", CreateWaveDatabase());
+            SetPrivateField(chapter, "_bossPrefab", CreatePrefab("Boss"));
+            return chapter;
         }
 
         private ChapterData CreateChapter(string chapterId)

--- a/project1/Assets/Tests/EditMode/ChapterBindingTests.cs
+++ b/project1/Assets/Tests/EditMode/ChapterBindingTests.cs
@@ -1,0 +1,272 @@
+using System.Collections.Generic;
+using System.Reflection;
+using Mukseon.Core;
+using Mukseon.Gameplay.Combat;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Mukseon.Tests.EditMode
+{
+    /// <summary>
+    /// 챕터 목록(<see cref="ChapterDatabase"/>)과, 선택된 챕터가 전투 시스템 세 곳에
+    /// 실제로 전달되는지(#64 DoD)를 본다.
+    ///
+    /// EditMode에서 AddComponent는 Awake를 부르지 않으므로, 각 디렉터의 <c>ApplyChapterData</c>를
+    /// 직접 호출해 검사한다 — 런타임에 이 메서드를 부르는 주체가 Awake다.
+    /// </summary>
+    public class ChapterBindingTests
+    {
+        private readonly List<Object> _created = new List<Object>();
+
+        [TearDown]
+        public void TearDown()
+        {
+            // static이라 테스트 간에 새어 나간다. RunContext.Reset()과 같은 이유로 반드시 비운다.
+            RunContext.SelectedChapter = null;
+
+            for (int i = 0; i < _created.Count; i++)
+            {
+                Object.DestroyImmediate(_created[i]);
+            }
+
+            _created.Clear();
+        }
+
+        [Test]
+        public void ChapterDatabase_IsInvalid_WhenChapterIdsCollide()
+        {
+            ChapterDatabase database = CreateDatabase(
+                CreateChapter("chapter.1.sillim"),
+                CreateChapter("chapter.1.sillim"));
+
+            Assert.That(database.IsValid(out string reason), Is.False);
+            Assert.That(reason, Does.Contain("chapter.1.sillim"));
+        }
+
+        [Test]
+        public void ChapterDatabase_FindAndDefaultChapter_ResolveById()
+        {
+            ChapterData first = CreateChapter("chapter.1.sillim");
+            ChapterData second = CreateChapter("chapter.2.cheonjedan");
+            ChapterDatabase database = CreateDatabase(first, second);
+
+            Assert.That(database.Find("chapter.2.cheonjedan"), Is.SameAs(second));
+            Assert.That(database.Find("chapter.9.missing"), Is.Null);
+            Assert.That(database.DefaultChapter, Is.SameAs(first));
+        }
+
+        [Test]
+        public void ChapterDatabase_DefaultChapter_SkipsNullEntries()
+        {
+            ChapterData real = CreateChapter("chapter.1.sillim");
+            ChapterDatabase database = CreateDatabase(null, real);
+
+            Assert.That(database.DefaultChapter, Is.SameAs(real));
+        }
+
+        [Test]
+        public void WaveCombatDirector_AppliesWaveDatabaseAndTimelineMarks()
+        {
+            ChapterData chapter = CreateChapter("chapter.1.sillim");
+            WaveDatabase waves = CreateWaveDatabase();
+            SetPrivateField(chapter, "_waveDatabase", waves);
+            SetPrivateField(chapter, "_bossMinuteMark", 12f);
+            SetPrivateField(chapter, "_miniBossStages", new List<MiniBossStageData>
+            {
+                CreateStage(4f),
+                CreateStage(8f)
+            });
+
+            WaveCombatDirector director = CreateComponent<WaveCombatDirector>();
+            SetPrivateField(director, "_chapterData", chapter);
+            Invoke(director, "ApplyChapterData");
+
+            Assert.That(GetPrivateField<WaveDatabase>(director, "_waveDatabase"), Is.SameAs(waves));
+            Assert.That(director.BossMinuteMark, Is.EqualTo(12f));
+            Assert.That(director.ActiveChapter, Is.SameAs(chapter));
+
+            // 마크는 챕터의 차수에서 파생되므로 스포너의 차수와 항상 짝이 맞는다.
+            Assert.That(
+                GetPrivateField<List<float>>(director, "_miniBossMinuteMarks"),
+                Is.EqualTo(new[] { 4f, 8f }));
+        }
+
+        [Test]
+        public void WaveCombatDirector_PrefersSelectedChapterOverSerializedOne()
+        {
+            ChapterData serialized = CreateChapter("chapter.1.sillim");
+            SetPrivateField(serialized, "_bossMinuteMark", 10f);
+
+            ChapterData selected = CreateChapter("chapter.2.cheonjedan");
+            SetPrivateField(selected, "_bossMinuteMark", 15f);
+
+            WaveCombatDirector director = CreateComponent<WaveCombatDirector>();
+            SetPrivateField(director, "_chapterData", serialized);
+            RunContext.SelectedChapter = selected;
+
+            Invoke(director, "ApplyChapterData");
+
+            // 스테이지 선택 결과가 씬 직렬화 값을 이긴다(#36 캐릭터 해석과 같은 규약).
+            Assert.That(director.ActiveChapter, Is.SameAs(selected));
+            Assert.That(director.BossMinuteMark, Is.EqualTo(15f));
+        }
+
+        [Test]
+        public void WaveCombatDirector_LeavesSceneValuesAlone_WhenNoChapterIsSet()
+        {
+            WaveDatabase sceneWaves = CreateWaveDatabase();
+            WaveCombatDirector director = CreateComponent<WaveCombatDirector>();
+            SetPrivateField(director, "_waveDatabase", sceneWaves);
+            SetPrivateField(director, "_bossMinuteMark", 7f);
+
+            Invoke(director, "ApplyChapterData");
+
+            // 게임플레이 씬 단독 실행(에디터)에서 종전처럼 동작해야 한다.
+            Assert.That(GetPrivateField<WaveDatabase>(director, "_waveDatabase"), Is.SameAs(sceneWaves));
+            Assert.That(director.BossMinuteMark, Is.EqualTo(7f));
+        }
+
+        [Test]
+        public void MiniBossSpawner_UsesCandidateList_NotFullRoster()
+        {
+            MonsterData wolf = CreateMonsterData("Changgwi");
+            MonsterData gimmick = CreateMonsterData("Dokkaebibul");
+
+            ChapterData chapter = CreateChapter("chapter.1.sillim");
+            SetPrivateField(chapter, "_enemyPool", new List<WaveEnemySpawnEntry>
+            {
+                CreateEntry(wolf),
+                CreateEntry(gimmick)
+            });
+            SetPrivateField(chapter, "_miniBossCandidates", new List<WaveEnemySpawnEntry> { CreateEntry(wolf) });
+            SetPrivateField(chapter, "_miniBossStages", new List<MiniBossStageData> { CreateStage(3f) });
+
+            MiniBossSpawner spawner = CreateComponent<MiniBossSpawner>();
+            SetPrivateField(spawner, "_chapterData", chapter);
+            Invoke(spawner, "ApplyChapterData");
+
+            var pool = GetPrivateField<List<WaveEnemySpawnEntry>>(spawner, "_enemyPool");
+            Assert.That(pool.Count, Is.EqualTo(1), "기믹 적은 미니 보스 후보에서 빠져야 한다.");
+            Assert.That(pool[0].SpeciesKey, Is.SameAs(wolf));
+
+            var stages = GetPrivateField<List<MiniBossStageData>>(spawner, "_stages");
+            Assert.That(stages.Count, Is.EqualTo(1));
+            Assert.That(stages[0].SpawnMinuteMark, Is.EqualTo(3f));
+        }
+
+        [Test]
+        public void BossEncounterDirector_AppliesChapterBossPrefab()
+        {
+            EnemyHealth chapterBoss = CreatePrefab("CorruptedMountainKing");
+            ChapterData chapter = CreateChapter("chapter.1.sillim");
+            SetPrivateField(chapter, "_bossPrefab", chapterBoss);
+
+            BossEncounterDirector director = CreateComponent<BossEncounterDirector>();
+            SetPrivateField(director, "_chapterData", chapter);
+            Invoke(director, "ApplyChapterData");
+
+            Assert.That(GetPrivateField<EnemyHealth>(director, "_bossPrefab"), Is.SameAs(chapterBoss));
+        }
+
+        [Test]
+        public void BossEncounterDirector_KeepsScenePrefab_WhenChapterHasNoBoss()
+        {
+            EnemyHealth sceneBoss = CreatePrefab("SceneBoss");
+            ChapterData skeleton = CreateChapter("chapter.2.cheonjedan");
+
+            BossEncounterDirector director = CreateComponent<BossEncounterDirector>();
+            SetPrivateField(director, "_bossPrefab", sceneBoss);
+            SetPrivateField(director, "_chapterData", skeleton);
+            Invoke(director, "ApplyChapterData");
+
+            // 아직 골격만 있는 2·3장이 씬의 멀쩡한 보스를 지워버리면 안 된다.
+            Assert.That(GetPrivateField<EnemyHealth>(director, "_bossPrefab"), Is.SameAs(sceneBoss));
+        }
+
+        private ChapterData CreateChapter(string chapterId)
+        {
+            ChapterData chapter = ScriptableObject.CreateInstance<ChapterData>();
+            chapter.name = chapterId;
+            SetPrivateField(chapter, "_chapterId", chapterId);
+            _created.Add(chapter);
+            return chapter;
+        }
+
+        private ChapterDatabase CreateDatabase(params ChapterData[] chapters)
+        {
+            ChapterDatabase database = ScriptableObject.CreateInstance<ChapterDatabase>();
+            database.name = "TestChapterDatabase";
+            SetPrivateField(database, "_chapters", new List<ChapterData>(chapters));
+            _created.Add(database);
+            return database;
+        }
+
+        private WaveDatabase CreateWaveDatabase()
+        {
+            WaveDatabase database = ScriptableObject.CreateInstance<WaveDatabase>();
+            database.name = "TestWaveDatabase";
+            SetPrivateField(database, "_waves", new List<WaveDefinition> { new WaveDefinition() });
+            _created.Add(database);
+            return database;
+        }
+
+        private WaveEnemySpawnEntry CreateEntry(MonsterData species)
+        {
+            var entry = new WaveEnemySpawnEntry();
+            SetPrivateField(entry, "_monsterData", species);
+            return entry;
+        }
+
+        private MonsterData CreateMonsterData(string displayName)
+        {
+            MonsterData species = ScriptableObject.CreateInstance<MonsterData>();
+            species.name = $"{displayName}_MonsterData";
+            SetPrivateField(species, "_displayName", displayName);
+            SetPrivateField(species, "_enemyPrefab", CreatePrefab(displayName));
+            _created.Add(species);
+            return species;
+        }
+
+        private EnemyHealth CreatePrefab(string objectName)
+        {
+            var go = new GameObject(objectName);
+            _created.Add(go);
+            return go.AddComponent<EnemyHealth>();
+        }
+
+        private T CreateComponent<T>() where T : Component
+        {
+            var go = new GameObject(typeof(T).Name);
+            _created.Add(go);
+            return go.AddComponent<T>();
+        }
+
+        private static MiniBossStageData CreateStage(float minuteMark)
+        {
+            var stage = new MiniBossStageData();
+            SetPrivateField(stage, "_spawnMinuteMark", minuteMark);
+            return stage;
+        }
+
+        private static void Invoke(object target, string methodName)
+        {
+            MethodInfo method = target.GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(method, Is.Not.Null, $"Method not found: {methodName}");
+            method.Invoke(target, null);
+        }
+
+        private static void SetPrivateField<T>(object target, string fieldName, T value)
+        {
+            FieldInfo fieldInfo = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(fieldInfo, Is.Not.Null, $"Field not found: {fieldName}");
+            fieldInfo.SetValue(target, value);
+        }
+
+        private static T GetPrivateField<T>(object target, string fieldName)
+        {
+            FieldInfo fieldInfo = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(fieldInfo, Is.Not.Null, $"Field not found: {fieldName}");
+            return (T)fieldInfo.GetValue(target);
+        }
+    }
+}

--- a/project1/Assets/Tests/EditMode/ChapterBindingTests.cs.meta
+++ b/project1/Assets/Tests/EditMode/ChapterBindingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3e5dcbd5bfb0fe04bbdf908f6c2bcae3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/project1/Assets/Tests/EditMode/ChapterDataTests.cs
+++ b/project1/Assets/Tests/EditMode/ChapterDataTests.cs
@@ -1,0 +1,269 @@
+using System.Collections.Generic;
+using System.Reflection;
+using Mukseon.Gameplay.Combat;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Mukseon.Tests.EditMode
+{
+    /// <summary>
+    /// <see cref="ChapterData"/>의 파생 값과 검증 규칙(#64).
+    /// 특히 '웨이브에 챕터 밖 적이 섞이지 않는다'는 DoD가 실제로 강제되는지를 본다.
+    /// </summary>
+    public class ChapterDataTests
+    {
+        private readonly List<Object> _created = new List<Object>();
+
+        [TearDown]
+        public void TearDown()
+        {
+            for (int i = 0; i < _created.Count; i++)
+            {
+                Object.DestroyImmediate(_created[i]);
+            }
+
+            _created.Clear();
+        }
+
+        [Test]
+        public void MiniBossMinuteMarks_AreDerivedFromStages()
+        {
+            ChapterData chapter = CreateChapter();
+            SetPrivateField(chapter, "_miniBossStages", new List<MiniBossStageData>
+            {
+                CreateStage(3f),
+                CreateStage(6f),
+                CreateStage(9f)
+            });
+
+            // 마크를 디렉터와 스포너에 따로 입력하던 중복을 없앤 지점 —
+            // 차수 목록이 유일한 출처이므로 둘이 어긋날 수 없다.
+            Assert.That(chapter.MiniBossMinuteMarks, Is.EqualTo(new[] { 3f, 6f, 9f }));
+        }
+
+        [Test]
+        public void MiniBossMinuteMarks_SkipNullAndNonPositiveStages()
+        {
+            ChapterData chapter = CreateChapter();
+            SetPrivateField(chapter, "_miniBossStages", new List<MiniBossStageData>
+            {
+                CreateStage(3f),
+                null,
+                CreateStage(0f),
+                CreateStage(9f)
+            });
+
+            Assert.That(chapter.MiniBossMinuteMarks, Is.EqualTo(new[] { 3f, 9f }));
+        }
+
+        [Test]
+        public void MiniBossCandidates_FallBackToFullRoster_WhenNotSpecified()
+        {
+            MonsterData wolf = CreateMonsterData("Changgwi");
+            MonsterData fox = CreateMonsterData("Maegu");
+            var roster = new List<WaveEnemySpawnEntry> { CreateEntry(wolf), CreateEntry(fox) };
+
+            ChapterData chapter = CreateChapter();
+            SetPrivateField(chapter, "_enemyPool", roster);
+            SetPrivateField(chapter, "_miniBossCandidates", new List<WaveEnemySpawnEntry>());
+
+            // 대부분의 챕터는 후보를 따로 나눌 이유가 없으므로 비워두는 게 기본이다.
+            Assert.That(chapter.MiniBossCandidates, Is.SameAs(roster));
+        }
+
+        [Test]
+        public void IsValid_Fails_WhenWaveUsesEnemyOutsideRoster()
+        {
+            MonsterData inChapter = CreateMonsterData("Changgwi");
+            MonsterData stranger = CreateMonsterData("Imugi");
+
+            ChapterData chapter = CreateChapter();
+            SetPrivateField(chapter, "_enemyPool", new List<WaveEnemySpawnEntry> { CreateEntry(inChapter) });
+            SetPrivateField(chapter, "_waveDatabase", CreateWaveDatabase(inChapter, stranger));
+
+            // #64 DoD: "챕터 진행 중 다른 챕터의 적이 등장하지 않는다"의 실제 강제 지점.
+            Assert.That(chapter.IsValid(out string reason), Is.False);
+            Assert.That(reason, Does.Contain("Imugi"));
+        }
+
+        [Test]
+        public void IsValid_Passes_WhenEveryWaveEnemyIsInRoster()
+        {
+            MonsterData wolf = CreateMonsterData("Changgwi");
+            MonsterData fox = CreateMonsterData("Maegu");
+
+            ChapterData chapter = CreateChapter();
+            SetPrivateField(chapter, "_enemyPool", new List<WaveEnemySpawnEntry>
+            {
+                CreateEntry(wolf),
+                CreateEntry(fox)
+            });
+            SetPrivateField(chapter, "_waveDatabase", CreateWaveDatabase(wolf, fox));
+
+            Assert.That(chapter.IsValid(out string reason), Is.True, reason);
+        }
+
+        [Test]
+        public void IsValid_Fails_WhenMiniBossCandidateIsOutsideRoster()
+        {
+            MonsterData wolf = CreateMonsterData("Changgwi");
+            MonsterData stranger = CreateMonsterData("Imugi");
+
+            ChapterData chapter = CreateChapter();
+            SetPrivateField(chapter, "_enemyPool", new List<WaveEnemySpawnEntry> { CreateEntry(wolf) });
+            SetPrivateField(chapter, "_waveDatabase", CreateWaveDatabase(wolf));
+            SetPrivateField(chapter, "_miniBossCandidates", new List<WaveEnemySpawnEntry> { CreateEntry(stranger) });
+
+            // 후보 목록이 격리 검증을 우회하는 뒷문이 되면 안 된다.
+            Assert.That(chapter.IsValid(out string reason), Is.False);
+            Assert.That(reason, Does.Contain("Imugi"));
+        }
+
+        [Test]
+        public void IsValid_Fails_WhenMiniBossMarksAreNotAscending()
+        {
+            ChapterData chapter = CreateValidChapter();
+            SetPrivateField(chapter, "_miniBossStages", new List<MiniBossStageData>
+            {
+                CreateStage(6f),
+                CreateStage(3f)
+            });
+
+            // 마크가 뒤섞이면 MiniBossSpawner가 먼저 등록된 차수만 쓰고 나머지를 조용히 버린다.
+            Assert.That(chapter.IsValid(out string reason), Is.False);
+            Assert.That(reason, Does.Contain("오름차순"));
+        }
+
+        [Test]
+        public void IsValid_Fails_WhenMiniBossMarkIsAtOrAfterBossMark()
+        {
+            ChapterData chapter = CreateValidChapter();
+            SetPrivateField(chapter, "_bossMinuteMark", 10f);
+            SetPrivateField(chapter, "_miniBossStages", new List<MiniBossStageData> { CreateStage(10f) });
+
+            // 보스 진입 후에는 마크가 발행되지 않으므로 이 차수는 영영 실행되지 않는다.
+            Assert.That(chapter.IsValid(out string reason), Is.False);
+            Assert.That(reason, Does.Contain("보스 마크"));
+        }
+
+        [Test]
+        public void IsValid_Fails_WhenBossMarkIsSetButPrefabIsMissing()
+        {
+            ChapterData chapter = CreateValidChapter();
+            SetPrivateField(chapter, "_bossPrefab", (EnemyHealth)null);
+
+            // 이대로 두면 10분에 아무 일도 일어나지 않고 런이 빈 채로 계속된다.
+            Assert.That(chapter.IsValid(out string reason), Is.False);
+            Assert.That(reason, Does.Contain("보스 프리팹"));
+        }
+
+        [Test]
+        public void IsValid_Passes_WhenBossMarkIsZeroAndPrefabIsMissing()
+        {
+            ChapterData chapter = CreateValidChapter();
+            SetPrivateField(chapter, "_bossPrefab", (EnemyHealth)null);
+            SetPrivateField(chapter, "_bossMinuteMark", 0f);
+            SetPrivateField(chapter, "_miniBossStages", new List<MiniBossStageData>());
+
+            // 보스 없는 챕터(튜토리얼 등)도 성립해야 한다.
+            Assert.That(chapter.IsValid(out string reason), Is.True, reason);
+        }
+
+        [Test]
+        public void IsValid_Fails_WhenRosterIsEmpty()
+        {
+            ChapterData chapter = CreateValidChapter();
+            SetPrivateField(chapter, "_enemyPool", new List<WaveEnemySpawnEntry>());
+
+            // 풀이 비면 미니 보스 마크만 울리고 아무것도 소환되지 않는다.
+            Assert.That(chapter.IsValid(out string reason), Is.False);
+            Assert.That(reason, Does.Contain("적 풀"));
+        }
+
+        /// <summary>보스·미니보스·로스터·웨이브가 모두 채워진, 검증을 통과하는 기준 챕터.</summary>
+        private ChapterData CreateValidChapter()
+        {
+            MonsterData wolf = CreateMonsterData("Changgwi");
+
+            ChapterData chapter = CreateChapter();
+            SetPrivateField(chapter, "_enemyPool", new List<WaveEnemySpawnEntry> { CreateEntry(wolf) });
+            SetPrivateField(chapter, "_waveDatabase", CreateWaveDatabase(wolf));
+            SetPrivateField(chapter, "_miniBossStages", new List<MiniBossStageData> { CreateStage(3f) });
+            SetPrivateField(chapter, "_bossMinuteMark", 10f);
+            SetPrivateField(chapter, "_bossPrefab", CreatePrefab("Boss"));
+
+            return chapter;
+        }
+
+        /// <summary>
+        /// 보스가 없는 최소 챕터. <c>_bossMinuteMark</c>를 0으로 낮추는 게 핵심이다 —
+        /// 기본값 10분을 그대로 두면 보스 프리팹 검사가 먼저 걸려, 정작 보려던 격리 검증까지 도달하지 못한다.
+        /// </summary>
+        private ChapterData CreateChapter()
+        {
+            ChapterData chapter = ScriptableObject.CreateInstance<ChapterData>();
+            chapter.name = "TestChapter";
+            SetPrivateField(chapter, "_bossMinuteMark", 0f);
+            _created.Add(chapter);
+            return chapter;
+        }
+
+        private WaveDatabase CreateWaveDatabase(params MonsterData[] species)
+        {
+            var wave = new WaveDefinition();
+            var entries = new List<WaveEnemySpawnEntry>();
+            for (int i = 0; i < species.Length; i++)
+            {
+                entries.Add(CreateEntry(species[i]));
+            }
+
+            SetPrivateField(wave, "_enemies", entries);
+            SetPrivateField(wave, "_waveName", "TestWave");
+
+            WaveDatabase database = ScriptableObject.CreateInstance<WaveDatabase>();
+            database.name = "TestWaveDatabase";
+            SetPrivateField(database, "_waves", new List<WaveDefinition> { wave });
+            _created.Add(database);
+            return database;
+        }
+
+        private WaveEnemySpawnEntry CreateEntry(MonsterData species)
+        {
+            var entry = new WaveEnemySpawnEntry();
+            SetPrivateField(entry, "_monsterData", species);
+            return entry;
+        }
+
+        private static MiniBossStageData CreateStage(float minuteMark)
+        {
+            var stage = new MiniBossStageData();
+            SetPrivateField(stage, "_spawnMinuteMark", minuteMark);
+            return stage;
+        }
+
+        /// <summary>MonsterData.IsValid가 프리팹을 요구하므로 항상 프리팹을 붙여 만든다.</summary>
+        private MonsterData CreateMonsterData(string displayName)
+        {
+            MonsterData species = ScriptableObject.CreateInstance<MonsterData>();
+            species.name = $"{displayName}_MonsterData";
+            SetPrivateField(species, "_displayName", displayName);
+            SetPrivateField(species, "_enemyPrefab", CreatePrefab(displayName));
+            _created.Add(species);
+            return species;
+        }
+
+        private EnemyHealth CreatePrefab(string objectName)
+        {
+            var go = new GameObject(objectName);
+            _created.Add(go);
+            return go.AddComponent<EnemyHealth>();
+        }
+
+        private static void SetPrivateField<T>(object target, string fieldName, T value)
+        {
+            FieldInfo fieldInfo = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(fieldInfo, Is.Not.Null, $"Field not found: {fieldName}");
+            fieldInfo.SetValue(target, value);
+        }
+    }
+}

--- a/project1/Assets/Tests/EditMode/ChapterDataTests.cs.meta
+++ b/project1/Assets/Tests/EditMode/ChapterDataTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 70147dd3bba72cb45a39c9590d9e79e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
챕터 단위 진행 데이터를 `ChapterData` 에셋으로 정의하고, 웨이브·미니 보스·보스 시스템이 이를 읽어가도록 배선했다.

## 문제

챕터 설정이 씬의 **세 컴포넌트에 흩어져** 있었다.

| 컴포넌트 | 들고 있던 챕터 설정 |
|---|---|
| `WaveCombatDirector` | `_waveDatabase` · `_miniBossMinuteMarks` · `_bossMinuteMark` |
| `MiniBossSpawner` | `_enemyPool` · `_stages` |
| `BossEncounterDirector` | `_bossPrefab` |

챕터를 바꾸려면 세 곳을 동시에 고쳐야 했고, 특히 **미니 보스 분 마크가 양쪽에 중복 입력**돼 있었다 — 디렉터의 `_miniBossMinuteMarks`와 스포너의 `_stages[].SpawnMinuteMark`. 둘이 어긋나면 마크만 울리고 미니 보스는 나오지 않는데, 예외도 로그도 없다.

## 구성

| 파일 | 줄 수 | 책임 |
|---|---|---|
| `Combat/ChapterData.cs` | 143 | 챕터 데이터 + 마크 파생 |
| `Combat/ChapterValidation.cs` | 230 | 검증 규칙 (순수 C#) |
| `Combat/ChapterDatabase.cs` | 90 | 챕터 목록 (`CharacterDatabase` 패턴) |
| 디렉터 3개 + `RunContext` | +90 | 챕터 해석·적용 |
| `Settings/Data/Chapters/` | — | 1장 완성 + 2·3장 골격 + 목록 에셋 |

`MiniBossMinuteMarks`를 차수 목록에서 **파생**시킨 게 핵심이다. 마크의 출처가 하나뿐이라 디렉터와 스포너가 어긋날 수 없다.

## 설계상 짚어둘 것

- **주입이 아니라 각자 읽어간다.** `RunContext.SelectedChapter` → 씬 직렬화 `_chapterData` → 기존 씬 값 순으로 각 디렉터가 `Awake`에서 해석한다. `PlayerStatSystem`의 캐릭터 해석과 같은 규약이며(#36), 컴포넌트 간 `Awake` 순서에 기대지 않는다. 세 곳에서 `_director`를 통해 챕터를 건네받는 방식은 순서 의존이라 택하지 않았다.
- **해석은 반드시 `Awake`에서 끝난다.** `WaveCombatDirector.OnEnable`이 곧바로 `StartWaves()`를 부르고, `MiniBossSpawner.OnEnable`이 `BuildMarkIndex()`로 차수를 읽기 때문이다.
- **폴백은 값이 있을 때만 덮어쓴다.** 골격뿐인 2·3장이 씬의 멀쩡한 보스 프리팹을 지워버리면 안 된다. 반대로 미니 보스 마크는 비어 있어도 그대로 반영한다 — 씬 값을 남기면 스포너에 없는 차수의 마크만 울린다.
- **로스터와 미니 보스 후보를 분리했다.** 씬의 기존 풀에 도깨비불·매구가 빠져 있었다(웨이브는 9종, 풀은 7종 — #104에서 두 적을 타임라인에 넣을 때 풀이 갱신되지 않은 것으로 보인다). 임의로 넓히지 않고 `_enemyPool`(9종) / `_miniBossCandidates`(7종)로 나눠 **현재 동작을 그대로 보존**했다. 의도된 제외였다면 그대로 두면 되고, 누락이었다면 Chapter1 에셋의 후보 목록에 2종 추가하면 된다. → **리뷰에서 확인 부탁드립니다.**
- 챕터 격리(DoD)는 `ChapterValidation`이 강제한다 — 웨이브의 모든 적이 로스터 안에 있어야 하고, 후보도 로스터의 부분집합이어야 한다(후보 목록이 격리 검증의 뒷문이 되지 않도록).

## 이슈 본문과 다르게 간 부분

이슈에 "각 챕터는 **3개의 웨이브** + 보스"라고 적혀 있지만, `wave_stage_system.md`와 실제 구현은 **분 단위 10웨이브**(VS 타임라인)다. 문서의 "필요한 데이터 항목 > 챕터 데이터"도 "분 단위 웨이브 데이터 목록"이라 적혀 있어 **문서·구현 쪽을 따랐다.**

## 검증

- **EditMode 299개 통과 / 실패 0** (신규 20개 포함), 컴파일 에러 없음. `Unity.exe -batchmode -runTests`로 실행.
- `ChapterAssetTests`는 `AssetDatabase`로 **커밋된 에셋을 실제 로드**해 검사한다. 에셋 YAML을 CLI에서 손으로 작성했기 때문에 이게 핵심 검증이다 — Chapter1의 `IsValid()` 통과가 곧 웨이브DB·로스터 9종·보스 프리팹 참조가 전부 해석됐다는 뜻이다.
- 씬 diff는 3줄(`_chapterData` 참조)뿐이며, 챕터 1의 타임라인 수치는 기존 씬 값과 동일하다 — 테스트로 고정해 뒀다.
- 실기 플레이 확인은 하지 않았다. 리뷰어가 확인해주면 좋겠다.

## 범위 밖

**스테이지 선택 UI는 만들지 않았다.** 2·3장이 골격뿐이라 선택 화면을 붙이면 플레이 불가한 챕터가 노출된다. 데이터가 채워지면 `ChapterDatabase.asset`을 `CharacterSelectScreenController`와 같은 패턴으로 순회하고 `RunContext.SelectedChapter`에 넣으면 배선은 끝난다.

에셋의 표시 이름은 저장소의 다른 데이터 에셋과 같이 로마자로 뒀다(`Chapter 1 - Sillim`). 현재 저장소의 어떤 에셋도 비ASCII를 포함하지 않으며, 현지화는 별도 건이다.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)
