### PR TITLE
feat: 강화 카드 시스템 — 카드 풀 / 가중치 추첨 / 강신 카드 적용 (#66)

### DIFF
--- a/project1/Assets/Scripts/Combat/GangshinController.cs
+++ b/project1/Assets/Scripts/Combat/GangshinController.cs
@@ -246,7 +246,33 @@ namespace Mukseon.Gameplay.Combat
             return index;
         }
 
-        /// <summary>슬롯이 모두 찼을 때 지정 슬롯의 강신을 교체한다(레벨업 연동 — 후속 PR에서 호출).</summary>
+        /// <summary>지정 어빌리티가 장착된 슬롯 인덱스. 보유하고 있지 않으면 -1.</summary>
+        public int FindSlotIndex(GangshinAbilityBase ability)
+        {
+            return _slotState != null ? _slotState.IndexOf(ability) : -1;
+        }
+
+        /// <summary>
+        /// 이미 보유 중인 강신의 레벨을 올린다(강신 강화 카드 — #66). 게이지는 보존된다.
+        /// 해당 어빌리티를 보유하고 있지 않으면 false를 반환한다(이 경우 호출자가 추가/교체를 시도한다).
+        /// </summary>
+        public bool TryUpgradeAbility(GangshinAbilityBase ability, int level)
+        {
+            int slotIndex = FindSlotIndex(ability);
+            if (slotIndex < 0 || !_slotState.TryUpgradeSlot(slotIndex, level, ResolveRequiredGauge(ability, level)))
+            {
+                return false;
+            }
+
+            // 레벨에 따라 패시브 수치가 달라질 수 있으므로 재동기화한다.
+            SyncActivePassives();
+            OnSlotsChanged?.Invoke();
+            NotifyGaugeChanged();
+            HandleStateTransition();
+            return true;
+        }
+
+        /// <summary>슬롯이 모두 찼을 때 지정 슬롯의 강신을 교체한다(강신 강화 카드 교체 — #66).</summary>
         public bool TryReplaceAbility(int slotIndex, GangshinAbilityBase ability, int level = 1)
         {
             if (_slotState == null || !_slotState.ReplaceSlot(slotIndex, ability, ResolveRequiredGauge(ability, level), level))

--- a/project1/Assets/Scripts/Combat/GangshinSlotState.cs
+++ b/project1/Assets/Scripts/Combat/GangshinSlotState.cs
@@ -149,6 +149,53 @@ namespace Mukseon.Gameplay.Combat
         }
 
         /// <summary>
+        /// 이미 보유 중인 강신의 레벨을 올린다(강화 카드 레벨업 — #66).
+        /// 교체(<see cref="ReplaceSlot"/>)와 달리 어빌리티가 그대로이므로 게이지를 초기화하지 않고
+        /// 새 필요 게이지에 맞춰 클램프만 한다 — 레벨업이 오히려 손해가 되지 않도록 한다.
+        /// 발동(Active) 중에도 허용한다: 어빌리티가 바뀌지 않아 진행 중인 효과와 충돌하지 않고,
+        /// 올라간 레벨은 다음 발동부터 반영된다.
+        /// </summary>
+        public bool TryUpgradeSlot(int index, int level, float requiredGauge)
+        {
+            if (index < 0 || index >= _slots.Length || !_slots[index].IsOccupied)
+            {
+                return false;
+            }
+
+            GangshinSlot slot = _slots[index];
+            slot.Level = Mathf.Max(1, level);
+            slot.RequiredGauge = Mathf.Max(0f, requiredGauge);
+            slot.Gauge = Mathf.Clamp(slot.Gauge, 0f, slot.RequiredGauge);
+
+            // 필요 게이지가 바뀌면 Ready 여부가 달라질 수 있다. 발동/쿨다운은 전역 잠금이므로 건드리지 않는다.
+            if (index == ActiveIndex && CurrentState != GangshinState.Active && CurrentState != GangshinState.Cooldown)
+            {
+                CurrentState = ResolveRestingState();
+            }
+
+            return true;
+        }
+
+        /// <summary>지정 어빌리티가 장착된 슬롯 인덱스를 반환한다. 보유하고 있지 않으면 -1.</summary>
+        public int IndexOf(GangshinAbilityBase ability)
+        {
+            if (ability == null)
+            {
+                return -1;
+            }
+
+            for (int i = 0; i < _slots.Length; i++)
+            {
+                if (_slots[i].IsOccupied && _slots[i].Ability == ability)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        /// <summary>
         /// 장착 슬롯을 변경한다. 점유 슬롯만 장착 가능하며, 이미 장착 중이거나 발동(Active) 중이면
         /// 변경하지 않는다. 게이지는 슬롯에 보존되어 있으므로 별도 저장/복원이 필요 없다.
         /// </summary>

--- a/project1/Assets/Scripts/Progression/Cards.meta
+++ b/project1/Assets/Scripts/Progression/Cards.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bfb491c249d3d6a45a4982d3b9aa1155
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/project1/Assets/Scripts/Progression/Cards/CardCategory.cs
+++ b/project1/Assets/Scripts/Progression/Cards/CardCategory.cs
@@ -1,0 +1,18 @@
+namespace Mukseon.Gameplay.Progression.Cards
+{
+    /// <summary>
+    /// 강화 카드 카테고리(`card_system.md` — 카드 목록, #66).
+    /// 추첨 가중치가 카테고리별로 다르므로(보유 중인 스킬/강신만 x2) 분류가 필요하다.
+    /// </summary>
+    public enum CardCategory
+    {
+        /// <summary>스탯 강화 카드 — 플레이어 기본 수치 영구 증가. 보유 여부와 무관하게 가중치 x1.</summary>
+        Stat = 0,
+
+        /// <summary>스킬 강화 카드 — 미보유 시 획득, 보유 시 레벨업. 보유 중이면 가중치 x2.</summary>
+        Skill = 1,
+
+        /// <summary>강신 강화 카드 — 강신 슬롯 추가 또는 레벨업. 보유 중이면 가중치 x2.</summary>
+        Gangshin = 2,
+    }
+}

--- a/project1/Assets/Scripts/Progression/Cards/CardCategory.cs.meta
+++ b/project1/Assets/Scripts/Progression/Cards/CardCategory.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4f5c05686df848248832b7909f7a998f

--- a/project1/Assets/Scripts/Progression/Cards/CardEffectApplier.cs
+++ b/project1/Assets/Scripts/Progression/Cards/CardEffectApplier.cs
@@ -1,0 +1,69 @@
+using Mukseon.Gameplay.Combat;
+using Mukseon.Gameplay.Stats;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Progression.Cards
+{
+    /// <summary>
+    /// 선택된 강화 카드의 효과를 즉시 적용한다(#66).
+    /// 스탯 계열처럼 스탯 시스템 / 스와이프 리스너만으로 끝나는 효과는 여기서 직접 처리하고,
+    /// 전담 시스템이 필요한 효과(도깨비불 · 결계 · 강신 등)는 <see cref="TryApply"/>가 false를 돌려
+    /// 호출자가 담당 시스템에 위임하도록 한다.
+    /// </summary>
+    public sealed class CardEffectApplier
+    {
+        private readonly PlayerStatSystem _statSystem;
+        private readonly SwipeAttackEventListener _swipeAttackEventListener;
+
+        // StatModifier 제거 시 출처로 식별되는 객체. 보통 PlayerLevelSystem 인스턴스를 넘긴다.
+        private readonly object _source;
+
+        public CardEffectApplier(PlayerStatSystem statSystem, SwipeAttackEventListener swipeAttackEventListener, object source)
+        {
+            _statSystem = statSystem;
+            _swipeAttackEventListener = swipeAttackEventListener;
+            _source = source;
+        }
+
+        /// <summary>
+        /// 효과를 적용했으면 true, 전담 시스템에 위임해야 하는 효과면 false를 반환한다.
+        /// 참조가 없어 적용하지 못한 경우에도 "이 계층이 담당하는 효과"이므로 true로 처리해,
+        /// 미구현 효과로 오인되어 경고가 발생하는 것을 막는다.
+        /// </summary>
+        public bool TryApply(SkillData definition)
+        {
+            if (definition == null)
+            {
+                return false;
+            }
+
+            switch (definition.EffectType)
+            {
+                case LevelUpSkillEffectType.StatFlat:
+                    AddStatModifier(definition.StatType, definition.Value, StatModifierType.Flat);
+                    return true;
+
+                case LevelUpSkillEffectType.StatPercent:
+                    AddStatModifier(definition.StatType, definition.Value, StatModifierType.Percent);
+                    return true;
+
+                case LevelUpSkillEffectType.BonusTargets:
+                    _swipeAttackEventListener?.AddBonusTargets(Mathf.RoundToInt(definition.Value));
+                    return true;
+
+                case LevelUpSkillEffectType.PickupRadius:
+                    // 혼불 자력 반경을 Flat StatModifier로 증가시킨다(#40). SoulCollector가 MagnetRadius 스탯을 읽는다.
+                    AddStatModifier(StatType.MagnetRadius, definition.Value, StatModifierType.Flat);
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        private void AddStatModifier(StatType statType, float value, StatModifierType modifierType)
+        {
+            _statSystem?.AddModifier(statType, new StatModifier(value, modifierType, _source));
+        }
+    }
+}

--- a/project1/Assets/Scripts/Progression/Cards/CardEffectApplier.cs.meta
+++ b/project1/Assets/Scripts/Progression/Cards/CardEffectApplier.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5e39227e1ed3cf948a978d40655e32fb

--- a/project1/Assets/Scripts/Progression/Cards/CardPool.cs
+++ b/project1/Assets/Scripts/Progression/Cards/CardPool.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+
+namespace Mukseon.Gameplay.Progression.Cards
+{
+    /// <summary>
+    /// 강화 카드 풀과 가중치 랜덤 추첨(#66, `card_system.md`).
+    /// MonoBehaviour / ScriptableObject에 의존하지 않는 순수 C# 로직이라 EditMode 테스트가 용이하다.
+    ///
+    /// 책임은 두 단계로 나뉜다.
+    /// 1) 생성 시점(런 시작): 캐릭터 전용 카드 필터링 + 중복 정의 제거 — 런 내내 고정된다.
+    /// 2) 추첨 시점(레벨업 / 미니 보스): 최대 레벨 카드 제외 + 보유 카드 가중치 x2 + 중복 없는 N장 추첨.
+    ///    보유 레벨은 런 중 계속 변하므로 반드시 추첨 때마다 다시 평가한다.
+    /// </summary>
+    /// <typeparam name="T">카드 정의 타입. 호출자가 원본 타입(예: SkillData)을 그대로 돌려받도록 제네릭이다.</typeparam>
+    public sealed class CardPool<T> where T : class, ICardDefinition
+    {
+        public const int DefaultDrawCount = 3;
+        public const float BaseWeight = 1f;
+
+        /// <summary>보유 중인 스킬 / 강신 카드에 적용되는 가중치 배율(`card_system.md` — 가중치 규칙).</summary>
+        public const float OwnedWeightMultiplier = 2f;
+
+        private readonly List<T> _cards = new List<T>();
+
+        // 추첨 1회분 작업 버퍼. 레벨업마다 재할당하지 않도록 필드로 유지한다(_candidates[i] ↔ _weights[i] 대응).
+        private readonly List<T> _candidates = new List<T>();
+        private readonly List<float> _weights = new List<float>();
+
+        /// <summary>
+        /// 캐릭터 및 정의 목록으로 풀을 초기화한다.
+        /// <paramref name="characterId"/>가 비어 있으면 전용 카드 필터링을 건너뛴다(캐릭터 미확정 상태에서
+        /// 전용 카드가 통째로 사라지는 것보다, 필터를 적용하지 않는 편이 덜 위험하다).
+        /// </summary>
+        public CardPool(IEnumerable<T> definitions, string characterId)
+        {
+            CharacterId = characterId ?? string.Empty;
+
+            if (definitions == null)
+            {
+                return;
+            }
+
+            // 같은 카드가 목록에 두 번 들어가면 한 번의 추첨에서 2장 등장할 수 있으므로 ID 기준으로 제거한다.
+            var seenIds = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (T definition in definitions)
+            {
+                if (definition == null || string.IsNullOrWhiteSpace(definition.CardId))
+                {
+                    continue;
+                }
+
+                if (!MatchesCharacter(definition, CharacterId))
+                {
+                    continue;
+                }
+
+                if (!seenIds.Add(definition.CardId))
+                {
+                    continue;
+                }
+
+                _cards.Add(definition);
+            }
+        }
+
+        /// <summary>이 풀이 초기화된 캐릭터 ID. 비어 있으면 전용 카드 필터링이 적용되지 않았다는 뜻이다.</summary>
+        public string CharacterId { get; }
+
+        /// <summary>캐릭터 필터를 통과한 카드 전체. 최대 레벨 제외는 추첨 시점에 적용된다.</summary>
+        public IReadOnlyList<T> Cards => _cards;
+
+        public int Count => _cards.Count;
+
+        /// <summary>
+        /// 추첨 시점에 카드를 추가로 걸러내는 선택적 조건(null이면 미적용).
+        /// 지금 선택해도 효과를 적용할 수 없는 카드를 제외해 "빈 선택"을 막는 용도다
+        /// (예: 강신 슬롯이 모두 찼는데 교체 UI가 없어 부여할 수 없는 강신 카드).
+        /// </summary>
+        public Func<T, bool> EligibilityFilter { get; set; }
+
+        /// <summary>
+        /// 가중치 랜덤으로 서로 다른 카드 <paramref name="count"/>장을 <paramref name="results"/>에 채운다.
+        /// 후보가 모자라면 가능한 만큼만 채운다. 실제로 담긴 장수를 반환한다.
+        /// </summary>
+        /// <param name="ownedLevelProvider">카드 ID → 현재 보유 레벨(미보유 = 0). 최대 레벨 제외와 가중치 판정에 쓰인다.</param>
+        /// <param name="results">결과를 담을 목록. 호출 시 비워진다.</param>
+        public int Draw(
+            Func<string, int> ownedLevelProvider,
+            List<T> results,
+            int count = DefaultDrawCount,
+            IRandomSource random = null)
+        {
+            if (results == null)
+            {
+                return 0;
+            }
+
+            results.Clear();
+
+            if (count <= 0 || _cards.Count == 0)
+            {
+                return 0;
+            }
+
+            BuildCandidates(ownedLevelProvider);
+
+            IRandomSource source = random ?? UnityRandomSource.Shared;
+            int drawCount = Math.Min(count, _candidates.Count);
+
+            for (int drawn = 0; drawn < drawCount; drawn++)
+            {
+                int index = PickWeightedIndex(source);
+                if (index < 0)
+                {
+                    break;
+                }
+
+                results.Add(_candidates[index]);
+
+                // 뽑힌 카드는 후보에서 제거해 같은 추첨에서 다시 나오지 않게 한다(비복원 추출).
+                RemoveCandidateAt(index);
+            }
+
+            _candidates.Clear();
+            _weights.Clear();
+            return results.Count;
+        }
+
+        /// <summary>
+        /// 카드 1장의 추첨 가중치를 반환한다(`card_system.md` — 가중치 규칙).
+        /// 스탯 카드는 보유 개념이 없어 항상 기본 가중치이고, 보유 중인 스킬 / 강신 카드만 x2다.
+        /// </summary>
+        public static float ResolveWeight(ICardDefinition card, int ownedLevel)
+        {
+            if (card == null || card.Category == CardCategory.Stat || ownedLevel <= 0)
+            {
+                return BaseWeight;
+            }
+
+            return BaseWeight * OwnedWeightMultiplier;
+        }
+
+        /// <summary>
+        /// 카드가 해당 캐릭터에게 허용되는지 판정한다. 전용 캐릭터가 지정되지 않은 카드는 공용이다.
+        /// </summary>
+        public static bool MatchesCharacter(ICardDefinition card, string characterId)
+        {
+            if (card == null)
+            {
+                return false;
+            }
+
+            string required = card.RequiredCharacterId;
+            if (string.IsNullOrWhiteSpace(required))
+            {
+                return true;
+            }
+
+            // 캐릭터를 특정할 수 없으면 필터링 자체를 적용하지 않는다(생성자 주석 참조).
+            if (string.IsNullOrWhiteSpace(characterId))
+            {
+                return true;
+            }
+
+            return string.Equals(required.Trim(), characterId.Trim(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>최대 레벨에 도달하지 않은 카드만 후보로 모으고, 각 후보의 가중치를 함께 계산한다.</summary>
+        private void BuildCandidates(Func<string, int> ownedLevelProvider)
+        {
+            _candidates.Clear();
+            _weights.Clear();
+
+            for (int i = 0; i < _cards.Count; i++)
+            {
+                T card = _cards[i];
+                int ownedLevel = ownedLevelProvider != null ? ownedLevelProvider(card.CardId) : 0;
+
+                if (ownedLevel >= card.MaxLevel)
+                {
+                    continue;
+                }
+
+                if (EligibilityFilter != null && !EligibilityFilter(card))
+                {
+                    continue;
+                }
+
+                _candidates.Add(card);
+                _weights.Add(ResolveWeight(card, ownedLevel));
+            }
+        }
+
+        /// <summary>
+        /// 누적 가중치 구간으로 후보 1개를 고른다.
+        /// [0, 총합) 구간에서 난수를 뽑아 앞에서부터 가중치를 누적하며, 난수가 누적값보다 작아지는
+        /// 첫 후보를 선택한다 — 각 후보가 차지하는 구간 길이가 곧 가중치이므로 확률이 가중치에 비례한다.
+        /// </summary>
+        private int PickWeightedIndex(IRandomSource source)
+        {
+            if (_candidates.Count == 0)
+            {
+                return -1;
+            }
+
+            float total = 0f;
+            for (int i = 0; i < _weights.Count; i++)
+            {
+                total += _weights[i];
+            }
+
+            // 모든 가중치가 0인 비정상 데이터에서도 추첨이 멈추지 않도록 첫 후보로 폴백한다.
+            if (total <= 0f)
+            {
+                return 0;
+            }
+
+            float roll = source.NextFloat(total);
+            float cumulative = 0f;
+
+            for (int i = 0; i < _weights.Count; i++)
+            {
+                cumulative += _weights[i];
+                if (roll < cumulative)
+                {
+                    return i;
+                }
+            }
+
+            // 부동소수 누적 오차나 상한 포함 난수로 구간을 벗어난 경우 마지막 후보를 고른다.
+            return _candidates.Count - 1;
+        }
+
+        /// <summary>후보를 O(1)로 제거한다. 순서는 추첨 결과에 영향을 주지 않으므로 마지막 원소와 교환한다.</summary>
+        private void RemoveCandidateAt(int index)
+        {
+            int last = _candidates.Count - 1;
+            _candidates[index] = _candidates[last];
+            _weights[index] = _weights[last];
+            _candidates.RemoveAt(last);
+            _weights.RemoveAt(last);
+        }
+    }
+}

--- a/project1/Assets/Scripts/Progression/Cards/CardPool.cs.meta
+++ b/project1/Assets/Scripts/Progression/Cards/CardPool.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6cdcc401accb5f54f93f02bd4bc6d45a

--- a/project1/Assets/Scripts/Progression/Cards/GangshinCardApplier.cs
+++ b/project1/Assets/Scripts/Progression/Cards/GangshinCardApplier.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using Mukseon.Gameplay.Combat;
+using UnityEngine;
+
+namespace Mukseon.Gameplay.Progression.Cards
+{
+    /// <summary>
+    /// 강신 강화 카드를 실제 강신 슬롯에 반영한다(#66, `card_system.md` — 강신 강화 카드).
+    /// 카드는 <see cref="SkillData.GangshinAbilityId"/>로 씬의 강신 어빌리티와 연결된다.
+    ///
+    /// 적용 규칙(우선순위 순):
+    /// 1. 이미 보유 중 → 레벨업(게이지 보존)
+    /// 2. 빈 슬롯 있음 → 해당 슬롯에 추가
+    /// 3. 슬롯 4개가 모두 참 → <see cref="OnReplaceRequested"/>로 교체 UI에 위임(#59)
+    ///
+    /// 3번을 처리할 구독자가 없으면 그 카드는 애초에 추첨 대상에서 빠진다
+    /// (<see cref="IsCardEligible"/>). 선택했는데 아무 일도 일어나지 않는 "빈 선택"을 막기 위함이다.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class GangshinCardApplier : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField]
+        private PlayerLevelSystem _playerLevelSystem;
+
+        [SerializeField]
+        private GangshinController _gangshinController;
+
+        [Header("Abilities")]
+        [SerializeField, Tooltip("강화 카드로 획득할 수 있는 강신 어빌리티. 카드의 Gangshin Ability Id와 GangshinAbilityData.AbilityId가 일치해야 연결된다.")]
+        private List<GangshinAbilityBase> _availableAbilities = new List<GangshinAbilityBase>();
+
+        /// <summary>
+        /// 슬롯이 모두 찬 상태에서 새 강신 카드가 선택되었을 때 발생한다.
+        /// 교체 UI가 구독해 슬롯을 고른 뒤 <see cref="ResolveReplacement"/>를 호출해야 한다(#59).
+        /// </summary>
+        public event Action<SkillData, GangshinAbilityBase, int> OnReplaceRequested;
+
+        private void Awake()
+        {
+            if (_playerLevelSystem == null)
+            {
+                _playerLevelSystem = GetComponentInParent<PlayerLevelSystem>();
+            }
+
+            if (_gangshinController == null)
+            {
+                _gangshinController = GetComponentInParent<GangshinController>();
+            }
+        }
+
+        private void OnEnable()
+        {
+            if (_playerLevelSystem == null)
+            {
+                Debug.LogWarning("[GangshinCardApplier] PlayerLevelSystem 참조가 없어 강신 카드가 적용되지 않습니다.", this);
+                return;
+            }
+
+            _playerLevelSystem.OnSkillEffectPending += HandleSkillEffectPending;
+            _playerLevelSystem.SetCardEligibilityFilter(IsCardEligible);
+        }
+
+        private void OnDisable()
+        {
+            if (_playerLevelSystem == null)
+            {
+                return;
+            }
+
+            _playerLevelSystem.OnSkillEffectPending -= HandleSkillEffectPending;
+            _playerLevelSystem.ClearCardEligibilityFilter(IsCardEligible);
+        }
+
+        /// <summary>
+        /// 교체 UI가 슬롯을 고른 뒤 호출한다. 성공 시 해당 슬롯의 강신이 교체된다.
+        /// </summary>
+        public bool ResolveReplacement(int slotIndex, GangshinAbilityBase ability, int level)
+        {
+            return _gangshinController != null && _gangshinController.TryReplaceAbility(slotIndex, ability, level);
+        }
+
+        /// <summary>
+        /// 지금 선택해도 적용할 수 없는 강신 카드를 추첨 대상에서 제외한다.
+        /// 강신 카드가 아니면 관여하지 않고 통과시킨다.
+        /// </summary>
+        private bool IsCardEligible(SkillData card)
+        {
+            if (card == null || card.Category != CardCategory.Gangshin)
+            {
+                return true;
+            }
+
+            GangshinAbilityBase ability = FindAbility(card.GangshinAbilityId);
+            if (ability == null || _gangshinController == null)
+            {
+                return false;
+            }
+
+            // 보유 중이면 레벨업으로, 빈 슬롯이 있으면 추가로 적용할 수 있다.
+            if (_gangshinController.FindSlotIndex(ability) >= 0 || _gangshinController.HasFreeSlot)
+            {
+                return true;
+            }
+
+            // 슬롯이 모두 찬 경우엔 교체를 처리할 구독자가 있을 때만 제시한다.
+            return OnReplaceRequested != null;
+        }
+
+        private void HandleSkillEffectPending(SkillData card, int nextLevel)
+        {
+            if (card == null || card.Category != CardCategory.Gangshin)
+            {
+                return;
+            }
+
+            if (_gangshinController == null)
+            {
+                Debug.LogWarning($"[GangshinCardApplier] GangshinController 참조가 없어 '{card.SkillId}' 카드를 적용하지 못했습니다.", this);
+                return;
+            }
+
+            GangshinAbilityBase ability = FindAbility(card.GangshinAbilityId);
+            if (ability == null)
+            {
+                Debug.LogWarning($"[GangshinCardApplier] 카드 '{card.SkillId}'의 강신 어빌리티 ID '{card.GangshinAbilityId}'에 해당하는 어빌리티를 찾지 못했습니다.", this);
+                return;
+            }
+
+            // 1) 이미 보유 중 → 레벨업(게이지 보존).
+            if (_gangshinController.TryUpgradeAbility(ability, nextLevel))
+            {
+                return;
+            }
+
+            // 2) 빈 슬롯 → 추가. 첫 강신이면 자동으로 장착 슬롯이 된다.
+            if (_gangshinController.TryAddAbility(ability, nextLevel) >= 0)
+            {
+                return;
+            }
+
+            // 3) 슬롯이 모두 참 → 교체 UI에 위임.
+            if (OnReplaceRequested != null)
+            {
+                OnReplaceRequested.Invoke(card, ability, nextLevel);
+                return;
+            }
+
+            Debug.LogWarning($"[GangshinCardApplier] 슬롯이 모두 차 있고 교체 UI 구독자가 없어 '{card.SkillId}' 카드를 적용하지 못했습니다.", this);
+        }
+
+        private GangshinAbilityBase FindAbility(string abilityId)
+        {
+            if (string.IsNullOrWhiteSpace(abilityId))
+            {
+                return null;
+            }
+
+            for (int i = 0; i < _availableAbilities.Count; i++)
+            {
+                GangshinAbilityBase ability = _availableAbilities[i];
+                if (ability == null || ability.Data == null)
+                {
+                    continue;
+                }
+
+                if (string.Equals(ability.Data.AbilityId, abilityId, StringComparison.Ordinal))
+                {
+                    return ability;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/project1/Assets/Scripts/Progression/Cards/GangshinCardApplier.cs.meta
+++ b/project1/Assets/Scripts/Progression/Cards/GangshinCardApplier.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1fe6f7aff565acb458189374e737131e

--- a/project1/Assets/Scripts/Progression/Cards/ICardDefinition.cs
+++ b/project1/Assets/Scripts/Progression/Cards/ICardDefinition.cs
@@ -1,0 +1,24 @@
+namespace Mukseon.Gameplay.Progression.Cards
+{
+    /// <summary>
+    /// 강화 카드 추첨에 필요한 최소 정보(#66). <see cref="CardPool"/>이 ScriptableObject에 의존하지
+    /// 않도록 분리한 인터페이스로, EditMode 테스트에서는 순수 C# 대역으로 대체할 수 있다.
+    /// 표시 정보(이름/아이콘/설명)는 추첨에 쓰이지 않으므로 여기 포함하지 않는다.
+    /// </summary>
+    public interface ICardDefinition
+    {
+        /// <summary>카드 식별자. 보유 레벨 조회 키이자 중복 판정 키다.</summary>
+        string CardId { get; }
+
+        CardCategory Category { get; }
+
+        /// <summary>이 레벨에 도달하면 풀에서 제외된다(1 이상).</summary>
+        int MaxLevel { get; }
+
+        /// <summary>
+        /// 이 카드를 사용할 수 있는 캐릭터 ID. 비어 있으면 전 캐릭터 공용이다.
+        /// 예: 부채살 흩뿌리기 = "character.mudang" → 박수 플레이 시 풀에서 제외(`card_system.md`).
+        /// </summary>
+        string RequiredCharacterId { get; }
+    }
+}

--- a/project1/Assets/Scripts/Progression/Cards/ICardDefinition.cs.meta
+++ b/project1/Assets/Scripts/Progression/Cards/ICardDefinition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5be0317fec803e7459e3294ec6155664

--- a/project1/Assets/Scripts/Progression/Cards/IRandomSource.cs
+++ b/project1/Assets/Scripts/Progression/Cards/IRandomSource.cs
@@ -1,0 +1,25 @@
+namespace Mukseon.Gameplay.Progression.Cards
+{
+    /// <summary>
+    /// 가중치 추첨용 난수 공급자(#66). UnityEngine.Random을 직접 쓰면 결과를 고정할 수 없어
+    /// 확률 규칙(보유 카드 x2 등)을 테스트할 수 없으므로 주입 가능한 형태로 분리한다.
+    /// </summary>
+    public interface IRandomSource
+    {
+        /// <summary>[0, maxExclusive) 구간의 실수를 반환한다.</summary>
+        float NextFloat(float maxExclusive);
+    }
+
+    /// <summary>런타임 기본 구현. UnityEngine.Random을 사용한다.</summary>
+    public sealed class UnityRandomSource : IRandomSource
+    {
+        public static readonly UnityRandomSource Shared = new UnityRandomSource();
+
+        public float NextFloat(float maxExclusive)
+        {
+            // Random.Range(float, float)는 상한 포함이 될 수 있으나, CardPool이 누적합 초과 시
+            // 마지막 후보로 폴백하므로 경계값이 나와도 추첨은 안전하게 성립한다.
+            return UnityEngine.Random.Range(0f, maxExclusive);
+        }
+    }
+}

--- a/project1/Assets/Scripts/Progression/Cards/IRandomSource.cs.meta
+++ b/project1/Assets/Scripts/Progression/Cards/IRandomSource.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a99ac3b0d36a06e468a10cfeddcec635

--- a/project1/Assets/Scripts/Progression/Cards/SkillLevelRegistry.cs
+++ b/project1/Assets/Scripts/Progression/Cards/SkillLevelRegistry.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+
+namespace Mukseon.Gameplay.Progression.Cards
+{
+    /// <summary>
+    /// 이번 런에서 카드별로 획득한 레벨을 보관한다(#66).
+    /// 카드 풀의 "최대 레벨 제외"와 "보유 카드 가중치 x2" 판정이 모두 이 값을 본다.
+    /// MonoBehaviour에 의존하지 않는 순수 C# 저장소다.
+    /// </summary>
+    public sealed class SkillLevelRegistry
+    {
+        private readonly Dictionary<string, int> _levels = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        /// <summary>보유 레벨(미보유 = 0). 알 수 없는 ID도 0을 반환한다.</summary>
+        public int GetLevel(string cardId)
+        {
+            if (string.IsNullOrWhiteSpace(cardId))
+            {
+                return 0;
+            }
+
+            return _levels.TryGetValue(cardId, out int level) ? level : 0;
+        }
+
+        public bool IsOwned(string cardId) => GetLevel(cardId) > 0;
+
+        /// <summary>레벨을 1 올리고 올라간 레벨을 반환한다. ID가 비어 있으면 0.</summary>
+        public int Increment(string cardId)
+        {
+            if (string.IsNullOrWhiteSpace(cardId))
+            {
+                return 0;
+            }
+
+            int current = GetLevel(cardId) + 1;
+            _levels[cardId] = current;
+            return current;
+        }
+
+        public void Clear()
+        {
+            _levels.Clear();
+        }
+    }
+}

--- a/project1/Assets/Scripts/Progression/Cards/SkillLevelRegistry.cs.meta
+++ b/project1/Assets/Scripts/Progression/Cards/SkillLevelRegistry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ba24b3bd86ae31f49a3800d856977352

--- a/project1/Assets/Scripts/Progression/LevelUpSkillEffectType.cs
+++ b/project1/Assets/Scripts/Progression/LevelUpSkillEffectType.cs
@@ -1,0 +1,30 @@
+namespace Mukseon.Gameplay.Progression
+{
+    /// <summary>
+    /// 강화 카드가 적용하는 효과 종류. <see cref="SkillData"/> 에셋에 정수로 직렬화되므로
+    /// 기존 값의 번호를 바꾸지 말고 새 항목만 추가한다.
+    /// 카드 카테고리(스탯 / 스킬 / 강신)는 이 값에서 파생된다 — <see cref="SkillData.ResolveCategory"/>.
+    /// </summary>
+    public enum LevelUpSkillEffectType
+    {
+        // 스탯 기반 (범용)
+        StatFlat = 0,
+        StatPercent = 1,
+        BonusTargets = 2,
+        PickupRadius = 3,         // 혼불 당기기 (자력) — docs 3.3 기준 공용 스킬 7종 중 하나
+
+        // 공용 스킬 (6종) — PickupRadius 포함 시 7종, 클래스 전용 4종과 합산하면 총 11종
+        SummonDokkaebiOrb = 10,   // 도깨비불 소환
+        InkExplosionOnKill = 11,  // 먹물 폭발 (적 처치 시 광역)
+        BarrierRadiusExpand = 12, // 결계 확장
+        KnockbackShield = 13,     // 수호 장승의 진 (피격 시 넉백)
+        HealthRegen = 14,         // 재생의 굿거리
+        InkTrailSlow = 15,        // 끈적한 묵액 (궤적 둔화)
+
+        // 클래스 전용 스킬 (4종)
+        FanAttackBuff = 20,       // [무당 전용] 부채살 흩뿌리기
+        SwordAttackBuff = 21,     // [박수 전용] 묵직한 신검
+        SalPulliKummuBuff = 22,   // [무당 강신] 살풀이 검무
+        PaCheonJingBuff = 23,     // [박수 강신] 파천의 징
+    }
+}

--- a/project1/Assets/Scripts/Progression/LevelUpSkillEffectType.cs.meta
+++ b/project1/Assets/Scripts/Progression/LevelUpSkillEffectType.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6cea6de8b5f9ed94a825d79653251ac9

--- a/project1/Assets/Scripts/Progression/PlayerLevelSystem.cs
+++ b/project1/Assets/Scripts/Progression/PlayerLevelSystem.cs
@@ -2,34 +2,12 @@ using System;
 using System.Collections.Generic;
 using Mukseon.Core;
 using Mukseon.Gameplay.Combat;
+using Mukseon.Gameplay.Progression.Cards;
 using Mukseon.Gameplay.Stats;
 using UnityEngine;
 
 namespace Mukseon.Gameplay.Progression
 {
-    public enum LevelUpSkillEffectType
-    {
-        // 스탯 기반 (범용)
-        StatFlat = 0,
-        StatPercent = 1,
-        BonusTargets = 2,
-        PickupRadius = 3,         // 혼불 당기기 (자력) — docs 3.3 기준 공용 스킬 7종 중 하나
-
-        // 공용 스킬 (6종) — PickupRadius 포함 시 7종, 클래스 전용 4종과 합산하면 총 11종
-        SummonDokkaebiOrb = 10,   // 도깨비불 소환
-        InkExplosionOnKill = 11,  // 먹물 폭발 (적 처치 시 광역)
-        BarrierRadiusExpand = 12, // 결계 확장
-        KnockbackShield = 13,     // 수호 장승의 진 (피격 시 넉백)
-        HealthRegen = 14,         // 재생의 굿거리
-        InkTrailSlow = 15,        // 끈적한 묵액 (궤적 둔화)
-
-        // 클래스 전용 스킬 (4종)
-        FanAttackBuff = 20,       // [무당 전용] 부채살 흩뿌리기
-        SwordAttackBuff = 21,     // [박수 전용] 묵직한 신검
-        SalPulliKummuBuff = 22,   // [무당 강신] 살풀이 검무
-        PaCheonJingBuff = 23,     // [박수 강신] 파천의 징
-    }
-
     [DisallowMultipleComponent]
     public class PlayerLevelSystem : MonoBehaviour
     {
@@ -54,10 +32,12 @@ namespace Mukseon.Gameplay.Progression
         [SerializeField]
         private List<SkillData> _skillDefinitions = new List<SkillData>();
 
-        private readonly List<SkillData> _currentChoices = new List<SkillData>(3);
-        private readonly Dictionary<string, int> _skillLevels = new Dictionary<string, int>();
+        private readonly List<SkillData> _currentChoices = new List<SkillData>(CardPool<SkillData>.DefaultDrawCount);
+        private readonly SkillLevelRegistry _skillLevels = new SkillLevelRegistry();
 
         private LevelProgressionModel _progressionModel;
+        private CardPool<SkillData> _cardPool;
+        private CardEffectApplier _effectApplier;
         private bool _startingSkillsGranted;
 
         public event Action<int, float, float> OnExperienceChanged;
@@ -92,14 +72,17 @@ namespace Mukseon.Gameplay.Progression
             }
 
             ResolveSkillDefinitions();
+            _effectApplier = new CardEffectApplier(_playerStatSystem, _swipeAttackEventListener, this);
             _progressionModel = new LevelProgressionModel(_baseExperienceThreshold, _thresholdGrowthFactor);
             NotifyExperienceChanged();
         }
 
         // 시작 스킬은 Start에서 부여한다. 다른 컴포넌트의 OnEnable(구독)이 모두 끝난 뒤여야
         // OnSkillEffectPending 구독자(예: FanAttackSkill)가 레벨 1 부여를 놓치지 않는다.
+        // 카드 풀도 여기서 만든다: PlayerStatSystem.Awake가 끝나야 이번 런의 캐릭터가 확정된다(#66).
         private void Start()
         {
+            InitializeCardPool();
             GrantStartingSkills();
         }
 
@@ -147,7 +130,7 @@ namespace Mukseon.Gameplay.Progression
             SkillData selected = _currentChoices[choiceIndex];
             ApplySkillEffect(selected);
 
-            int newLevel = IncrementSkillLevel(selected.SkillId);
+            int newLevel = _skillLevels.Increment(selected.SkillId);
             OnSkillApplied?.Invoke(selected, newLevel);
 
             IsSelectionOpen = false;
@@ -178,15 +161,8 @@ namespace Mukseon.Gameplay.Progression
             }
         }
 
-        public int GetSkillLevel(string skillId)
-        {
-            if (string.IsNullOrWhiteSpace(skillId))
-            {
-                return 0;
-            }
-
-            return _skillLevels.TryGetValue(skillId, out int level) ? level : 0;
-        }
+        /// <summary>해당 카드의 현재 보유 레벨(미보유 = 0). 카드 풀의 최대 레벨 제외 / 가중치 판정에 쓰인다.</summary>
+        public int GetSkillLevel(string skillId) => _skillLevels.GetLevel(skillId);
 
         /// <summary>
         /// CharacterData.StartingSkills를 레벨 1로 부여한다(예: 무당 = 부채살 흩뿌리기, #76).
@@ -236,7 +212,7 @@ namespace Mukseon.Gameplay.Progression
             // ApplySkillEffect는 미내장 효과(부채살 등)에 OnSkillEffectPending(skill, 1)을 발행하므로
             // 레벨 증가 전에 호출해 구독자가 레벨 1을 받게 한다(ApplyChoice와 동일한 순서).
             ApplySkillEffect(skill);
-            int newLevel = IncrementSkillLevel(skill.SkillId);
+            int newLevel = _skillLevels.Increment(skill.SkillId);
             OnSkillApplied?.Invoke(skill, newLevel);
         }
 
@@ -264,106 +240,106 @@ namespace Mukseon.Gameplay.Progression
             OnLevelSelectionOpened?.Invoke(CurrentLevel, _currentChoices);
         }
 
+        /// <summary>
+        /// 이번 런의 카드 풀을 만든다(#66). 캐릭터 전용 카드 필터링과 유효성 검사는 여기서 한 번만 수행하고,
+        /// 최대 레벨 제외 / 가중치는 매 추첨 시점에 <see cref="CardPool{T}.Draw"/>가 다시 계산한다.
+        /// </summary>
+        public void InitializeCardPool()
+        {
+            string characterId = _playerStatSystem != null && _playerStatSystem.CharacterData != null
+                ? _playerStatSystem.CharacterData.CharacterId
+                : null;
+
+            if (string.IsNullOrWhiteSpace(characterId))
+            {
+                Debug.LogWarning("[PlayerLevelSystem] 이번 런의 캐릭터를 확인할 수 없어 캐릭터 전용 카드 필터링을 건너뜁니다.", this);
+            }
+
+            // EligibilityFilter는 풀을 다시 만들어도 유지되어야 한다(강신 카드 적용 가능 여부 등, 외부에서 주입).
+            Func<SkillData, bool> previousFilter = _cardPool?.EligibilityFilter;
+            _cardPool = new CardPool<SkillData>(EnumerateValidDefinitions(), characterId)
+            {
+                EligibilityFilter = previousFilter,
+            };
+
+            if (_cardPool.Count <= 0)
+            {
+                Debug.LogWarning("[PlayerLevelSystem] 카드 풀이 비어 있습니다. 레벨업 선택지가 표시되지 않습니다.", this);
+            }
+        }
+
+        /// <summary>
+        /// 추첨 시점에 카드를 추가로 걸러내는 조건을 주입한다(null이면 해제).
+        /// 지금 선택해도 적용할 수 없는 카드를 제외해 "빈 선택"을 방지한다
+        /// (예: 강신 슬롯이 모두 찬 상태에서 미보유 강신 카드 — <see cref="GangshinCardApplier"/>).
+        /// </summary>
+        public void SetCardEligibilityFilter(Func<SkillData, bool> filter)
+        {
+            EnsureCardPool();
+            _cardPool.EligibilityFilter = filter;
+        }
+
+        /// <summary>
+        /// 자신이 등록한 조건만 해제한다. 그 사이 다른 쪽이 조건을 덮어썼다면 아무것도 하지 않아,
+        /// 컴포넌트 비활성화 순서에 따라 남의 조건을 지워버리는 일이 없다.
+        /// </summary>
+        public void ClearCardEligibilityFilter(Func<SkillData, bool> filter)
+        {
+            if (_cardPool != null && _cardPool.EligibilityFilter == filter)
+            {
+                _cardPool.EligibilityFilter = null;
+            }
+        }
+
         private void BuildRandomChoices()
         {
-            _currentChoices.Clear();
+            EnsureCardPool();
+            _cardPool.Draw(GetSkillLevel, _currentChoices);
+        }
 
-            var candidates = new List<SkillData>(_skillDefinitions.Count);
+        private void EnsureCardPool()
+        {
+            if (_cardPool == null)
+            {
+                InitializeCardPool();
+            }
+        }
+
+        /// <summary>null / 유효하지 않은 정의를 경고와 함께 걸러낸다. 풀 생성 시 1회만 순회한다.</summary>
+        private IEnumerable<SkillData> EnumerateValidDefinitions()
+        {
             for (int i = 0; i < _skillDefinitions.Count; i++)
             {
                 SkillData definition = _skillDefinitions[i];
                 if (definition == null)
                 {
-                    Debug.LogWarning("[PlayerLevelSystem] SkillData list contains a null entry.");
+                    Debug.LogWarning("[PlayerLevelSystem] SkillData list contains a null entry.", this);
                     continue;
                 }
 
                 if (!definition.IsValid(out string reason))
                 {
-                    Debug.LogWarning($"[PlayerLevelSystem] SkillData '{definition.name}' is invalid. {reason}");
+                    Debug.LogWarning($"[PlayerLevelSystem] SkillData '{definition.name}' is invalid. {reason}", this);
                     continue;
                 }
 
-                if (GetSkillLevel(definition.SkillId) >= definition.MaxLevel)
-                {
-                    continue;
-                }
-
-                candidates.Add(definition);
-            }
-
-            if (candidates.Count <= 0)
-            {
-                return;
-            }
-
-            Shuffle(candidates);
-            int choiceCount = Mathf.Min(3, candidates.Count);
-            for (int i = 0; i < choiceCount; i++)
-            {
-                _currentChoices.Add(candidates[i]);
-            }
-        }
-
-        private static void Shuffle<T>(IList<T> list)
-        {
-            for (int i = 0; i < list.Count - 1; i++)
-            {
-                int swapIndex = UnityEngine.Random.Range(i, list.Count);
-                (list[i], list[swapIndex]) = (list[swapIndex], list[i]);
+                yield return definition;
             }
         }
 
         private void ApplySkillEffect(SkillData definition)
         {
-            switch (definition.EffectType)
+            if (_effectApplier != null && _effectApplier.TryApply(definition))
             {
-                case LevelUpSkillEffectType.StatFlat:
-                    if (_playerStatSystem != null)
-                    {
-                        _playerStatSystem.AddModifier(definition.StatType, new StatModifier(definition.Value, StatModifierType.Flat, this));
-                    }
-                    break;
-                case LevelUpSkillEffectType.StatPercent:
-                    if (_playerStatSystem != null)
-                    {
-                        _playerStatSystem.AddModifier(definition.StatType, new StatModifier(definition.Value, StatModifierType.Percent, this));
-                    }
-                    break;
-                case LevelUpSkillEffectType.BonusTargets:
-                    if (_swipeAttackEventListener != null)
-                    {
-                        _swipeAttackEventListener.AddBonusTargets(Mathf.RoundToInt(definition.Value));
-                    }
-                    break;
-                case LevelUpSkillEffectType.PickupRadius:
-                    if (_playerStatSystem != null)
-                    {
-                        // 혼불 자력 반경을 Flat StatModifier로 증가시킨다(#40). SoulCollector가 MagnetRadius 스탯을 읽는다.
-                        _playerStatSystem.AddModifier(StatType.MagnetRadius, new StatModifier(definition.Value, StatModifierType.Flat, this));
-                    }
-                    break;
-                default:
-                    OnSkillEffectPending?.Invoke(definition, GetSkillLevel(definition.SkillId) + 1);
-                    if (OnSkillEffectPending == null)
-                    {
-                        Debug.LogWarning($"[PlayerLevelSystem] ApplySkillEffect: 처리되지 않은 스킬 타입 {definition.EffectType} ('{definition.SkillId}'). switch 케이스를 추가하거나 OnSkillEffectPending 구독을 확인하세요.");
-                    }
-                    break;
-            }
-        }
-
-        private int IncrementSkillLevel(string skillId)
-        {
-            if (string.IsNullOrWhiteSpace(skillId))
-            {
-                return 0;
+                return;
             }
 
-            int previous = GetSkillLevel(skillId);
-            int current = previous + 1;
-            _skillLevels[skillId] = current;
-            return current;
+            // 전담 시스템(도깨비불 / 결계 / 강신 등)이 처리해야 하는 효과.
+            OnSkillEffectPending?.Invoke(definition, GetSkillLevel(definition.SkillId) + 1);
+            if (OnSkillEffectPending == null)
+            {
+                Debug.LogWarning($"[PlayerLevelSystem] ApplySkillEffect: 처리되지 않은 스킬 타입 {definition.EffectType} ('{definition.SkillId}'). CardEffectApplier에 케이스를 추가하거나 OnSkillEffectPending 구독을 확인하세요.", this);
+            }
         }
 
         private void ResolveSkillDefinitions()

--- a/project1/Assets/Scripts/Progression/SkillData.cs
+++ b/project1/Assets/Scripts/Progression/SkillData.cs
@@ -1,10 +1,15 @@
+using Mukseon.Gameplay.Progression.Cards;
 using Mukseon.Gameplay.Stats;
 using UnityEngine;
 
 namespace Mukseon.Gameplay.Progression
 {
+    /// <summary>
+    /// 강화 카드 1장의 정의(#66, `card_system.md`). 스탯 / 스킬 / 강신 카드를 모두 이 에셋으로 표현하며,
+    /// 카테고리는 <see cref="EffectType"/>에서 파생한다(별도 필드를 두면 두 값이 어긋날 수 있다).
+    /// </summary>
     [CreateAssetMenu(fileName = "SkillData", menuName = "Mukseon/Data/Skill Data")]
-    public class SkillData : ScriptableObject
+    public class SkillData : ScriptableObject, ICardDefinition
     {
         [SerializeField]
         private string _skillId;
@@ -30,6 +35,12 @@ namespace Mukseon.Gameplay.Progression
         [SerializeField]
         private Sprite _icon;
 
+        [SerializeField, Tooltip("이 카드를 사용할 수 있는 캐릭터 ID(예: character.mudang). 비워두면 전 캐릭터 공용.")]
+        private string _requiredCharacterId;
+
+        [SerializeField, Tooltip("강신 강화 카드일 때 부여 / 레벨업할 강신 어빌리티 ID(GangshinAbilityData.AbilityId).")]
+        private string _gangshinAbilityId;
+
         public string SkillId => string.IsNullOrWhiteSpace(_skillId) ? name : _skillId;
         public string DisplayName => string.IsNullOrWhiteSpace(_displayName) ? name : _displayName;
         public string Description => _description;
@@ -39,6 +50,37 @@ namespace Mukseon.Gameplay.Progression
         public int MaxLevel => Mathf.Max(1, _maxLevel);
         public Sprite Icon => _icon;
 
+        /// <summary>강신 강화 카드가 대상으로 삼는 어빌리티 ID. 강신 카드가 아니면 비어 있다.</summary>
+        public string GangshinAbilityId => _gangshinAbilityId;
+
+        public string CardId => SkillId;
+        public string RequiredCharacterId => _requiredCharacterId;
+        public CardCategory Category => ResolveCategory(_effectType);
+
+        /// <summary>
+        /// 효과 타입에서 카드 카테고리를 결정한다(`card_system.md` — 카드 목록).
+        /// 스탯 수치를 직접 올리는 효과는 스탯 카드, 강신 슬롯에 얹히는 효과는 강신 카드,
+        /// 나머지(도깨비불 / 결계 / 재생 등)는 스킬 카드다.
+        /// </summary>
+        public static CardCategory ResolveCategory(LevelUpSkillEffectType effectType)
+        {
+            switch (effectType)
+            {
+                case LevelUpSkillEffectType.StatFlat:
+                case LevelUpSkillEffectType.StatPercent:
+                case LevelUpSkillEffectType.BonusTargets:
+                case LevelUpSkillEffectType.PickupRadius:
+                    return CardCategory.Stat;
+
+                case LevelUpSkillEffectType.SalPulliKummuBuff:
+                case LevelUpSkillEffectType.PaCheonJingBuff:
+                    return CardCategory.Gangshin;
+
+                default:
+                    return CardCategory.Skill;
+            }
+        }
+
         public bool IsValid(out string reason)
         {
             if (MaxLevel <= 0)
@@ -47,8 +89,22 @@ namespace Mukseon.Gameplay.Progression
                 return false;
             }
 
+            if (Category == CardCategory.Gangshin && string.IsNullOrWhiteSpace(_gangshinAbilityId))
+            {
+                reason = "Gangshin card requires a gangshin ability id.";
+                return false;
+            }
+
             reason = null;
             return true;
+        }
+
+        internal void ConfigureForTests(string skillId, LevelUpSkillEffectType effectType, int maxLevel, string requiredCharacterId = null)
+        {
+            _skillId = skillId;
+            _effectType = effectType;
+            _maxLevel = maxLevel;
+            _requiredCharacterId = requiredCharacterId;
         }
     }
 }

--- a/project1/Assets/Settings/Data/Skills/Skill_FanAttack.asset
+++ b/project1/Assets/Settings/Data/Skills/Skill_FanAttack.asset
@@ -22,3 +22,5 @@ MonoBehaviour:
   _value: 1
   _maxLevel: 3
   _icon: {fileID: 0}
+  _requiredCharacterId: character.mudang
+  _gangshinAbilityId:

--- a/project1/Assets/Tests/EditMode/CardPoolTests.cs
+++ b/project1/Assets/Tests/EditMode/CardPoolTests.cs
@@ -1,0 +1,315 @@
+using System.Collections.Generic;
+using Mukseon.Gameplay.Progression;
+using Mukseon.Gameplay.Progression.Cards;
+using NUnit.Framework;
+
+namespace Mukseon.Tests.EditMode
+{
+    /// <summary>
+    /// 강화 카드 풀 / 가중치 추첨 검증(#66, `card_system.md`).
+    /// CardPool은 순수 C#이므로 ScriptableObject 없이 대역 카드(<see cref="FakeCard"/>)로 테스트한다.
+    /// </summary>
+    public class CardPoolTests
+    {
+        private const string Mudang = "character.mudang";
+        private const string Baksu = "character.baksu";
+
+        // ── 대역 ───────────────────────────────────────────────────────────
+
+        private sealed class FakeCard : ICardDefinition
+        {
+            public FakeCard(string id, CardCategory category = CardCategory.Skill, int maxLevel = 3, string requiredCharacterId = null)
+            {
+                CardId = id;
+                Category = category;
+                MaxLevel = maxLevel;
+                RequiredCharacterId = requiredCharacterId;
+            }
+
+            public string CardId { get; }
+            public CardCategory Category { get; }
+            public int MaxLevel { get; }
+            public string RequiredCharacterId { get; }
+        }
+
+        /// <summary>정해진 정규화 값(0~1)을 순서대로 돌려주는 난수 대역. 구간 경계를 정확히 겨냥할 수 있다.</summary>
+        private sealed class ScriptedRandomSource : IRandomSource
+        {
+            private readonly Queue<float> _normalizedRolls;
+
+            public ScriptedRandomSource(params float[] normalizedRolls)
+            {
+                _normalizedRolls = new Queue<float>(normalizedRolls);
+            }
+
+            public float NextFloat(float maxExclusive)
+            {
+                float normalized = _normalizedRolls.Count > 0 ? _normalizedRolls.Dequeue() : 0f;
+                return normalized * maxExclusive;
+            }
+        }
+
+        /// <summary>재현 가능한 선형 합동 생성기. 확률 분포 검증에 사용한다.</summary>
+        private sealed class SeededRandomSource : IRandomSource
+        {
+            private uint _state;
+
+            public SeededRandomSource(uint seed)
+            {
+                _state = seed == 0 ? 1u : seed;
+            }
+
+            public float NextFloat(float maxExclusive)
+            {
+                _state = (1664525u * _state) + 1013904223u;
+                float normalized = (_state >> 8) / (float)(1 << 24);
+                return normalized * maxExclusive;
+            }
+        }
+
+        private static CardPool<FakeCard> CreatePool(string characterId, params FakeCard[] cards)
+        {
+            return new CardPool<FakeCard>(cards, characterId);
+        }
+
+        // ── 추첨 장수 / 중복 ────────────────────────────────────────────────
+
+        [Test]
+        public void Draw_ReturnsThreeDistinctCards()
+        {
+            CardPool<FakeCard> pool = CreatePool(Mudang,
+                new FakeCard("a"), new FakeCard("b"), new FakeCard("c"), new FakeCard("d"), new FakeCard("e"));
+            var results = new List<FakeCard>();
+
+            int drawn = pool.Draw(_ => 0, results, 3, new SeededRandomSource(12345));
+
+            Assert.That(drawn, Is.EqualTo(3));
+            Assert.That(results, Has.Count.EqualTo(3));
+            Assert.That(results, Is.Unique);
+        }
+
+        [Test]
+        public void Draw_NeverRepeatsCard_AcrossManyRolls()
+        {
+            CardPool<FakeCard> pool = CreatePool(Mudang,
+                new FakeCard("a"), new FakeCard("b"), new FakeCard("c"), new FakeCard("d"));
+            var results = new List<FakeCard>();
+            var random = new SeededRandomSource(777);
+
+            for (int i = 0; i < 500; i++)
+            {
+                pool.Draw(_ => 0, results, 3, random);
+                Assert.That(results, Is.Unique, $"{i}번째 추첨에서 중복 카드가 나왔습니다.");
+            }
+        }
+
+        [Test]
+        public void Draw_ReturnsFewerCards_WhenCandidatesAreScarce()
+        {
+            CardPool<FakeCard> pool = CreatePool(Mudang, new FakeCard("a"), new FakeCard("b"));
+            var results = new List<FakeCard>();
+
+            int drawn = pool.Draw(_ => 0, results, 3, new SeededRandomSource(1));
+
+            Assert.That(drawn, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Draw_ClearsPreviousResults()
+        {
+            CardPool<FakeCard> pool = CreatePool(Mudang, new FakeCard("a"));
+            var results = new List<FakeCard> { new FakeCard("stale") };
+
+            pool.Draw(_ => 0, results, 3, new SeededRandomSource(1));
+
+            Assert.That(results, Has.Count.EqualTo(1));
+            Assert.That(results[0].CardId, Is.EqualTo("a"));
+        }
+
+        // ── 최대 레벨 제외 ──────────────────────────────────────────────────
+
+        [Test]
+        public void Draw_ExcludesCardsAtMaxLevel()
+        {
+            CardPool<FakeCard> pool = CreatePool(Mudang,
+                new FakeCard("maxed", CardCategory.Skill, maxLevel: 3),
+                new FakeCard("open", CardCategory.Skill, maxLevel: 3));
+            var results = new List<FakeCard>();
+
+            pool.Draw(id => id == "maxed" ? 3 : 0, results, 3, new SeededRandomSource(42));
+
+            Assert.That(results.Count, Is.EqualTo(1));
+            Assert.That(results[0].CardId, Is.EqualTo("open"));
+        }
+
+        [Test]
+        public void Draw_ReturnsNothing_WhenEveryCardIsMaxed()
+        {
+            CardPool<FakeCard> pool = CreatePool(Mudang, new FakeCard("a", maxLevel: 1), new FakeCard("b", maxLevel: 1));
+            var results = new List<FakeCard>();
+
+            int drawn = pool.Draw(_ => 1, results, 3, new SeededRandomSource(9));
+
+            Assert.That(drawn, Is.Zero);
+            Assert.That(results, Is.Empty);
+        }
+
+        // ── 캐릭터 전용 필터링 ──────────────────────────────────────────────
+
+        [Test]
+        public void Constructor_ExcludesCardsLockedToAnotherCharacter()
+        {
+            CardPool<FakeCard> pool = CreatePool(Baksu,
+                new FakeCard("shared"),
+                new FakeCard("fan", CardCategory.Skill, 3, Mudang));
+
+            Assert.That(pool.Count, Is.EqualTo(1));
+            Assert.That(pool.Cards[0].CardId, Is.EqualTo("shared"));
+        }
+
+        [Test]
+        public void Constructor_KeepsCardsLockedToTheActiveCharacter()
+        {
+            CardPool<FakeCard> pool = CreatePool(Mudang,
+                new FakeCard("shared"),
+                new FakeCard("fan", CardCategory.Skill, 3, Mudang));
+
+            Assert.That(pool.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Constructor_SkipsCharacterFilter_WhenCharacterIsUnknown()
+        {
+            // 캐릭터를 특정할 수 없을 때 전용 카드를 통째로 잃는 것보다 필터를 적용하지 않는 편이 안전하다.
+            CardPool<FakeCard> pool = CreatePool(null, new FakeCard("fan", CardCategory.Skill, 3, Mudang));
+
+            Assert.That(pool.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Constructor_RemovesDuplicateDefinitions()
+        {
+            var card = new FakeCard("a");
+            CardPool<FakeCard> pool = CreatePool(Mudang, card, card, new FakeCard("a"));
+
+            Assert.That(pool.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Constructor_SkipsNullAndIdlessEntries()
+        {
+            CardPool<FakeCard> pool = CreatePool(Mudang, null, new FakeCard(" "), new FakeCard("a"));
+
+            Assert.That(pool.Count, Is.EqualTo(1));
+            Assert.That(pool.Cards[0].CardId, Is.EqualTo("a"));
+        }
+
+        // ── 가중치 ──────────────────────────────────────────────────────────
+
+        [Test]
+        public void ResolveWeight_DoublesOwnedSkillAndGangshinCards()
+        {
+            Assert.That(CardPool<FakeCard>.ResolveWeight(new FakeCard("s", CardCategory.Skill), 1), Is.EqualTo(2f));
+            Assert.That(CardPool<FakeCard>.ResolveWeight(new FakeCard("g", CardCategory.Gangshin), 2), Is.EqualTo(2f));
+        }
+
+        [Test]
+        public void ResolveWeight_UsesBaseWeight_ForUnownedCards()
+        {
+            Assert.That(CardPool<FakeCard>.ResolveWeight(new FakeCard("s", CardCategory.Skill), 0), Is.EqualTo(1f));
+        }
+
+        [Test]
+        public void ResolveWeight_KeepsBaseWeight_ForStatCards_EvenWhenOwned()
+        {
+            // 스탯 카드는 보유 개념이 없어 항상 x1(card_system.md — 가중치 규칙).
+            Assert.That(CardPool<FakeCard>.ResolveWeight(new FakeCard("hp", CardCategory.Stat), 3), Is.EqualTo(1f));
+        }
+
+        [Test]
+        public void Draw_PicksOwnedCard_TwiceAsOften()
+        {
+            var pool = CreatePool(Mudang,
+                new FakeCard("owned", CardCategory.Skill, maxLevel: 99),
+                new FakeCard("fresh", CardCategory.Skill, maxLevel: 99));
+            var results = new List<FakeCard>();
+            var random = new SeededRandomSource(2024);
+
+            const int Trials = 30000;
+            int ownedFirst = 0;
+
+            for (int i = 0; i < Trials; i++)
+            {
+                // 1장만 뽑아 첫 선택의 분포를 본다. 보유(x2) : 미보유(x1) = 2 : 1 이 기대값이다.
+                pool.Draw(id => id == "owned" ? 1 : 0, results, 1, random);
+                if (results[0].CardId == "owned")
+                {
+                    ownedFirst++;
+                }
+            }
+
+            float ratio = ownedFirst / (float)Trials;
+            Assert.That(ratio, Is.EqualTo(2f / 3f).Within(0.02f), $"보유 카드 등장 비율이 기대(0.667)와 다릅니다: {ratio}");
+        }
+
+        [Test]
+        public void Draw_HonoursWeightBoundaries_WithScriptedRolls()
+        {
+            // 후보 순서는 생성 순서와 같다. 가중치는 owned=2, fresh=1 → 총합 3.
+            // 정규화 0.66(=1.98 < 2)은 owned 구간, 0.67(=2.01 >= 2)은 fresh 구간에 떨어진다.
+            var pool = CreatePool(Mudang,
+                new FakeCard("owned", CardCategory.Skill, maxLevel: 99),
+                new FakeCard("fresh", CardCategory.Skill, maxLevel: 99));
+            var results = new List<FakeCard>();
+
+            pool.Draw(id => id == "owned" ? 1 : 0, results, 1, new ScriptedRandomSource(0.66f));
+            Assert.That(results[0].CardId, Is.EqualTo("owned"));
+
+            pool.Draw(id => id == "owned" ? 1 : 0, results, 1, new ScriptedRandomSource(0.67f));
+            Assert.That(results[0].CardId, Is.EqualTo("fresh"));
+        }
+
+        // ── 적용 가능 여부 필터 ─────────────────────────────────────────────
+
+        [Test]
+        public void Draw_AppliesEligibilityFilter()
+        {
+            CardPool<FakeCard> pool = CreatePool(Mudang,
+                new FakeCard("blocked", CardCategory.Gangshin),
+                new FakeCard("allowed"));
+            pool.EligibilityFilter = card => card.CardId != "blocked";
+            var results = new List<FakeCard>();
+
+            pool.Draw(_ => 0, results, 3, new SeededRandomSource(5));
+
+            Assert.That(results.Count, Is.EqualTo(1));
+            Assert.That(results[0].CardId, Is.EqualTo("allowed"));
+        }
+
+        // ── SkillData 카테고리 파생 ─────────────────────────────────────────
+
+        [Test]
+        public void ResolveCategory_MapsStatEffectsToStatCategory()
+        {
+            Assert.That(SkillData.ResolveCategory(LevelUpSkillEffectType.StatFlat), Is.EqualTo(CardCategory.Stat));
+            Assert.That(SkillData.ResolveCategory(LevelUpSkillEffectType.StatPercent), Is.EqualTo(CardCategory.Stat));
+            Assert.That(SkillData.ResolveCategory(LevelUpSkillEffectType.BonusTargets), Is.EqualTo(CardCategory.Stat));
+            Assert.That(SkillData.ResolveCategory(LevelUpSkillEffectType.PickupRadius), Is.EqualTo(CardCategory.Stat));
+        }
+
+        [Test]
+        public void ResolveCategory_MapsGangshinBuffsToGangshinCategory()
+        {
+            Assert.That(SkillData.ResolveCategory(LevelUpSkillEffectType.SalPulliKummuBuff), Is.EqualTo(CardCategory.Gangshin));
+            Assert.That(SkillData.ResolveCategory(LevelUpSkillEffectType.PaCheonJingBuff), Is.EqualTo(CardCategory.Gangshin));
+        }
+
+        [Test]
+        public void ResolveCategory_MapsRemainingEffectsToSkillCategory()
+        {
+            Assert.That(SkillData.ResolveCategory(LevelUpSkillEffectType.SummonDokkaebiOrb), Is.EqualTo(CardCategory.Skill));
+            Assert.That(SkillData.ResolveCategory(LevelUpSkillEffectType.HealthRegen), Is.EqualTo(CardCategory.Skill));
+            Assert.That(SkillData.ResolveCategory(LevelUpSkillEffectType.FanAttackBuff), Is.EqualTo(CardCategory.Skill));
+        }
+    }
+}

--- a/project1/Assets/Tests/EditMode/CardPoolTests.cs.meta
+++ b/project1/Assets/Tests/EditMode/CardPoolTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a095dfccbd7ab6c4ab3ade6c7467cb7f


### PR DESCRIPTION
레벨업·미니 보스 처치 시 제시할 카드 3장을 고르는 로직을 순수 C# `CardPool<T>`로 분리하고, 균등 셔플을 가중치 기반 비복원 추출로 교체했다.

## 문제

기존 `PlayerLevelSystem.BuildRandomChoices`는 후보를 모아 **Fisher-Yates 셔플 후 앞 3장**을 잘라 썼다. `card_system.md`가 정의한 두 규칙이 빠져 있었다.

| 규칙 | 기존 동작 |
|---|---|
| 보유 중인 스킬·강신 카드 가중치 x2 | 없음 — 전부 균등 |
| 캐릭터 전용 카드 필터링 | `CharacterData._levelUpSkills`에 **안 넣는** 방식 |

특히 두 번째가 위험했다. 박수에게 부채살 흩뿌리기가 안 뜨는 이유가 "박수 목록에 그 항목이 없어서"일 뿐이라, 목록 관리 실수 한 번이면 전용 카드가 그대로 샌다. 카드 자체는 자기가 누구 전용인지 모른다.

## 구성

| 파일 | 줄 수 | 책임 |
|---|---|---|
| `Progression/Cards/CardPool.cs` | 246 | 필터링 + 가중치 비복원 추첨 (순수 C#) |
| `Progression/Cards/GangshinCardApplier.cs` | 177 | 강신 카드 → 슬롯 반영 |
| `Progression/Cards/CardEffectApplier.cs` | 69 | 스탯 계열 효과 적용 (`PlayerLevelSystem`에서 추출) |
| `Progression/Cards/SkillLevelRegistry.cs` | 46 | 카드별 보유 레벨 저장소 |
| `Progression/Cards/ICardDefinition.cs` | 24 | 추첨에 필요한 최소 정보 |
| `Progression/Cards/IRandomSource.cs` | 25 | 난수 주입점 |
| `Progression/Cards/CardCategory.cs` | 18 | 스탯 / 스킬 / 강신 |
| `Progression/LevelUpSkillEffectType.cs` | 30 | 기존 enum 분리 |
| `Tests/EditMode/CardPoolTests.cs` | 315 | 신규 테스트 20개 |

`PlayerLevelSystem`은 411 → 387줄. 300줄 규칙에는 아직 못 미친다 — `[SerializeField]` 필드가 묶여 있어 더 빼면 씬·프리팹 배선이 깨진다.

## 설계상 짚어둘 것

- **필터 조건을 평가 시점으로 나눴다.** 캐릭터 전용 제외와 중복 정의 제거는 런 내내 안 변하므로 `CardPool` 생성자에서 1회, 최대 레벨 제외와 가중치는 보유 레벨이 계속 변하므로 매 추첨 시점에 다시 평가한다. 한 곳에 몰면 레벨업마다 SO 유효성 검사를 다시 돌리게 되고, 무엇보다 "이 조건이 언제 평가되는가"가 코드에서 사라진다.
- **중복 방지는 확률이 아니라 구조로 보장한다.** 한 장 뽑을 때마다 후보에서 제거하고 가중치 총합을 다시 계산하는 비복원 추출이라, 같은 카드가 2장 나오는 경우의 수 자체가 없다.
- **스탯 카드는 보유해도 x1이다.** 스탯은 "미보유 → 획득" 개념이 없어 스킬과 같은 규칙을 적용하면 한 번만 찍어도 남은 런 내내 x2가 박힌다. 문서의 가중치 표와도 일치한다.
- **캐릭터를 특정할 수 없으면 필터를 적용하지 않는다.** 게임플레이 씬 단독 실행 등으로 `CharacterData`가 해석되지 않았을 때, 전용 카드를 통째로 잃는 쪽이 더 위험하다고 봤다. 경고는 남긴다.
- **`SkillData`가 `ICardDefinition`을 구현한다.** 제네릭 `CardPool<SkillData>`라 `OnLevelSelectionOpened(int, IReadOnlyList<SkillData>)` 시그니처가 그대로다 — HUD·오디오·입력 게이트 4개 구독자에 변경이 없다.
- **카테고리는 `EffectType`에서 파생한다.** 별도 필드를 두면 두 값이 어긋난 에셋이 만들어질 수 있다.
- **강신 카드는 `PlayerLevelSystem`을 안 건드린다.** 기존 `OnSkillEffectPending` 구독만으로 붙였다. 보유 중이면 레벨업 → 빈 슬롯이면 추가 → 4칸 만석이면 교체 요청 순.
- **`GangshinSlotState.TryUpgradeSlot`을 새로 팠다.** 기존 `ReplaceSlot`은 어빌리티 교체용이라 게이지를 0으로 미는데, 같은 강신의 레벨업까지 게이지를 날리면 레벨업이 손해 보는 선택지가 된다. 새 필요 게이지로 클램프만 한다.

## 교체 UI 부재에 대한 처리 — 리뷰 포인트

강신 슬롯 4칸이 다 찼을 때 띄울 교체 UI는 아직 없다(#59 후속). 그대로 두면 카드를 골라도 아무 일이 없어 **선택권 1회가 그냥 날아간다.**

`CardPool.EligibilityFilter`를 두고, `GangshinCardApplier.OnReplaceRequested`에 구독자가 없으면 그 카드를 애초에 추첨 대상에서 뺐다. 교체 UI가 이벤트를 구독하는 순간 조건이 참이 되어 자동으로 후보에 복귀한다.

"빈 선택을 만드느니 안 보여준다"가 맞는 판단인지 확인 부탁드립니다. 반대로 카드를 보여주고 만석이면 자동으로 최저 레벨 슬롯을 교체하는 방향도 가능하지만, 플레이어 모르게 강신이 사라지는 쪽이 더 나쁘다고 봤다.

## 검증

- **EditMode 322개 통과 / 실패 0** (신규 20개 포함), 컴파일 에러 없음.
- 확률 규칙을 테스트로 고정했다. `IRandomSource`를 주입 가능하게 만든 이유가 이것이다 — `UnityEngine.Random`을 직접 쓰면 "3장 나오는지" 이상은 검증할 수 없다.
  - **분포**: 보유/미보유 2장에서 3만 회 추첨 → 보유 카드 등장률 0.667 ± 0.02
  - **구간 경계**: 가중치 [2, 1] 총합 3에서 난수 1.98 → 보유 카드, 2.01 → 미보유 카드
  - 500회 반복 추첨 전수에 대해 중복 없음
- DoD 6개 중 추첨 관련 5개는 신규 테스트로 검증했다. "선택 완료 시 효과 즉시 적용"은 `CardEffectApplier`로 추출만 하고 동작을 바꾸지 않아 기존 경로·기존 테스트가 그대로 커버한다.
- 실기 플레이 확인은 하지 않았다. 리뷰어가 확인해주면 좋겠다.

## 범위 밖

**강신 카드 에셋과 대응 어빌리티 컴포넌트는 만들지 않았다.** 코드 경로(`SalPulliKummuBuff` / `PaCheonJingBuff` → 슬롯 추가·레벨업·교체)는 전부 뚫려 있지만, `gangshin_balance_mvp.md`의 레벨별 수치가 확정되지 않았고 씬에 어빌리티 컴포넌트도 하나(`_equippedAbility`)뿐이라 지금 에셋을 만들면 수치를 임의로 지어내야 한다. `GangshinAbilityData` 에셋을 만들고 `GangshinCardApplier._availableAbilities`에 넣으면 배선은 끝난다.

**스탯 카드는 문서상 7종 중 5종만 존재한다.** 방어력·강신 게이지 충전 속도 카드가 없다. `StatType.Defense` / `GangshinGaugeChargeRate`는 #40에서 이미 읽히고 있으므로 `SkillData` 에셋 2개만 추가하면 되지만, 수치가 `stat_balance_mvp.md`에 TBD로 남아 있어 이번 PR에는 넣지 않았다.

**리롤(광고 시청)은 범위 밖이다.** 수익화 문서 기준이라 별건으로 본다.

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)
